### PR TITLE
Fix `priority=5` not doing an actual blink submission

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -889,7 +889,7 @@ namespace tools
         return false;
       }
 
-      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay, req.blink,
+      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_blink,
           res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, er);
     }
     catch (const std::exception& e)
@@ -939,7 +939,7 @@ namespace tools
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices, tx_params);
       LOG_PRINT_L2("on_transfer_split called create_transactions_2");
 
-      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, req.blink,
+      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_blink,
           res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, er);
     }
     catch (const std::exception& e)
@@ -1348,7 +1348,7 @@ namespace tools
       if (req.blink) priority = tools::tx_priority_blink;
       std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, req.unlock_time, priority, extra, req.account_index, req.subaddr_indices);
 
-      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, req.blink,
+      return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.fee_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_blink,
           res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, er);
     }
     catch (const std::exception& e)
@@ -1424,7 +1424,7 @@ namespace tools
         return false;
       }
 
-      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay, req.blink,
+      return fill_response(ptx_vector, req.get_tx_key, res.tx_key, res.amount, res.fee, res.multisig_txset, res.unsigned_txset, req.do_not_relay, priority == tx_priority_blink,
           res.tx_hash, req.get_tx_hex, res.tx_blob, req.get_tx_metadata, res.tx_metadata, er);
     }
     catch (const std::exception& e)

--- a/tests/network_tests/daemons.py
+++ b/tests/network_tests/daemons.py
@@ -313,17 +313,15 @@ class Wallet(RPCDaemon):
         return (b['balance'], b['unlocked_balance'])
 
 
-    def transfer(self, to, amount=None, *, priority=None, blink=False, sweep=False):
+    def transfer(self, to, amount=None, *, priority=None, sweep=False):
         """Attempts a transfer.  Throws TransferFailed if it gets rejected by the daemon, otherwise
         returns the 'result' key."""
-        if blink and priority:
-            raise RuntimeError("Wallet.transfer: priority and blink are mutually exclusive")
-        elif priority is None:
-            priority = 0
+        if priority is None:
+            priority = 1
         if sweep and not amount:
-            r = self.json_rpc("sweep_all", {"address": to.address(), "priority": priority, "blink": blink})
+            r = self.json_rpc("sweep_all", {"address": to.address(), "priority": priority})
         elif amount and not sweep:
-            r = self.json_rpc("transfer_split", {"destinations": [{"address": to.address(), "amount": amount}], "priority": priority, "blink": blink})
+            r = self.json_rpc("transfer_split", {"destinations": [{"address": to.address(), "amount": amount}], "priority": priority})
         else:
             raise RuntimeError("Wallet.transfer: either `sweep` or `amount` must be given")
 

--- a/tests/network_tests/test_blink.py
+++ b/tests/network_tests/test_blink.py
@@ -60,11 +60,11 @@ def test_basic_blink(net, alice, bob, mike):
 
     b1 = bob.balances()
 
-    sent_blink = alice.transfer(bob, coins(10), blink=True)
+    sent_blink = alice.transfer(bob, coins(10), priority=5)
     assert sent_blink['amount_list'] == [coins(10)]
     assert len(sent_blink['tx_hash_list']) == 1
 
-    sent_normal = mike.transfer(bob, coins(3), blink=False)
+    sent_normal = mike.transfer(bob, coins(3), priority=1)
     assert sent_normal['amount_list'] == [coins(3)]
     assert len(sent_normal['tx_hash_list']) == 1
 
@@ -129,7 +129,7 @@ def test_blink_sweep(net, mike, alice, bob):
     assert alice.balances() == coins(150, 150)
     assert bob.balances() == coins(9, 9)
 
-    sweep_a = bob.transfer(alice, sweep=True, blink=True)
+    sweep_a = bob.transfer(alice, sweep=True, priority=5)
     assert len(sweep_a['amount_list']) == 1
     amount_a = sweep_a['amount_list'][0]
     assert amount_a == coins(9) - sweep_a['fee_list'][0]
@@ -139,7 +139,7 @@ def test_blink_sweep(net, mike, alice, bob):
     alice.refresh()
     assert alice.balances() == (coins(150) + amount_a, coins(150))
 
-    sweep_b = alice.transfer(bob, sweep=True, blink=True)
+    sweep_b = alice.transfer(bob, sweep=True, priority=5)
     assert len(sweep_b['amount_list']) > 1
     amount_b = sum(sweep_b['amount_list'])
     assert amount_b == coins(150) - sum(sweep_b['fee_list'])
@@ -177,7 +177,7 @@ def test_blink_fail_mempool(net, mike, alice, bob):
 
     from daemons import TransferFailed
     with pytest.raises(TransferFailed, match='rejected by quorum') as exc_info:
-        double_spend = alice.transfer(bob, coins(5), blink=True)  # Has to spend the same input, since we only have one input
+        double_spend = alice.transfer(bob, coins(5), priority=5)  # Has to spend the same input, since we only have one input
 
 
 def test_blink_replacement(net, mike, alice, chuck, chuck_double_spend):


### PR DESCRIPTION
The RPC wallet `fill_response` calls were still passing `req.blink` to blink a tx, but that is supposed to be deprecated in favour of passing (just) `priority=5` (discovered when I updated the blink tests to stop passing `blink`, also included here).

This PR fixes it to blink based on the priority value instead (which already gets set properly if `req.blink` is true).