### PR TITLE
Fix unit tests under updated gtest

### DIFF
--- a/tests/unit_tests/hmac_keccak.cpp
+++ b/tests/unit_tests/hmac_keccak.cpp
@@ -123,7 +123,7 @@ static void test_keccak_hmac(const size_t * chunks)
 }
 
 
-TEST(keccak_hmac, )
+TEST(keccak_hmac, nullptr)
 {
   test_keccak_hmac(nullptr);
 }

--- a/tests/unit_tests/keccak.cpp
+++ b/tests/unit_tests/keccak.cpp
@@ -54,10 +54,6 @@ extern "C" {
   keccak_finish(&ctx, md1); \
   ASSERT_EQ(memcmp(md0, md1, 32), 0);
 
-TEST(keccak, )
-{
-}
-
 TEST(keccak, 0_and_0)
 {
   static const size_t chunks[] = {0};


### PR DESCRIPTION
`TEST(name, )` was never allowed, but in newer gtest it is actually checked.