### PR TITLE
Osrb serialization fix

### DIFF
--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -99,10 +99,6 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
 {
 
   explicit binary_archive(stream_type &s) : base_type(s) {
-    stream_type::pos_type pos = stream_.tellg();
-    stream_.seekg(0, std::ios_base::end);
-    eof_pos_ = stream_.tellg();
-    stream_.seekg(pos);
   }
 
   template <class T>
@@ -165,16 +161,6 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
   void read_variant_tag(variant_tag_type &t) {
     serialize_int(t);
   }
-
-  size_t remaining_bytes() {
-    if (!stream_.good())
-      return 0;
-    //std::cerr << "tell: " << stream_.tellg() << std::endl;
-    assert(stream_.tellg() <= eof_pos_);
-    return eof_pos_ - stream_.tellg();
-  }
-protected:
-  std::streamoff eof_pos_;
 };
 
 template <>

--- a/src/serialization/container.h
+++ b/src/serialization/container.h
@@ -70,12 +70,6 @@ bool do_serialize_container(Archive<false> &ar, C &v)
     return false;
   v.clear();
 
-  // very basic sanity check
-  if (ar.remaining_bytes() < cnt) {
-    ar.stream().setstate(std::ios::failbit);
-    return false;
-  }
-
   ::serialization::detail::do_reserve(v, cnt);
 
   for (size_t i = 0; i < cnt; i++) {

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -44,13 +44,6 @@ bool do_serialize(Archive<false> &ar, std::vector<crypto::signature> &v)
 {
   size_t cnt = v.size();
   v.clear();
-
-  // very basic sanity check
-  if (ar.remaining_bytes() < cnt*sizeof(crypto::signature)) {
-    ar.stream().setstate(std::ios::failbit);
-    return false;
-  }
-
   v.reserve(cnt);
   for (size_t i = 0; i < cnt; i++) {
     v.resize(i+1);

--- a/src/serialization/string.h
+++ b/src/serialization/string.h
@@ -37,17 +37,9 @@ inline bool do_serialize(Archive<false>& ar, std::string& str)
 {
   size_t size = 0;
   ar.serialize_varint(size);
-  if (ar.remaining_bytes() < size)
-  {
-    ar.stream().setstate(std::ios::failbit);
-    return false;
-  }
-
-  std::unique_ptr<std::string::value_type[]> buf(new std::string::value_type[size]);
-  ar.serialize_blob(buf.get(), size);
-  str.erase();
-  str.append(buf.get(), size);
-  return true;
+  str.resize(size);
+  ar.serialize_blob(&str[0], size);
+  return ar.stream().good();
 }
 
 
@@ -56,6 +48,6 @@ inline bool do_serialize(Archive<true>& ar, std::string& str)
 {
   size_t size = str.size();
   ar.serialize_varint(size);
-  ar.serialize_blob(const_cast<std::string::value_type*>(str.c_str()), size);
-  return true;
+  ar.serialize_blob(&str[0], size);
+  return ar.stream().good();
 }


### PR DESCRIPTION
The seek being done for serialization is completely pointless, and make serialization fail on any non-streamable input stream (which apparently is the case for a stringbuf under macos, but would also apply if the input stream is actually a stream, e.g. from a socket).  This removes it and the macOS workaround.  It also fixes some needlessly convoluted code in string serialization.

Needs confirmation under macOS.