### PR TITLE
Loki name service - Wallet CLI improve name parsing/LNS queries

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6645,7 +6645,7 @@ bool simple_wallet::print_lns_name_to_owners(const std::vector<std::string>& arg
   }
 
   for (auto const &mapping : response)
-    tools::msg_writer() << "name=\"" << entry.name << "\", owner=" << mapping.owner << ", type=" << static_cast<lns::mapping_type>(mapping.type) << ", height=" << mapping.register_height;
+    tools::msg_writer() << "name=\"" << lns_name << "\", owner=" << mapping.owner << ", type=" << static_cast<lns::mapping_type>(mapping.type) << ", height=" << mapping.register_height << "\", value=" << mapping.value << ", prev_txid=" << mapping.prev_txid;
 
   return true;
 }


### PR DESCRIPTION
- Move the owner field to the end for `buy_lns_mapping` to match the optional signature field in `update_lns_mapping`. 
- Correctly pull out the owner from args when multiple words are specified for the name.
- Update parse_lns_name_string to handle edge cases with escaped quotes and multi words
- Make `print_lns_*` report the same fields as each other for consistency 

```
buy_lns_mapping [index=<N1>[,<N2>,...]] [<priority>] \"<name>\" <value> [owner]
```