### PR TITLE
Loki Name System - Name Hashing/Mapping Value Encryption/Decryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - mkdir build
   - cd build
   - if [ -z "$CMAKE_BUILD_TYPE" ]; then CMAKE_BUILD_TYPE=Release; fi
-  - CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"
+  - CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -D DOWNLOAD_SODIUM=ON"
   - if [ -n "$BUILD_TESTS" ]; then CMAKE_OPTS="$CMAKE_OPTS -DBUILD_TESTS=$BUILD_TESTS"; fi
   - cmake $CMAKE_OPTS ..
   - |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,15 +864,29 @@ if (LOKI_DEBUG_SHORT_PROOFS)
   add_definitions(-DUPTIME_PROOF_BASE_MINUTE=3) # 20x faster uptime proofs
 endif()
 
-
 add_library(sodium INTERFACE)
-if(NOT SODIUM_LIBRARIES)
+
+# Allow -DDOWNLOAD_SODIUM=FORCE to download without even checking for a local libsodium
+option(DOWNLOAD_SODIUM "Allow libsodium to be downloaded and built locally if not found on the system" OFF)
+if(NOT SODIUM_LIBRARIES AND NOT DOWNLOAD_SODIUM STREQUAL "FORCE")
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(SODIUM REQUIRED libsodium)
+  pkg_check_modules(SODIUM REQUIRED libsodium>=1.0.18)
+
+  find_library(sodium_link_libs NAMES ${SODIUM_LIBRARIES} PATHS ${SODIUM_LIBRARY_DIRS})
+  target_link_libraries(sodium INTERFACE ${sodium_link_libs})
+  target_include_directories(sodium INTERFACE ${SODIUM_INCLUDE_DIRS})
 endif()
-find_library(sodium_link_libs NAMES ${SODIUM_LIBRARIES} PATHS ${SODIUM_LIBRARY_DIRS})
-target_link_libraries(sodium INTERFACE ${sodium_link_libs})
-target_include_directories(sodium INTERFACE ${SODIUM_INCLUDE_DIRS})
+
+if (NOT sodium_FOUND)
+  if (DOWNLOAD_SODIUM)
+    message(STATUS "Sodium >= 1.0.18 not found, but DOWNLOAD_SODIUM specified, so downloading it")
+    include(DownloadLibSodium)
+    target_link_libraries(sodium INTERFACE sodium_vendor)
+    target_include_directories(sodium INTERFACE sodium_vendor)
+  else()
+    message(FATAL_ERROR "Could not find libsodium >= 1.0.18; either install it on your system or use -DDOWNLOAD_SODIUM=ON to download and build an internal copy")
+  endif()
+endif()
 
 
 add_library(sqlite3 INTERFACE)

--- a/cmake/DownloadLibSodium.cmake
+++ b/cmake/DownloadLibSodium.cmake
@@ -1,0 +1,48 @@
+set(LIBSODIUM_PREFIX ${CMAKE_BINARY_DIR}/libsodium)
+set(LIBSODIUM_URL https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz)
+set(LIBSODIUM_HASH SHA512=17e8638e46d8f6f7d024fe5559eccf2b8baf23e143fadd472a7d29d228b186d86686a5e6920385fe2020729119a5f12f989c3a782afbd05a8db4819bb18666ef)
+
+if(SODIUM_TARBALL_URL)
+    # make a build time override of the tarball url so we can fetch it if the original link goes away
+    set(LIBSODIUM_URL ${SODIUM_TARBALL_URL})
+endif()
+
+
+file(MAKE_DIRECTORY ${LIBSODIUM_PREFIX}/include)
+
+include(ExternalProject)
+include(ProcessorCount)
+
+set(SODIUM_CONFIGURE ./configure --prefix=${LIBSODIUM_PREFIX} CC=${CMAKE_C_COMPILER})
+if (LIBSODIUM_CROSS_TARGET)
+  set(SODIUM_CONFIGURE ${SODIUM_CONFIGURE} --target=${LIBSODIUM_CROSS_TARGET} --host=${LIBSODIUM_CROSS_TARGET})
+endif()
+
+if (BUILD_SHARED_LIBS)
+  set(SODIUM_CONFIGURE ${SODIUM_CONFIGURE} --disable-static --enable-shared)
+else()
+  set(SODIUM_CONFIGURE ${SODIUM_CONFIGURE} --enable-static --disable-shared)
+endif()
+
+
+ExternalProject_Add(libsodium_external
+    BUILD_IN_SOURCE ON
+    PREFIX ${LIBSODIUM_PREFIX}
+    URL ${LIBSODIUM_URL}
+    URL_HASH ${LIBSODIUM_HASH}
+    CONFIGURE_COMMAND ${SODIUM_CONFIGURE}
+    BUILD_COMMAND make -j${PROCESSOR_COUNT}
+    INSTALL_COMMAND ${MAKE}
+    BUILD_BYPRODUCTS ${LIBSODIUM_PREFIX}/lib/libsodium.a ${LIBSODIUM_PREFIX}/lib/libsodium.so ${LIBSODIUM_PREFIX}/include
+    )
+
+add_library(sodium_vendor STATIC IMPORTED GLOBAL)
+add_dependencies(sodium_vendor libsodium_external)
+set_target_properties(sodium_vendor PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBSODIUM_PREFIX}/include)
+
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET sodium_vendor PROPERTY IMPORTED_LOCATION ${LIBSODIUM_PREFIX}/lib/libsodium.so)
+else()
+  set_property(TARGET sodium_vendor PROPERTY IMPORTED_LOCATION ${LIBSODIUM_PREFIX}/lib/libsodium.a)
+endif()
+

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -401,28 +401,28 @@ namespace cryptonote
     crypto::ed25519_public_key owner; // only serialized if command == tx_command_t::buy
     crypto::ed25519_signature  signature; // only serialized if command == tx_command_t::update
     crypto::hash               name_hash;
-    std::string                value; // binary format of the name->value mapping
+    std::string                encrypted_value; // encrypted binary format of the value in the name->value mapping
     crypto::hash               prev_txid = crypto::null_hash; // previous txid that purchased the mapping
 
-    static tx_extra_loki_name_system make_buy(crypto::ed25519_public_key const &owner, lns::mapping_type type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
+    static tx_extra_loki_name_system make_buy(crypto::ed25519_public_key const &owner, lns::mapping_type type, crypto::hash const &name_hash, std::string const &encrypted_value, crypto::hash const &prev_txid)
     {
       tx_extra_loki_name_system result = {};
       result.owner                     = owner;
       result.type                      = type;
       result.name_hash                 = name_hash;
-      result.value                     = value;
+      result.encrypted_value           = encrypted_value;
       result.prev_txid                 = prev_txid;
       result.command                   = lns::tx_command_t::buy;
       return result;
     }
 
-    static tx_extra_loki_name_system make_update(crypto::ed25519_signature const &signature, lns::mapping_type type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
+    static tx_extra_loki_name_system make_update(crypto::ed25519_signature const &signature, lns::mapping_type type, crypto::hash const &name_hash, std::string const &encrypted_value, crypto::hash const &prev_txid)
     {
       tx_extra_loki_name_system result = {};
       result.signature                 = signature;
       result.type                      = type;
       result.name_hash                 = name_hash;
-      result.value                     = value;
+      result.encrypted_value           = encrypted_value;
       result.prev_txid                 = prev_txid;
       result.command                   = lns::tx_command_t::update;
       return result;
@@ -437,7 +437,7 @@ namespace cryptonote
       else
         FIELD(signature)
       FIELD(name_hash)
-      FIELD(value)
+      FIELD(encrypted_value)
       FIELD(prev_txid)
     END_SERIALIZE()
   };

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -400,28 +400,28 @@ namespace cryptonote
     lns::mapping_type          type; // alias to lns::mapping_type
     crypto::ed25519_public_key owner; // only serialized if command == tx_command_t::buy
     crypto::ed25519_signature  signature; // only serialized if command == tx_command_t::update
-    std::string                name;
+    crypto::hash               name_hash;
     std::string                value; // binary format of the name->value mapping
     crypto::hash               prev_txid = crypto::null_hash; // previous txid that purchased the mapping
 
-    static tx_extra_loki_name_system make_buy(crypto::ed25519_public_key const &owner, lns::mapping_type type, std::string const &name, std::string const &value, crypto::hash const &prev_txid)
+    static tx_extra_loki_name_system make_buy(crypto::ed25519_public_key const &owner, lns::mapping_type type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
     {
       tx_extra_loki_name_system result = {};
       result.owner                     = owner;
       result.type                      = type;
-      result.name                      = name;
+      result.name_hash                 = name_hash;
       result.value                     = value;
       result.prev_txid                 = prev_txid;
       result.command                   = lns::tx_command_t::buy;
       return result;
     }
 
-    static tx_extra_loki_name_system make_update(crypto::ed25519_signature const &signature, lns::mapping_type type, std::string const &name, std::string const &value, crypto::hash const &prev_txid)
+    static tx_extra_loki_name_system make_update(crypto::ed25519_signature const &signature, lns::mapping_type type, crypto::hash const &name_hash, std::string const &value, crypto::hash const &prev_txid)
     {
       tx_extra_loki_name_system result = {};
       result.signature                 = signature;
       result.type                      = type;
-      result.name                      = name;
+      result.name_hash                 = name_hash;
       result.value                     = value;
       result.prev_txid                 = prev_txid;
       result.command                   = lns::tx_command_t::update;
@@ -436,7 +436,7 @@ namespace cryptonote
         FIELD(owner)
       else
         FIELD(signature)
-      FIELD(name)
+      FIELD(name_hash)
       FIELD(value)
       FIELD(prev_txid)
     END_SERIALIZE()

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -5,7 +5,7 @@
 #include "cryptonote_config.h"
 #include "span.h"
 #include "cryptonote_basic/tx_extra.h"
-#include "common/hex.h"
+#include <lokimq/hex.h>
 
 #include <string>
 
@@ -42,7 +42,7 @@ struct mapping_value
   bool operator==(mapping_value const &other) const { return other.len    == len && memcmp(buffer.data(), other.buffer.data(), len) == 0; }
   bool operator==(std::string   const &other) const { return other.size() == len && memcmp(buffer.data(), other.data(), len) == 0; }
 };
-inline std::ostream &operator<<(std::ostream &os, mapping_value const &v) { return os << hex::from_hex(v.buffer.begin(), v.buffer.begin() + v.len); }
+inline std::ostream &operator<<(std::ostream &os, mapping_value const &v) { return os << lokimq::to_hex({reinterpret_cast<char const *>(v.buffer.data()), v.len}); }
 
 inline char const *mapping_type_str(mapping_type type)
 {

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -28,12 +28,11 @@ constexpr size_t LOKINET_DOMAIN_NAME_MAX          = 253;
 constexpr size_t LOKINET_ADDRESS_BINARY_LENGTH    = sizeof(crypto::ed25519_public_key);
 constexpr size_t SESSION_DISPLAY_NAME_MAX         = 64;
 constexpr size_t SESSION_PUBLIC_KEY_BINARY_LENGTH = 1 + sizeof(crypto::ed25519_public_key); // Session keys at prefixed with 0x05 + ed25519 key
-constexpr size_t GENERIC_NAME_MAX                 = 255;
-constexpr size_t GENERIC_VALUE_MAX                = 255;
 
 struct lns_value
 {
-  std::array<uint8_t, lns::GENERIC_VALUE_MAX> buffer;
+  static size_t constexpr BUFFER_SIZE = 255;
+  std::array<uint8_t, BUFFER_SIZE> buffer;
   size_t len;
 };
 

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -69,7 +69,7 @@ crypto::hash tx_extra_signature_hash(epee::span<const uint8_t> blob, crypto::has
 bool         validate_lns_name(mapping_type type, std::string const &name, std::string *reason = nullptr);
 
 // Validate a human readable mapping value representation in 'value' and write the binary form into 'blob'.
-// value: if type is session, 64 character hex string of an ed25519 public key
+// value: if type is session, 66 character hex string of an ed25519 public key
 //                   lokinet, 52 character base32z string of an ed25519 public key
 //                   wallet,  the wallet public address string
 // blob: (optional) if function returns true, validate_mapping_value will convert the 'value' into a binary format suitable for encryption in encrypt_mapping_value(...)
@@ -81,8 +81,8 @@ bool         validate_encrypted_mapping_value(mapping_type type, std::string con
 // mapping_type: (optional) if function returns true, the uint16_t value of the 'type' will be set
 bool         validate_mapping_type(std::string const &type, mapping_type *mapping_type, std::string *reason);
 
-// Takes a human readable mapping name and converts to a hash suitable for storing into the LNS DB.
-crypto::hash name_to_hash(std::string const &name);
+crypto::hash name_to_hash(std::string const &name);        // Takes a human readable name and hashes it.
+std::string  name_to_base64_hash(std::string const &name); // Takes a human readable name, hashes it and returns a base64 representation of the hash, suitable for storage into the LNS DB.
 
 // Takes a binary value and encrypts it using 'name' as a secret key or vice versa, suitable for storing into the LNS DB.
 // Only basic overflow validation is attempted, values should be pre-validated in the validate* functions.
@@ -120,7 +120,7 @@ struct mapping_record
 
   bool                       loaded;
   mapping_type               type;
-  crypto::hash               name_hash;
+  std::string                name_hash; // name hashed and represented in base64 encoding
   mapping_value              encrypted_value;
   uint64_t                   register_height;
   int64_t                    owner_id;
@@ -149,8 +149,8 @@ struct name_system_db
 
   owner_record                get_owner_by_key      (crypto::ed25519_public_key const &key) const;
   owner_record                get_owner_by_id       (int64_t owner_id) const;
-  mapping_record              get_mapping           (mapping_type type, crypto::hash const &name_hash) const;
-  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, crypto::hash const &name) const;
+  mapping_record              get_mapping           (mapping_type type, std::string const &name_base64_hash) const;
+  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, std::string const &name_base64_hash) const;
   std::vector<mapping_record> get_mappings_by_owner (crypto::ed25519_public_key const &key) const;
   std::vector<mapping_record> get_mappings_by_owners(std::vector<crypto::ed25519_public_key> const &keys) const;
   settings_record             get_settings          () const;

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -25,6 +25,7 @@ namespace lns
 {
 
 constexpr size_t WALLET_NAME_MAX                  = 96;
+constexpr size_t WALLET_ACCOUNT_BINARY_LENGTH     = 2 * sizeof(crypto::public_key);
 constexpr size_t LOKINET_DOMAIN_NAME_MAX          = 253;
 constexpr size_t LOKINET_ADDRESS_BINARY_LENGTH    = sizeof(crypto::ed25519_public_key);
 constexpr size_t SESSION_DISPLAY_NAME_MAX         = 64;
@@ -57,7 +58,6 @@ inline char const *mapping_type_str(mapping_type type)
   }
 }
 inline std::ostream &operator<<(std::ostream &os, mapping_type type) { return os << mapping_type_str(type); }
-
 constexpr bool mapping_type_allowed(uint8_t hf_version, mapping_type type) { return type == mapping_type::session; }
 constexpr bool is_lokinet_type     (lns::mapping_type type)                { return type >= mapping_type::lokinet_1year && type <= mapping_type::lokinet_10years; }
 sqlite3       *init_loki_name_system(char const *file_path);
@@ -68,14 +68,24 @@ uint64_t     expiry_blocks(cryptonote::network_type nettype, mapping_type type, 
 crypto::hash tx_extra_signature_hash(epee::span<const uint8_t> blob, crypto::hash const &prev_txid);
 bool         validate_lns_name(mapping_type type, std::string const &name, std::string *reason = nullptr);
 
-// blob: if set, validate_lns_value will convert the value into the binary format suitable for storing into the LNS DB.
+// Validate a human readable mapping value representation in 'value' and write the binary form into 'blob'.
+// value: if type is session, 64 character hex string of an ed25519 public key
+//                   lokinet, 52 character base32z string of an ed25519 public key
+//                   wallet,  the wallet public address string
+// blob: (optional) if function returns true, validate_mapping_value will convert the 'value' into a binary format suitable for encryption in encrypt_mapping_value(...)
 bool         validate_mapping_value(cryptonote::network_type nettype, mapping_type type, std::string const &value, mapping_value *blob = nullptr, std::string *reason = nullptr);
 bool         validate_encrypted_mapping_value(mapping_type type, std::string const &value, std::string *reason = nullptr);
-bool         validate_mapping_type(std::string const &type, lns::mapping_type *mapping_type, std::string *reason);
+
+// Converts a human readable case-insensitive string denoting the mapping type into a value suitable for storing into the LNS DB.
+// Currently only accepts "session"
+// mapping_type: (optional) if function returns true, the uint16_t value of the 'type' will be set
+bool         validate_mapping_type(std::string const &type, mapping_type *mapping_type, std::string *reason);
+
+// Takes a human readable mapping name and converts to a hash suitable for storing into the LNS DB.
 crypto::hash name_to_hash(std::string const &name);
 
 // Takes a binary value and encrypts it using 'name' as a secret key or vice versa, suitable for storing into the LNS DB.
-// Only basic overflow validation is attempted, values should be pre-validated in the validate* functions
+// Only basic overflow validation is attempted, values should be pre-validated in the validate* functions.
 bool         encrypt_mapping_value(std::string const &name, mapping_value const &value, mapping_value &encrypted_value);
 bool         decrypt_mapping_value(std::string const &name, mapping_value const &encrypted_value, mapping_value &value);
 
@@ -121,17 +131,21 @@ struct mapping_record
 
 struct name_system_db
 {
-  bool            init        (cryptonote::network_type nettype, sqlite3 *db, uint64_t top_height, crypto::hash const &top_hash);
-  bool            add_block   (const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
-  void            block_detach(cryptonote::Blockchain const &blockchain, uint64_t height);
-  uint64_t        height      () { return last_processed_height; }
+  bool                        init        (cryptonote::network_type nettype, sqlite3 *db, uint64_t top_height, crypto::hash const &top_hash);
+  bool                        add_block   (const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
 
-  bool            save_owner     (crypto::ed25519_public_key const &key, int64_t *row_id);
-  bool            save_mapping   (crypto::hash const &tx_hash, cryptonote::tx_extra_loki_name_system const &src, uint64_t height, int64_t owner_id);
-  bool            save_settings  (uint64_t top_height, crypto::hash const &top_hash, int version);
+  cryptonote::network_type    network_type() const { return nettype; }
+  uint64_t                    height      () const { return last_processed_height; }
 
-  // NOTE: Delete all mappings that are registered on height or newer followed by deleting all owners no longer referenced in the DB
-  bool            prune_db(uint64_t height);
+  // Signifies the blockchain has reorganized commences the rollback and pruning procedures.
+  void                        block_detach(cryptonote::Blockchain const &blockchain, uint64_t new_blockchain_height);
+
+  bool                        save_owner   (crypto::ed25519_public_key const &key, int64_t *row_id);
+  bool                        save_mapping (crypto::hash const &tx_hash, cryptonote::tx_extra_loki_name_system const &src, uint64_t height, int64_t owner_id);
+  bool                        save_settings(uint64_t top_height, crypto::hash const &top_hash, int version);
+
+  // Delete all mappings that are registered on height or newer followed by deleting all owners no longer referenced in the DB
+  bool                        prune_db(uint64_t height);
 
   owner_record                get_owner_by_key      (crypto::ed25519_public_key const &key) const;
   owner_record                get_owner_by_id       (int64_t owner_id) const;
@@ -141,13 +155,13 @@ struct name_system_db
   std::vector<mapping_record> get_mappings_by_owners(std::vector<crypto::ed25519_public_key> const &keys) const;
   settings_record             get_settings          () const;
 
-  bool                        validate_lns_tx(uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system *entry = nullptr, std::string *reason = nullptr) const;
-  cryptonote::network_type    network_type() const { return nettype; }
+  // entry: (optional) if function returns true, the Loki Name System entry in the TX extra is copied into 'entry'
+  bool                        validate_lns_tx       (uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system *entry = nullptr, std::string *reason = nullptr) const;
 
-  sqlite3                  *db                       = nullptr;
-  bool                      transaction_begun        = false;
+  sqlite3 *db               = nullptr;
+  bool    transaction_begun = false;
 private:
-  cryptonote::network_type  nettype;
+  cryptonote::network_type nettype;
   uint64_t last_processed_height                     = 0;
   sqlite3_stmt *save_owner_sql                       = nullptr;
   sqlite3_stmt *save_mapping_sql                     = nullptr;

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -65,7 +65,8 @@ bool         validate_lns_name(mapping_type type, std::string const &name, std::
 // blob: if set, validate_lns_value will convert the value into the binary format suitable for storing into the LNS DB.
 bool         validate_lns_value(cryptonote::network_type nettype, mapping_type type, std::string const &value, lns_value *blob = nullptr, std::string *reason = nullptr);
 bool         validate_lns_value_binary(mapping_type type, std::string const &value, std::string *reason = nullptr);
-bool         validate_mapping_type(std::string const &mapping_type_str, lns::mapping_type *mapping_type, std::string *reason);
+bool         validate_mapping_type(std::string const &type, lns::mapping_type *mapping_type, std::string *reason);
+crypto::hash name_to_hash(std::string const &name);
 
 struct owner_record
 {
@@ -98,7 +99,7 @@ struct mapping_record
 
   bool                       loaded;
   mapping_type               type;
-  std::string                name;
+  crypto::hash               name_hash;
   std::string                value;
   uint64_t                   register_height;
   int64_t                    owner_id;
@@ -123,8 +124,8 @@ struct name_system_db
 
   owner_record                get_owner_by_key      (crypto::ed25519_public_key const &key) const;
   owner_record                get_owner_by_id       (int64_t owner_id) const;
-  mapping_record              get_mapping           (mapping_type type, std::string const &name) const;
-  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, std::string const &name) const;
+  mapping_record              get_mapping           (mapping_type type, crypto::hash const &name_hash) const;
+  std::vector<mapping_record> get_mappings          (std::vector<uint16_t> const &types, crypto::hash const &name) const;
   std::vector<mapping_record> get_mappings_by_owner (crypto::ed25519_public_key const &key) const;
   std::vector<mapping_record> get_mappings_by_owners(std::vector<crypto::ed25519_public_key> const &keys) const;
   settings_record             get_settings          () const;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -238,7 +238,7 @@ namespace cryptonote
           return true;
         }
 
-        if (data.type == pool_data.type && data.name == pool_data.name)
+        if (data.type == pool_data.type && data.name_hash == pool_data.name_hash)
         {
           LOG_PRINT_L1("New TX: " << get_transaction_hash(tx) << ", has TX: " << get_transaction_hash(pool_tx) << " from the pool that is requesting the same LNS entry already.");
           return true;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3386,7 +3386,7 @@ namespace cryptonote
       if (exceeds_quantity_limit(ctx, error_resp, m_restricted, request.types.size(), COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES, "types"))
         return false;
 
-      crypto::hash name_hash = lns::name_to_hash(request.name);
+      std::string name_hash = lns::name_to_base64_hash(request.name);
       std::vector<lns::mapping_record> records = db.get_mappings(request.types, name_hash);
       res.entries.reserve(records.size());
       for (auto const &record : records)
@@ -3433,7 +3433,7 @@ namespace cryptonote
 
     lns::name_system_db const &db = m_core.get_blockchain_storage().name_system_db();
     std::vector<lns::mapping_record> records = db.get_mappings_by_owners(keys);
-    for (auto const &record : records)
+    for (auto &record : records)
     {
       res.entries.emplace_back();
       COMMAND_RPC_GET_LNS_OWNERS_TO_NAMES::response_entry &entry = res.entries.back();
@@ -3448,7 +3448,7 @@ namespace cryptonote
 
       entry.request_index   = it->second;
       entry.type            = static_cast<uint16_t>(record.type);
-      entry.name_hash       = epee::string_tools::pod_to_hex(record.name_hash);
+      entry.name_hash       = std::move(record.name_hash);
       entry.encrypted_value = epee::to_hex::string(epee::span<const uint8_t>(record.encrypted_value.buffer.data(), record.encrypted_value.len));
       entry.register_height = record.register_height;
       entry.txid            = epee::string_tools::pod_to_hex(record.txid);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3374,22 +3374,6 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  static std::string extract_lns_mapping_value(lns::mapping_record const &record)
-  {
-    std::string result;
-    if (lns::is_lokinet_type(record.type))
-    {
-      char buf[64] = {};
-      base32z::encode(record.value, buf);
-      result = std::string(buf) + ".loki";
-    }
-    else
-    {
-      result = epee::to_hex::string(epee::span<const uint8_t>(reinterpret_cast<const uint8_t *>(record.value.data()), record.value.size()));
-    }
-    return result;
-  }
-  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_lns_names_to_owners(const COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::request &req, COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::response &res, epee::json_rpc::error &error_resp, const connection_context *ctx)
   {
     if (exceeds_quantity_limit(ctx, error_resp, m_restricted, req.entries.size(), COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES))
@@ -3412,7 +3396,7 @@ namespace cryptonote
         entry.entry_index         = request_index;
         entry.type                = static_cast<uint16_t>(record.type);
         entry.owner               = epee::string_tools::pod_to_hex(record.owner);
-        entry.value               = extract_lns_mapping_value(record);
+        entry.encrypted_value     = epee::to_hex::string(epee::span<const uint8_t>(record.encrypted_value.buffer.data(), record.encrypted_value.len));
         entry.register_height     = record.register_height;
         entry.txid                = epee::string_tools::pod_to_hex(record.txid);
         entry.prev_txid           = epee::string_tools::pod_to_hex(record.prev_txid);
@@ -3448,27 +3432,27 @@ namespace cryptonote
     }
 
     lns::name_system_db const &db = m_core.get_blockchain_storage().name_system_db();
-    std::vector<lns::mapping_record> db_mappings = db.get_mappings_by_owners(keys);
-    for (lns::mapping_record const &mapping : db_mappings)
+    std::vector<lns::mapping_record> records = db.get_mappings_by_owners(keys);
+    for (auto const &record : records)
     {
       res.entries.emplace_back();
       COMMAND_RPC_GET_LNS_OWNERS_TO_NAMES::response_entry &entry = res.entries.back();
 
-      auto it = key_to_request_index.find(mapping.owner);
+      auto it = key_to_request_index.find(record.owner);
       if (it == key_to_request_index.end())
       {
         error_resp.code    = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
-        error_resp.message = "Public key=" + epee::string_tools::pod_to_hex(mapping.owner) + ", could not be mapped back a index in the request 'entries' array";
+        error_resp.message = "Public key=" + epee::string_tools::pod_to_hex(record.owner) + ", could not be mapped back a index in the request 'entries' array";
         return false;
       }
 
       entry.request_index   = it->second;
-      entry.type            = static_cast<uint16_t>(mapping.type);
-      entry.name_hash       = epee::string_tools::pod_to_hex(mapping.name_hash);
-      entry.value           = extract_lns_mapping_value(mapping);
-      entry.register_height = mapping.register_height;
-      entry.txid            = epee::string_tools::pod_to_hex(mapping.txid);
-      entry.prev_txid       = epee::string_tools::pod_to_hex(mapping.prev_txid);
+      entry.type            = static_cast<uint16_t>(record.type);
+      entry.name_hash       = epee::string_tools::pod_to_hex(record.name_hash);
+      entry.encrypted_value = epee::to_hex::string(epee::span<const uint8_t>(record.encrypted_value.buffer.data(), record.encrypted_value.len));
+      entry.register_height = record.register_height;
+      entry.txid            = epee::string_tools::pod_to_hex(record.txid);
+      entry.prev_txid       = epee::string_tools::pod_to_hex(record.prev_txid);
     }
 
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3402,7 +3402,8 @@ namespace cryptonote
       if (exceeds_quantity_limit(ctx, error_resp, m_restricted, request.types.size(), COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES, "types"))
         return false;
 
-      std::vector<lns::mapping_record> records = db.get_mappings(request.types, request.name);
+      crypto::hash name_hash = lns::name_to_hash(request.name);
+      std::vector<lns::mapping_record> records = db.get_mappings(request.types, name_hash);
       res.entries.reserve(records.size());
       for (auto const &record : records)
       {
@@ -3463,7 +3464,7 @@ namespace cryptonote
 
       entry.request_index   = it->second;
       entry.type            = static_cast<uint16_t>(mapping.type);
-      entry.name            = mapping.name;
+      entry.name_hash       = epee::string_tools::pod_to_hex(mapping.name_hash);
       entry.value           = extract_lns_mapping_value(mapping);
       entry.register_height = mapping.register_height;
       entry.txid            = epee::string_tools::pod_to_hex(mapping.txid);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3527,14 +3527,14 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
     {
       uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
       uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
-      std::string name;            // The name purchased via Loki Name Service
-      std::string value;           // The value that the name maps to
+      std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
+      std::string value;           // The value that the name maps to.
       uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
       std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(type)
-        KV_SERIALIZE(name)
+        KV_SERIALIZE(name_hash)
         KV_SERIALIZE(value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3482,7 +3482,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       uint64_t entry_index;     // The index in request_entry's `entries` array that was resolved via Loki Name Service.
       uint16_t type;            // The type of Loki Name Service entry that the owner owns.
       std::string owner;        // The ed25519 public key that purchased the Loki Name Service entry.
-      std::string value;        // The value that the name maps to.
+      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
       uint64_t register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;         // The txid of who purchased the mapping, null hash if not applicable.
       std::string prev_txid;    // The previous txid that purchased the mapping, null hash if not applicable.
@@ -3490,7 +3490,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
         KV_SERIALIZE(entry_index)
         KV_SERIALIZE(type)
         KV_SERIALIZE(owner)
-        KV_SERIALIZE(value)
+        KV_SERIALIZE(encrypted_value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)
         KV_SERIALIZE(prev_txid)
@@ -3528,14 +3528,15 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
       uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
       std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
-      std::string value;           // The value that the name maps to.
+      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
       uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
       std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
       std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
       BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(request_index)
         KV_SERIALIZE(type)
         KV_SERIALIZE(name_hash)
-        KV_SERIALIZE(value)
+        KV_SERIALIZE(encrypted_value)
         KV_SERIALIZE(register_height)
         KV_SERIALIZE(txid)
         KV_SERIALIZE(prev_txid)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -271,7 +271,7 @@ namespace
   const char* USAGE_PRINT_LOCKED_STAKES("print_locked_stakes");
   const char* USAGE_BUY_LNS_MAPPING("buy_lns_mapping [index=<N1>[,<N2>,...]] [<priority>] [owner] \"<name>\" <value>");
   const char* USAGE_UPDATE_LNS_MAPPING("update_lns_mapping [index=<N1>[,<N2>,...]] [<priority>] \"<name>\" <value> [<signature>]");
-  const char* USAGE_PRINT_LNS_OWNERS_TO_NAMES("print_lns_owners_to_names [<64 hex character ed25519 public key>]");
+  const char* USAGE_PRINT_LNS_OWNERS_TO_NAME_HASHES("print_lns_owners_to_name_hashes [<64 hex character ed25519 public key>]");
   const char* USAGE_PRINT_LNS_NAME_TO_OWNERS("print_lns_name_to_owners [type=<N1|all>[,<N2>...]] \"name\"");
 
 #if defined (LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
@@ -3113,10 +3113,10 @@ Pending or Failed: "failed"|"pending",  "out", Time, Amount*, Transaction Hash, 
                            tr(USAGE_UPDATE_LNS_MAPPING),
                            tr(stream.str().c_str()));
 
-  m_cmd_binder.set_handler("print_lns_owners_to_names",
-                           boost::bind(&simple_wallet::print_lns_owners_to_names, this, _1),
-                           tr(USAGE_PRINT_LNS_OWNERS_TO_NAMES),
-                           tr("Query the Loki Name Service names that the keys have purchased. If no keys are specified, it defaults to the current wallet."));
+  m_cmd_binder.set_handler("print_lns_owners_to_name_hashes",
+                           boost::bind(&simple_wallet::print_lns_owners_to_name_hashes, this, _1),
+                           tr(USAGE_PRINT_LNS_OWNERS_TO_NAME_HASHES),
+                           tr("Query the Loki Name Service names that the owners have purchased. If no keys are specified, it defaults to the current wallet."));
 
   m_cmd_binder.set_handler("print_lns_name_to_owners",
                            boost::bind(&simple_wallet::print_lns_name_to_owners, this, _1),
@@ -6614,7 +6614,7 @@ bool simple_wallet::print_lns_name_to_owners(const std::vector<std::string>& arg
   return true;
 }
 //----------------------------------------------------------------------------------------------------
-bool simple_wallet::print_lns_owners_to_names(const std::vector<std::string>& args)
+bool simple_wallet::print_lns_owners_to_name_hashes(const std::vector<std::string>& args)
 {
   if (!try_connect_to_daemon())
     return false;
@@ -6675,7 +6675,7 @@ bool simple_wallet::print_lns_owners_to_names(const std::vector<std::string>& ar
       }
     }
 
-    tools::msg_writer() << "owner=" << *owner << ", type=" << static_cast<lns::mapping_type>(entry.type) << ", height=" << entry.register_height << ", name=\"" << entry.name << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
+    tools::msg_writer() << "owner=" << *owner << ", type=" << entry.type << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
   }
   return true;
 }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6675,7 +6675,7 @@ bool simple_wallet::print_lns_owners_to_name_hashes(const std::vector<std::strin
       }
     }
 
-    tools::msg_writer() << "owner=" << *owner << ", type=" << entry.type << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", value=" << entry.value << ", prev_txid=" << entry.prev_txid;
+    tools::msg_writer() << "owner=" << *owner << ", type=" << entry.type << ", height=" << entry.register_height << ", name_hash=\"" << entry.name_hash << "\", encrypted_value=" << entry.encrypted_value << ", prev_txid=" << entry.prev_txid;
   }
   return true;
 }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -176,7 +176,7 @@ namespace cryptonote
     bool query_locked_stakes(bool print_result);
     bool buy_lns_mapping(const std::vector<std::string> &args);
     bool update_lns_mapping(const std::vector<std::string> &args);
-    bool print_lns_owners_to_names(const std::vector<std::string> &args);
+    bool print_lns_owners_to_name_hashes(const std::vector<std::string> &args);
     bool print_lns_name_to_owners(const std::vector<std::string> &args);
 
     enum class sweep_type_t { stake, register_stake, all_or_below, single };

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8469,7 +8469,7 @@ static bool prepare_tx_extra_loki_name_system_values(cryptonote::network_type ne
 
     if (response.size())
     {
-      crypto::hash txid_hash;
+      crypto::hash txid_hash = {};
       if (epee::string_tools::hex_to_pod(response[0].txid, txid_hash))
       {
         prev_txid = txid_hash;
@@ -8515,7 +8515,7 @@ std::vector<wallet2::pending_tx> wallet2::create_buy_lns_mapping_tx(lns::mapping
     return {};
 
   std::vector<uint8_t> extra;
-  auto entry = cryptonote::tx_extra_loki_name_system::make_buy(pkey, type, name, std::string(reinterpret_cast<char const *>(value_blob.buffer.data()), value_blob.len), prev_txid);
+  auto entry = cryptonote::tx_extra_loki_name_system::make_buy(pkey, type, lns::name_to_hash(name), std::string(reinterpret_cast<char const *>(value_blob.buffer.data()), value_blob.len), prev_txid);
   add_loki_name_system_to_tx_extra(extra, entry);
 
   boost::optional<uint8_t> hf_version = get_hard_fork_version();
@@ -8588,7 +8588,7 @@ std::vector<wallet2::pending_tx> wallet2::create_update_lns_mapping_tx(lns::mapp
   }
 
   std::vector<uint8_t> extra;
-  auto entry = cryptonote::tx_extra_loki_name_system::make_update(signature_binary, type, name, std::string(reinterpret_cast<char const *>(value_blob.buffer.data()), value_blob.len), prev_txid);
+  auto entry = cryptonote::tx_extra_loki_name_system::make_update(signature_binary, type, lns::name_to_hash(name), std::string(reinterpret_cast<char const *>(value_blob.buffer.data()), value_blob.len), prev_txid);
   add_loki_name_system_to_tx_extra(extra, entry);
 
   boost::optional<uint8_t> hf_version = get_hard_fork_version();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8434,7 +8434,7 @@ static bool prepare_tx_extra_loki_name_system_values(cryptonote::network_type ne
                                                      std::string const &value,
                                                      wallet2 const &wallet,
                                                      crypto::hash &prev_txid,
-                                                     lns::lns_value &value_blob,
+                                                     lns::mapping_value &encrypted_value,
                                                      std::string *reason)
 {
   if (priority == tools::tx_priority_blink)
@@ -8443,11 +8443,38 @@ static bool prepare_tx_extra_loki_name_system_values(cryptonote::network_type ne
     return false;
   }
 
-  if (!lns::validate_lns_name(type, name, reason))
+  boost::optional<uint8_t> hf_version = wallet.get_hard_fork_version();
+  if (!hf_version)
+  {
+    if (reason) *reason = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
     return false;
+  }
 
-  if (!lns::validate_lns_value(nettype, type, value, &value_blob, reason))
-    return false;
+  // Make encrypted value
+  {
+    if (!lns::validate_lns_name(type, name, reason))
+      return false;
+
+    if (!lns::mapping_type_allowed(*hf_version, type))
+    {
+      if (reason)
+      {
+        *reason = "Mapping type not allowed=";
+        reason->append(lns::mapping_type_str(type));
+      }
+      return false;
+    }
+
+    lns::mapping_value blob = {};
+    if (!lns::validate_mapping_value(nettype, type, value, &blob, reason))
+      return false;
+
+    if (!lns::encrypt_mapping_value(name, blob, encrypted_value))
+    {
+      if (reason) *reason = "Failed to encrypt LNS value=" + value;
+       return false;
+    }
+  }
 
   prev_txid = crypto::null_hash;
   {
@@ -8509,13 +8536,13 @@ std::vector<wallet2::pending_tx> wallet2::create_buy_lns_mapping_tx(lns::mapping
     crypto_sign_ed25519_seed_keypair(pkey.data, skey.data, reinterpret_cast<const unsigned char *>(&m_account.get_keys().m_spend_secret_key));
   }
 
-  lns::lns_value value_blob;
+  lns::mapping_value encrypted_value;
   crypto::hash prev_txid;
-  if (!prepare_tx_extra_loki_name_system_values(nettype(), type, priority, name, value, *this, prev_txid, value_blob, reason))
+  if (!prepare_tx_extra_loki_name_system_values(nettype(), type, priority, name, value, *this, prev_txid, encrypted_value, reason))
     return {};
 
   std::vector<uint8_t> extra;
-  auto entry = cryptonote::tx_extra_loki_name_system::make_buy(pkey, type, lns::name_to_hash(name), std::string(reinterpret_cast<char const *>(value_blob.buffer.data()), value_blob.len), prev_txid);
+  auto entry = cryptonote::tx_extra_loki_name_system::make_buy(pkey, type, lns::name_to_hash(name), encrypted_value.to_string(), prev_txid);
   add_loki_name_system_to_tx_extra(extra, entry);
 
   boost::optional<uint8_t> hf_version = get_hard_fork_version();
@@ -8564,7 +8591,7 @@ std::vector<wallet2::pending_tx> wallet2::create_update_lns_mapping_tx(lns::mapp
                                                                        std::set<uint32_t> subaddr_indices)
 {
   crypto::hash prev_txid;
-  lns::lns_value value_blob;
+  lns::mapping_value value_blob;
   if (!prepare_tx_extra_loki_name_system_values(nettype(), type, priority, name, value, *this, prev_txid, value_blob, reason))
     return {};
 

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -537,9 +537,10 @@ cryptonote::transaction loki_chain_generator::create_loki_name_system_tx(crypton
   if (burn == LNS_AUTO_BURN)
     burn = lns::burn_needed(new_hf_version, type);
 
-  crypto::hash name_hash = lns::name_to_hash(name);
+  crypto::hash name_hash       = lns::name_to_hash(name);
+  std::string name_base64_hash = lns::name_to_base64_hash(name);
   crypto::hash prev_txid = crypto::null_hash;
-  if (lns::mapping_record mapping = lns_db_.get_mapping(type, name_hash))
+  if (lns::mapping_record mapping = lns_db_.get_mapping(type, name_base64_hash))
     prev_txid = mapping.txid;
 
   lns::mapping_value encrypted_value = {};
@@ -567,9 +568,10 @@ cryptonote::transaction loki_chain_generator::create_loki_name_system_tx_update(
                                                                                 crypto::ed25519_signature *signature,
                                                                                 bool use_asserts) const
 {
-  crypto::hash name_hash      = lns::name_to_hash(name);
-  lns::mapping_record mapping = lns_db_.get_mapping(type, name_hash);
-  crypto::hash prev_txid      = mapping.txid;
+  crypto::hash name_hash       = lns::name_to_hash(name);
+  std::string name_base64_hash = lns::name_to_base64_hash(name);
+  lns::mapping_record mapping  = lns_db_.get_mapping(type, name_base64_hash);
+  crypto::hash prev_txid       = mapping.txid;
   if (use_asserts) assert(mapping);
 
   crypto::ed25519_public_key pkey;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1421,8 +1421,9 @@ struct loki_chain_generator
 
   // NOTE: Add constructed TX to events_ and assume that it is valid to add to the blockchain. If the TX is meant to be unaddable to the blockchain use the individual create + add functions to
   // be able to mark the add TX event as something that should trigger a failure.
-  cryptonote::transaction                              create_and_add_loki_name_system_tx(cryptonote::account_base const &src, lns::mapping_type type, std::string const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, bool kept_by_block = false);
-  cryptonote::transaction                              create_and_add_loki_name_system_tx_update(cryptonote::account_base const &src, lns::mapping_type type, std::string const &value, std::string const &name, bool kept_by_block = false);
+  // value: The binary representation of the value part in the name->value mapping
+  cryptonote::transaction                              create_and_add_loki_name_system_tx(cryptonote::account_base const &src, lns::mapping_type type, lns::mapping_value const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, bool kept_by_block = false);
+  cryptonote::transaction                              create_and_add_loki_name_system_tx_update(cryptonote::account_base const &src, lns::mapping_type type, lns::mapping_value const &value, std::string const &name, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_tx                 (const cryptonote::account_base& src, const cryptonote::account_public_address& dest, uint64_t amount, uint64_t fee = TESTS_DEFAULT_FEE, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_state_change_tx(service_nodes::new_state state, const crypto::public_key& pub_key, uint64_t height = -1, const std::vector<uint64_t>& voters = {}, uint64_t fee = 0, bool kept_by_block = false);
   cryptonote::transaction                              create_and_add_registration_tx(const cryptonote::account_base& src, const cryptonote::keypair& sn_keys = cryptonote::keypair::generate(hw::get_device("default")), bool kept_by_block = false);
@@ -1443,8 +1444,8 @@ struct loki_chain_generator
 
   // value: Takes the binary value NOT the human readable version, of the name->value mapping
   static const uint64_t LNS_AUTO_BURN = static_cast<uint64_t>(-1);
-  cryptonote::transaction                              create_loki_name_system_tx    (cryptonote::account_base const &src, lns::mapping_type type, std::string const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, uint64_t burn = LNS_AUTO_BURN) const;
-  cryptonote::transaction                              create_loki_name_system_tx_update(cryptonote::account_base const &src, lns::mapping_type type, std::string const &value, std::string const &name, crypto::ed25519_signature *signature = nullptr, bool use_asserts = false) const;
+  cryptonote::transaction                              create_loki_name_system_tx    (cryptonote::account_base const &src, lns::mapping_type type, lns::mapping_value const &value, std::string const &name, crypto::ed25519_public_key const *owner = nullptr, uint64_t burn = LNS_AUTO_BURN) const;
+  cryptonote::transaction                              create_loki_name_system_tx_update(cryptonote::account_base const &src, lns::mapping_type type, lns::mapping_value const &value, std::string const &name, crypto::ed25519_signature *signature = nullptr, bool use_asserts = false) const;
   cryptonote::transaction                              create_loki_name_system_tx_update_w_extra(cryptonote::account_base const &src, cryptonote::tx_extra_loki_name_system const &lns_extra) const;
 
   loki_blockchain_entry                                create_genesis_block(const cryptonote::account_base &miner, uint64_t timestamp);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1067,6 +1067,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
 
       uint64_t height_of_lns_entry   = gen.height();
       uint64_t expected_expiry_block = height_of_lns_entry + lns::expiry_blocks(cryptonote::FAKECHAIN, mapping_type, nullptr);
+      crypto::hash name_hash         = lns::name_to_hash(name);
 
       loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
       {
@@ -1078,10 +1079,10 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
         CHECK_EQ(owner.id, 1);
         CHECK_EQ(miner_key.ed_key, owner.key);
 
-        lns::mapping_record mappings = lns_db.get_mapping(mapping_type, name);
+        lns::mapping_record mappings = lns_db.get_mapping(mapping_type, name_hash);
         CHECK_EQ(mappings.loaded, true);
         CHECK_EQ(mappings.type, mapping_type);
-        CHECK_EQ(mappings.name, name);
+        CHECK_EQ(mappings.name_hash, name_hash);
         CHECK_EQ(mappings.value, miner_key.lokinet_value);
         CHECK_EQ(mappings.register_height, height_of_lns_entry);
         CHECK_EQ(mappings.owner_id, owner.id);
@@ -1103,11 +1104,11 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
         CHECK_EQ(owner.id, 1);
         CHECK_EQ(miner_key.ed_key, owner.key);
 
-        lns::mapping_record mappings = lns_db.get_mapping(mapping_type, name);
+        lns::mapping_record mappings = lns_db.get_mapping(mapping_type, name_hash);
         CHECK_EQ(mappings.loaded, true);
         CHECK_EQ(mappings.active(cryptonote::FAKECHAIN, blockchain_height), false);
         CHECK_EQ(mappings.type, mapping_type);
-        CHECK_EQ(mappings.name, name);
+        CHECK_EQ(mappings.name_hash, name_hash);
         CHECK_EQ(mappings.value, miner_key.lokinet_value);
         CHECK_EQ(mappings.register_height, height_of_lns_entry);
         CHECK_EQ(mappings.owner_id, owner.id);
@@ -1192,8 +1193,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::session))
     {
-      CHECK_EQ(records[0].name, session_name1);
-      CHECK_EQ(records[1].name, session_name2);
+      CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
+      CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
       CHECK_EQ(records[0].register_height, session_height);
       CHECK_EQ(records[1].register_height, session_height);
       CHECK_EQ(records[0].value, bob_key.session_value);
@@ -1204,8 +1205,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::lokinet_1year))
     {
-      CHECK_EQ(records[2].name, lokinet_name1);
-      CHECK_EQ(records[3].name, lokinet_name2);
+      CHECK_EQ(records[2].name_hash, lns::name_to_hash(lokinet_name1));
+      CHECK_EQ(records[3].name_hash, lns::name_to_hash(lokinet_name2));
       CHECK_EQ(records[2].register_height, lokinet_height);
       CHECK_EQ(records[3].register_height, lokinet_height);
       CHECK_EQ(records[2].value, bob_key.lokinet_value);
@@ -1216,8 +1217,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::wallet))
     {
-      CHECK_EQ(records[4].name, wallet_name1);
-      CHECK_EQ(records[5].name, wallet_name2);
+      CHECK_EQ(records[4].name_hash, lns::name_to_hash(wallet_name1));
+      CHECK_EQ(records[5].name_hash, lns::name_to_hash(wallet_name2));
       CHECK_EQ(records[4].register_height, wallet_height);
       CHECK_EQ(records[5].register_height, wallet_height);
       CHECK_EQ(records[4].value, bob_key.wallet_value);
@@ -1293,7 +1294,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
       return lhs.register_height < rhs.register_height;
     });
     CHECK_EQ(records[0].type, lns::mapping_type::session);
-    CHECK_EQ(records[0].name, session_name1);
+    CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
     CHECK_EQ(records[0].value, bob_key.session_value);
     CHECK_EQ(records[0].register_height, session_height1);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
@@ -1301,7 +1302,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[0].owner, bob_key.ed_key);
 
     CHECK_EQ(records[1].type, lns::mapping_type::session);
-    CHECK_EQ(records[1].name, session_name2);
+    CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
     CHECK_EQ(records[1].value, bob_key.session_value);
     CHECK_EQ(records[1].register_height, session_height2);
     CHECK_EQ(records[1].prev_txid, crypto::null_hash);
@@ -1309,7 +1310,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[1].owner, bob_key.ed_key);
 
     CHECK_EQ(records[2].type, lns::mapping_type::session);
-    CHECK_EQ(records[2].name, session_name3);
+    CHECK_EQ(records[2].name_hash, lns::name_to_hash(session_name3));
     CHECK_EQ(records[2].value, miner_key.session_value);
     CHECK_EQ(records[2].register_height, session_height3);
     CHECK_EQ(records[2].prev_txid, crypto::null_hash);
@@ -1354,10 +1355,12 @@ bool loki_name_system_get_mappings::generate(std::vector<test_event_entry> &even
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
     lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
-    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name1);
+
+    crypto::hash session_name_hash = lns::name_to_hash(session_name1);
+    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name_hash);
     CHECK_EQ(records.size(), 1);
     CHECK_EQ(records[0].type, lns::mapping_type::session);
-    CHECK_EQ(records[0].name, session_name1);
+    CHECK_EQ(records[0].name_hash, session_name_hash);
     CHECK_EQ(records[0].value, bob_key.session_value);
     CHECK_EQ(records[0].register_height, session_height);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
@@ -1427,20 +1430,21 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::session, session_name);
+    crypto::hash session_name_hash = lns::name_to_hash(session_name);
+    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::session, session_name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::session);
-    CHECK_EQ(mappings.name, session_name);
+    CHECK_EQ(mappings.name_hash, session_name_hash);
     CHECK_EQ(mappings.value, bob_key.session_value);
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.owner_id, owner.id);
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::lokinet_1year))
     {
-      lns::mapping_record mappings2 = lns_db.get_mapping(lns::mapping_type::lokinet_1year, session_name);
+      lns::mapping_record mappings2 = lns_db.get_mapping(lns::mapping_type::lokinet_1year, session_name_hash);
       CHECK_EQ(mappings2.loaded, true);
       CHECK_EQ(mappings2.type, lns::mapping_type::lokinet_1year);
-      CHECK_EQ(mappings2.name, session_name);
+      CHECK_EQ(mappings2.name_hash, session_name_hash);
       CHECK_EQ(mappings2.value, miner_key.lokinet_value);
       CHECK_EQ(mappings2.register_height, height_of_lns_entry);
       CHECK_EQ(mappings2.owner_id, owner.id);
@@ -1448,10 +1452,10 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), custom_type))
     {
-      lns::mapping_record mappings3 = lns_db.get_mapping(custom_type, session_name);
+      lns::mapping_record mappings3 = lns_db.get_mapping(custom_type, session_name_hash);
       CHECK_EQ(mappings3.loaded, true);
       CHECK_EQ(mappings3.type, custom_type);
-      CHECK_EQ(mappings3.name, session_name);
+      CHECK_EQ(mappings3.name_hash, session_name_hash);
       CHECK_EQ(mappings3.value, bob_key.session_value);
       CHECK_EQ(mappings3.register_height, height_of_lns_entry);
       CHECK_EQ(mappings3.owner_id, owner.id);
@@ -1541,21 +1545,14 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     valid_data.owner                                 = miner_key.ed_key;
     valid_data.type                                  = lns::mapping_type::wallet;
     valid_data.value                                 = miner_key.wallet_value;
-    valid_data.name                                  = "my_lns_name";
+    valid_data.name_hash                             = lns::name_to_hash("my_lns_name");
 
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
     {
-      // Blockchain name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::WALLET_NAME_MAX + 1, 'A');
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet to name in LNS too long");
-      }
-
       // Blockchain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Empty wallet name in LNS is invalid");
       }
 
@@ -1570,18 +1567,10 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet_1year))
     {
       valid_data.type = lns::mapping_type::lokinet_1year;
-      // Lokinet domain name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::LOKINET_DOMAIN_NAME_MAX, 'A');
-        data.name                                 += ".loki";
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain name in LNS too long");
-      }
-
       // Lokinet domain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Empty domain name in LNS is invalid");
       }
 
@@ -1629,7 +1618,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
 
     // Session value too short
     // We added valid tx prior, we should update name to avoid conflict names in session land and test other invalid params
-    valid_data.name = "new_friendly_name";
+    valid_data.name_hash = lns::name_to_hash("new_friendly_name");
     {
       cryptonote::tx_extra_loki_name_system data = valid_data;
       data.value                                 = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH * 2 - 1, 'A');
@@ -1643,18 +1632,11 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too long");
     }
 
-    // Session name too long
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.name                                  = std::string(lns::SESSION_DISPLAY_NAME_MAX + 1, 'A');
-      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, name too long");
-    }
-
     // Session name empty
     {
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.name                                  = {};
-      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, name too long");
+      data.name_hash                             = {};
+      make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) Name empty");
     }
 
     auto custom_type = static_cast<lns::mapping_type>(1111);
@@ -1666,7 +1648,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       // Generic name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = {};
+        data.name_hash                             = {};
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
       }
 
@@ -1680,7 +1662,7 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       // Generic name too long
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name                                  = std::string(lns::GENERIC_NAME_MAX + 1, 'A');
+        data.name_hash                             = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX + 1, 'A'));
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
       }
 
@@ -1765,19 +1747,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == lns::mapping_type::session)
         {
-          CHECK_EQ(record.name, miner_session_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.session_value);
         }
         else if (record.type == lns::mapping_type::lokinet_1year)
         {
-          CHECK_EQ(record.name, miner_lokinet_domain1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.lokinet_value);
         }
         else if (record.type == lns::mapping_type::wallet)
         {
-          CHECK_EQ(record.name, miner_wallet_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.wallet_value);
         }
@@ -1823,19 +1805,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         {
           if (record.type == lns::mapping_type::session)
           {
-            CHECK_EQ(record.name, miner_session_name1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.value, miner_key.session_value);
           }
           else if (record.type == lns::mapping_type::lokinet_1year)
           {
-            CHECK_EQ(record.name, miner_lokinet_domain1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
             CHECK_EQ(record.register_height, second_lns_height);
             CHECK_EQ(record.value, miner_key.lokinet_value);
           }
           else if (record.type == lns::mapping_type::wallet)
           {
-            CHECK_EQ(record.name, miner_wallet_name1);
+            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.value, miner_key.wallet_value);
           }
@@ -1850,7 +1832,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owner(bob_key.ed_key);
         CHECK_EQ(records.size(), 1);
-        CHECK_EQ(records[0].name, bob_session_name1);
+        CHECK_EQ(records[0].name_hash, lns::name_to_hash(bob_session_name1));
         CHECK_EQ(records[0].register_height, second_lns_height);
         CHECK_EQ(records[0].value, bob_key.session_value);
         CHECK_EQ(records[0].type, lns::mapping_type::session);
@@ -1892,19 +1874,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == lns::mapping_type::session)
         {
-          CHECK_EQ(record.name, miner_session_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.session_value);
         }
         else if (record.type == lns::mapping_type::lokinet_1year)
         {
-          CHECK_EQ(record.name, miner_lokinet_domain1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.lokinet_value);
         }
         else if (record.type == lns::mapping_type::wallet)
         {
-          CHECK_EQ(record.name, miner_wallet_name1);
+          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.value, miner_key.wallet_value);
         }
@@ -1979,10 +1961,11 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name);
+    crypto::hash name_hash = lns::name_to_hash(name);
+    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
-    CHECK_EQ(mappings.name, name);
+    CHECK_EQ(mappings.name_hash, name_hash);
     CHECK_EQ(mappings.value, miner_key.lokinet_value);
     CHECK_EQ(mappings.register_height, height_of_lns_entry);
     CHECK_EQ(mappings.prev_txid, crypto::null_hash);
@@ -2008,10 +1991,11 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name);
+    crypto::hash name_hash = lns::name_to_hash(name);
+    lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
-    CHECK_EQ(mappings.name, name);
+    CHECK_EQ(mappings.name_hash, name_hash);
     CHECK_EQ(mappings.value, miner_key.lokinet_value);
     CHECK_EQ(mappings.register_height, renewal_height);
     CHECK_EQ(mappings.prev_txid, prev_txid);
@@ -2061,37 +2045,28 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   // Blockchain
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
   {
-    data.type                                  = lns::mapping_type::wallet;
-    data.name                                  = std::string(lns::WALLET_NAME_MAX, 'A');
-    data.value                                 = miner_key.wallet_value;
+    data.type      = lns::mapping_type::wallet;
+    data.name_hash = lns::name_to_hash(std::string(lns::WALLET_NAME_MAX, 'A'));
+    data.value     = miner_key.wallet_value;
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
   // Lokinet
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet_1year))
   {
-    data.type                                  = lns::mapping_type::lokinet_1year;
-    data.name                                  = "doyle.loki";
-    data.value                                 = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH, 'a');
+    data.type      = lns::mapping_type::lokinet_1year;
+    data.name_hash = lns::name_to_hash("doyle.loki");
+    data.value     = std::string(lns::LOKINET_ADDRESS_BINARY_LENGTH, 'a');
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
   // Session
   {
-    data.type     = lns::mapping_type::session;
-    data.name     = std::string(lns::SESSION_DISPLAY_NAME_MAX, 'A');
-    data.value    = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH, 'a');
-    data.value[0] = '0';
-    data.value[1] = '5';
-    make_lns_tx_with_custom_extra(gen, events, miner, data);
-  }
-
-  // Generic
-  if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::lokinet_1year))
-  {
-    data.type  = static_cast<lns::mapping_type>(1111);
-    data.name  = std::string(lns::GENERIC_NAME_MAX, 'A');
-    data.value = std::string(lns::GENERIC_VALUE_MAX, 'a');
+    data.type      = lns::mapping_type::session;
+    data.name_hash = lns::name_to_hash(std::string(lns::SESSION_DISPLAY_NAME_MAX, 'A'));
+    data.value     = std::string(lns::SESSION_PUBLIC_KEY_BINARY_LENGTH, 'a');
+    data.value[0]  = '0';
+    data.value[1]  = '5';
     make_lns_tx_with_custom_extra(gen, events, miner, data);
   }
 
@@ -2135,10 +2110,11 @@ bool loki_name_system_update_mapping_after_expiry_fails::generate(std::vector<te
       CHECK_EQ(owner.id, 1);
       CHECK_EQ(miner_key.ed_key, owner.key);
 
-      lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name);
+      crypto::hash name_hash = lns::name_to_hash(name);
+      lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
       CHECK_EQ(mappings.loaded, true);
       CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
-      CHECK_EQ(mappings.name, name);
+      CHECK_EQ(mappings.name_hash, name_hash);
       CHECK_EQ(mappings.value, miner_key.lokinet_value);
       CHECK_EQ(mappings.register_height, height_of_lns_entry);
       CHECK_EQ(mappings.owner_id, owner.id);
@@ -2188,10 +2164,12 @@ bool loki_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_updated");
     lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
-    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name1);
+
+    crypto::hash name_hash = lns::name_to_hash(session_name1);
+    std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, name_hash);
     CHECK_EQ(records.size(), 1);
     CHECK_EQ(records[0].type, lns::mapping_type::session);
-    CHECK_EQ(records[0].name, session_name1);
+    CHECK_EQ(records[0].name_hash, name_hash);
     CHECK_EQ(records[0].value, bob_key.session_value);
     CHECK_EQ(records[0].register_height, session_height2);
     CHECK_EQ(records[0].prev_txid, session_tx_hash1);
@@ -2362,7 +2340,7 @@ bool loki_name_system_wrong_version::generate(std::vector<test_event_entry> &eve
   data.owner                                 = miner_key.ed_key;
   data.type                                  = lns::mapping_type::session;
   data.value                                 = miner_key.session_value;
-  data.name                                  = "my_lns_name";
+  data.name_hash                             = lns::name_to_hash("my_lns_name");
 
   uint64_t new_height       = cryptonote::get_block_height(gen.top().block) + 1;
   uint8_t new_hf_version    = gen.get_hf_version_at(new_height);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1546,12 +1546,12 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
     std::string name = "my_lns_name";
     cryptonote::tx_extra_loki_name_system valid_data = {};
     valid_data.owner                                 = miner_key.ed_key;
-    valid_data.type                                  = lns::mapping_type::wallet;
     valid_data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
     valid_data.name_hash                             = lns::name_to_hash("my_lns_name");
 
     if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
     {
+      valid_data.type = lns::mapping_type::wallet;
       // Blockchain name empty
       {
         cryptonote::tx_extra_loki_name_system data = valid_data;
@@ -1560,13 +1560,19 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Empty wallet name in LNS is invalid");
       }
 
-      // Blockchain value (wallet address) is invalid, clearly too short
+      // Blockchain value (wallet address) is invalid, too short
       {
-        lns::mapping_value value = {};
-        value.len                = miner_key.wallet_value.len - 1;
-
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() - 1);
+        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet value in LNS too long");
+      }
+
+      // Blockchain value (wallet address) is invalid, too long
+      {
+        cryptonote::tx_extra_loki_name_system data = valid_data;
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() + 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Blockchain) Wallet value in LNS too long");
       }
     }
@@ -1584,43 +1590,38 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
 
       // Lokinet value too short
       {
-        lns::mapping_value value                   = {};
-        value.len                                  = miner_key.lokinet_value.len - 1;
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.lokinet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() - 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
 
       // Lokinet value too long
       {
-        lns::mapping_value value                   = {};
-        value.len                                  = miner_key.lokinet_value.len + 1;
         cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+        data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.lokinet_value).to_string();
+        data.encrypted_value.resize(data.encrypted_value.size() + 1);
         make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Lokinet) Domain value in LNS too long");
       }
     }
 
     // Session value too short
     // We added valid tx prior, we should update name to avoid conflict names in session land and test other invalid params
+    valid_data.type      = lns::mapping_type::session;
     name                 = "new_friendly_name";
     valid_data.name_hash = lns::name_to_hash(name);
     {
-      lns::mapping_value value = {};
-      value.len                = miner_key.session_value.len - 1;
-
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+      data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
+      data.encrypted_value.resize(data.encrypted_value.size() - 1);
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too short");
     }
 
     // Session value too long
     {
-      lns::mapping_value value = {};
-      value.len                = miner_key.session_value.len - 1;
-
       cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.encrypted_value                       = helper_encrypt_lns_value(name, value).to_string();
+      data.encrypted_value                       = helper_encrypt_lns_value(name, miner_key.session_value).to_string();
+      data.encrypted_value.resize(data.encrypted_value.size() + 1);
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) User id, value too long");
     }
 

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1638,41 +1638,6 @@ bool loki_name_system_invalid_tx_extra_params::generate(std::vector<test_event_e
       data.name_hash                             = {};
       make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Session) Name empty");
     }
-
-    auto custom_type = static_cast<lns::mapping_type>(1111);
-    if (lns::mapping_type_allowed(gen.hardfork(), custom_type))
-    {
-      cryptonote::tx_extra_loki_name_system data = valid_data;
-      data.type                                  = custom_type;
-
-      // Generic name empty
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name_hash                             = {};
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
-      }
-
-      // Generic valid empty
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = {};
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Value empty");
-      }
-
-      // Generic name too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.name_hash                             = lns::name_to_hash(std::string(lns::GENERIC_NAME_MAX + 1, 'A'));
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Name empty");
-      }
-
-      // Generic value too long
-      {
-        cryptonote::tx_extra_loki_name_system data = valid_data;
-        data.value                                 = std::string(lns::GENERIC_VALUE_MAX + 1, 'A');
-        make_lns_tx_with_custom_extra(gen, events, miner, data, false, "(Generic) Value too long");
-      }
-    }
   }
   return true;
 }

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1069,7 +1069,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
 
       uint64_t height_of_lns_entry   = gen.height();
       uint64_t expected_expiry_block = height_of_lns_entry + lns::expiry_blocks(cryptonote::FAKECHAIN, mapping_type, nullptr);
-      crypto::hash name_hash         = lns::name_to_hash(name);
+      std::string name_hash = lns::name_to_base64_hash(name);
 
       loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
       {
@@ -1195,8 +1195,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::session))
     {
-      CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
-      CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
+      CHECK_EQ(records[0].name_hash, lns::name_to_base64_hash(session_name1));
+      CHECK_EQ(records[1].name_hash, lns::name_to_base64_hash(session_name2));
       CHECK_EQ(records[0].register_height, session_height);
       CHECK_EQ(records[1].register_height, session_height);
       CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(session_name1, bob_key.session_value));
@@ -1207,8 +1207,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::lokinet_1year))
     {
-      CHECK_EQ(records[2].name_hash, lns::name_to_hash(lokinet_name1));
-      CHECK_EQ(records[3].name_hash, lns::name_to_hash(lokinet_name2));
+      CHECK_EQ(records[2].name_hash, lns::name_to_base64_hash(lokinet_name1));
+      CHECK_EQ(records[3].name_hash, lns::name_to_base64_hash(lokinet_name2));
       CHECK_EQ(records[2].register_height, lokinet_height);
       CHECK_EQ(records[3].register_height, lokinet_height);
       CHECK_EQ(records[2].encrypted_value, helper_encrypt_lns_value(lokinet_name1, bob_key.lokinet_value));
@@ -1219,8 +1219,8 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
 
     if (lns::mapping_type_allowed(c.get_blockchain_storage().get_current_hard_fork_version(), lns::mapping_type::wallet))
     {
-      CHECK_EQ(records[4].name_hash, lns::name_to_hash(wallet_name1));
-      CHECK_EQ(records[5].name_hash, lns::name_to_hash(wallet_name2));
+      CHECK_EQ(records[4].name_hash, lns::name_to_base64_hash(wallet_name1));
+      CHECK_EQ(records[5].name_hash, lns::name_to_base64_hash(wallet_name2));
       CHECK_EQ(records[4].register_height, wallet_height);
       CHECK_EQ(records[5].register_height, wallet_height);
       CHECK_EQ(records[4].encrypted_value, helper_encrypt_lns_value(wallet_name1, bob_key.wallet_value));
@@ -1296,7 +1296,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
       return lhs.register_height < rhs.register_height;
     });
     CHECK_EQ(records[0].type, lns::mapping_type::session);
-    CHECK_EQ(records[0].name_hash, lns::name_to_hash(session_name1));
+    CHECK_EQ(records[0].name_hash, lns::name_to_base64_hash(session_name1));
     CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(session_name1, bob_key.session_value));
     CHECK_EQ(records[0].register_height, session_height1);
     CHECK_EQ(records[0].prev_txid, crypto::null_hash);
@@ -1304,7 +1304,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[0].owner, bob_key.ed_key);
 
     CHECK_EQ(records[1].type, lns::mapping_type::session);
-    CHECK_EQ(records[1].name_hash, lns::name_to_hash(session_name2));
+    CHECK_EQ(records[1].name_hash, lns::name_to_base64_hash(session_name2));
     CHECK_EQ(records[1].encrypted_value, helper_encrypt_lns_value(session_name2, bob_key.session_value));
     CHECK_EQ(records[1].register_height, session_height2);
     CHECK_EQ(records[1].prev_txid, crypto::null_hash);
@@ -1312,7 +1312,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
     CHECK_EQ(records[1].owner, bob_key.ed_key);
 
     CHECK_EQ(records[2].type, lns::mapping_type::session);
-    CHECK_EQ(records[2].name_hash, lns::name_to_hash(session_name3));
+    CHECK_EQ(records[2].name_hash, lns::name_to_base64_hash(session_name3));
     CHECK_EQ(records[2].encrypted_value, helper_encrypt_lns_value(session_name3, miner_key.session_value));
     CHECK_EQ(records[2].register_height, session_height3);
     CHECK_EQ(records[2].prev_txid, crypto::null_hash);
@@ -1358,7 +1358,7 @@ bool loki_name_system_get_mappings::generate(std::vector<test_event_entry> &even
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
     lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
 
-    crypto::hash session_name_hash = lns::name_to_hash(session_name1);
+    std::string session_name_hash = lns::name_to_base64_hash(session_name1);
     std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name_hash);
     CHECK_EQ(records.size(), 1);
     CHECK_EQ(records[0].type, lns::mapping_type::session);
@@ -1432,7 +1432,7 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    crypto::hash session_name_hash = lns::name_to_hash(session_name);
+    std::string session_name_hash = lns::name_to_base64_hash(session_name);
     lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::session, session_name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::session);
@@ -1706,19 +1706,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == lns::mapping_type::session)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
         }
         else if (record.type == lns::mapping_type::lokinet_1year)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
         }
         else if (record.type == lns::mapping_type::wallet)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
         }
@@ -1764,19 +1764,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
         {
           if (record.type == lns::mapping_type::session)
           {
-            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
+            CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_session_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
           }
           else if (record.type == lns::mapping_type::lokinet_1year)
           {
-            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
+            CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_lokinet_domain1));
             CHECK_EQ(record.register_height, second_lns_height);
             CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
           }
           else if (record.type == lns::mapping_type::wallet)
           {
-            CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
+            CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_wallet_name1));
             CHECK_EQ(record.register_height, first_lns_height);
             CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
           }
@@ -1791,7 +1791,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owner(bob_key.ed_key);
         CHECK_EQ(records.size(), 1);
-        CHECK_EQ(records[0].name_hash, lns::name_to_hash(bob_session_name1));
+        CHECK_EQ(records[0].name_hash, lns::name_to_base64_hash(bob_session_name1));
         CHECK_EQ(records[0].register_height, second_lns_height);
         CHECK_EQ(records[0].encrypted_value, helper_encrypt_lns_value(bob_session_name1, bob_key.session_value));
         CHECK_EQ(records[0].type, lns::mapping_type::session);
@@ -1833,19 +1833,19 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
       {
         if (record.type == lns::mapping_type::session)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_session_name1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_session_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_session_name1, miner_key.session_value));
         }
         else if (record.type == lns::mapping_type::lokinet_1year)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_lokinet_domain1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_lokinet_domain1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_lokinet_domain1, miner_key.lokinet_value));
         }
         else if (record.type == lns::mapping_type::wallet)
         {
-          CHECK_EQ(record.name_hash, lns::name_to_hash(miner_wallet_name1));
+          CHECK_EQ(record.name_hash, lns::name_to_base64_hash(miner_wallet_name1));
           CHECK_EQ(record.register_height, first_lns_height);
           CHECK_EQ(record.encrypted_value, helper_encrypt_lns_value(miner_wallet_name1, miner_key.wallet_value));
         }
@@ -1920,7 +1920,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    crypto::hash name_hash = lns::name_to_hash(name);
+    std::string name_hash = lns::name_to_base64_hash(name);
     lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
@@ -1950,7 +1950,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
     CHECK_EQ(owner.id, 1);
     CHECK_EQ(miner_key.ed_key, owner.key);
 
-    crypto::hash name_hash = lns::name_to_hash(name);
+    std::string name_hash = lns::name_to_base64_hash(name);
     lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
     CHECK_EQ(mappings.loaded, true);
     CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
@@ -2005,7 +2005,7 @@ bool loki_name_system_name_value_max_lengths::generate(std::vector<test_event_en
   if (lns::mapping_type_allowed(gen.hardfork(), lns::mapping_type::wallet))
   {
     std::string name(lns::WALLET_NAME_MAX, 'A');
-    data.type      = lns::mapping_type::wallet;
+    data.type            = lns::mapping_type::wallet;
     data.name_hash       = lns::name_to_hash(name);
     data.encrypted_value = helper_encrypt_lns_value(name, miner_key.wallet_value).to_string();
     make_lns_tx_with_custom_extra(gen, events, miner, data);
@@ -2077,7 +2077,7 @@ bool loki_name_system_update_mapping_after_expiry_fails::generate(std::vector<te
       CHECK_EQ(owner.id, 1);
       CHECK_EQ(miner_key.ed_key, owner.key);
 
-      crypto::hash name_hash       = lns::name_to_hash(name);
+      std::string name_hash       = lns::name_to_base64_hash(name);
       lns::mapping_record mappings = lns_db.get_mapping(lns::mapping_type::lokinet_1year, name_hash);
       CHECK_EQ(mappings.loaded, true);
       CHECK_EQ(mappings.type, lns::mapping_type::lokinet_1year);
@@ -2132,7 +2132,7 @@ bool loki_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
     DEFINE_TESTS_ERROR_CONTEXT("check_updated");
     lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
 
-    crypto::hash name_hash = lns::name_to_hash(session_name1);
+    std::string name_hash = lns::name_to_base64_hash(session_name1);
     std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, name_hash);
 
     CHECK_EQ(records.size(), 1);

--- a/tests/unit_tests/loki_name_system.cpp
+++ b/tests/unit_tests/loki_name_system.cpp
@@ -62,3 +62,41 @@ TEST(loki_name_system, lokinet_domain_names)
     ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
   }
 }
+
+TEST(loki_name_system, value_encrypt_and_decrypt)
+{
+  std::string name         = "my lns name";
+  lns::mapping_value value = {};
+  value.len                = 32;
+  memset(&value.buffer[0], 'a', value.len);
+
+  // Encryption and Decryption success
+  {
+    lns::mapping_value encrypted_value = {};
+    lns::mapping_value decrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name, value, encrypted_value));
+    ASSERT_TRUE(lns::decrypt_mapping_value(name, encrypted_value, decrypted_value));
+    ASSERT_TRUE(value == decrypted_value);
+  }
+
+  // Decryption Fail: Encrypted value was modified
+  {
+    lns::mapping_value encrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name, value, encrypted_value));
+
+    encrypted_value.buffer[0] = 'Z';
+    lns::mapping_value decrypted_value;
+    ASSERT_FALSE(lns::decrypt_mapping_value(name, encrypted_value, decrypted_value));
+  }
+
+  // Decryption Fail: Name was modified
+  {
+    std::string name_copy = name;
+    lns::mapping_value encrypted_value = {};
+    ASSERT_TRUE(lns::encrypt_mapping_value(name_copy, value, encrypted_value));
+
+    name_copy[0] = 'Z';
+    lns::mapping_value decrypted_value;
+    ASSERT_FALSE(lns::decrypt_mapping_value(name_copy, encrypted_value, decrypted_value));
+  }
+}


### PR DESCRIPTION
> This structure is going to allow enumeration in a few different ways which I think we can avoid.  First it makes it super easy for anyone with the blockchain to see that "jason.loki" has been registered by just looking at the registration.  I think we can feasibly blind them:
> 
> - instead of storing `name` we would store `name_hash`.  Anyone who has the name already can get this, but some rando watching the blockchain would have to use a dictionary attack (and even then can't identify everything, e.g. `omgcatsareawesome.loki` isn't going to be decipherable).  We probably want that hash to be moderately expensive so that a dictionary attack is hard.
> - Encrypt `value` using the name as the secret.  This prevents correlation between registrations: if I have two opaque records that I don't know the name of, I can't tell that they are two registrations going to the same .loki address (or wallet or whatever).
> 
> The second problem is with the `owner` pubkey: since this is unique per wallet, I can instantly connect all registrations from the same wallet together.  We can fix that, too, if we use distinct keys for each registration.  (We would still want them to be determined from the wallet, but there are ways to do something along the lines of BIP32 to generate derivative keys).
>
> (I think this should be left for a later commit rather than addressed in this PR, however).

https://github.com/loki-project/loki-core/pull/922#discussion_r371468122

PR is implemented on top of: https://github.com/loki-project/loki-core/pull/1026 and adds the first 2 bullet points, and updates the following RPC output

```
  LOKI_RPC_DOC_INTROSPECT
  // Get the name mapping for a Loki Name Service entry. Loki currently supports mappings
  // for Session.
  struct COMMAND_RPC_GET_LNS_NAMES_TO_OWNERS
  {
    ...
    struct response_entry
    {
      uint64_t entry_index;     // The index in request_entry's `entries` array that was resolved via Loki Name Service.
      uint16_t type;            // The type of Loki Name Service entry that the owner owns.
      std::string owner;        // The ed25519 public key that purchased the Loki Name Service entry.
      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
      uint64_t register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
      std::string txid;         // The txid of who purchased the mapping, null hash if not applicable.
      std::string prev_txid;    // The previous txid that purchased the mapping, null hash if not applicable.
    };

    struct response
    {
      std::vector<response_entry> entries;
      std::string status; // Generic RPC error code. "OK" is the success value.
    };
  };

  LOKI_RPC_DOC_INTROSPECT
  // Get all the name mappings for the queried owner. The owner should be
  // a ed25519 public key; by default this is the public key of an ed25519
  // keypair derived using the wallet's secret spend key as the seed value.
  struct COMMAND_RPC_GET_LNS_OWNERS_TO_NAMES
  {
    ...
    struct response_entry
    {
      uint64_t    request_index;   // The index in request's `entries` array that was resolved via Loki Name Service.
      uint16_t    type;            // The category the Loki Name Service entry belongs to, currently only Session whose value is 0.
      std::string name_hash;       // The hash of the name that the owner purchased via Loki Name Service.
      std::string encrypted_value; // The encrypted value that the name maps to. This value is encrypted using the name (not the hash) as the secret.
      uint64_t    register_height; // The height that this Loki Name Service entry was purchased on the Blockchain.
      std::string txid;            // The txid of who purchases the mapping, null hash if not applicable
      std::string prev_txid;       // The previous txid that purchased the mapping, null hash if not applicable.
    };

    struct response
    {
      std::vector<response_entry> entries;
      std::string status; // Generic RPC error code. "OK" is the success value.
    };
  };
```
