### PR TITLE
Loki Name Service - propagate errors to wallet CLI

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1248,6 +1248,9 @@ namespace cryptonote
   {
     std::ostringstream os;
 
+    if (tvc.m_verbose_error.size())
+        os << tvc.m_verbose_error << "\n";
+
     if (tvc.m_verifivation_failed)       os << "Verification failed, connection should be dropped, "; //bad tx, should drop connection
     if (tvc.m_verifivation_impossible)   os << "Verification impossible, related to alt chain, "; //the transaction is related with an alternative blockchain
     if (tvc.m_should_be_relayed)         os << "TX should be relayed, ";

--- a/src/cryptonote_basic/verification_context.h
+++ b/src/cryptonote_basic/verification_context.h
@@ -83,7 +83,7 @@ namespace cryptonote
     bool m_invalid_type;
     bool m_key_image_locked_by_snode;
     bool m_key_image_blacklisted;
-
+    std::string m_verbose_error;
     vote_verification_context m_vote_ctx;
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -103,8 +103,9 @@ namespace cryptonote
       KV_SERIALIZE(m_invalid_type);
       KV_SERIALIZE(m_key_image_locked_by_snode);
       KV_SERIALIZE(m_key_image_blacklisted);
-
+      KV_SERIALIZE(m_verbose_error);
       KV_SERIALIZE(m_vote_ctx)
+
     END_KV_SERIALIZE_MAP()
   };
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3357,6 +3357,7 @@ bool Blockchain::check_tx_inputs(transaction& tx, tx_verification_context &tvc, 
       if (!m_lns_db.validate_lns_tx(hf_version, get_current_blockchain_height(), tx, &data, &fail_reason))
       {
         MERROR_VER("Failed to validate LNS TX reason: " << fail_reason);
+        tvc.m_verbose_error = std::move(fail_reason);
         return false;
       }
     }


### PR DESCRIPTION
Propagate errors from daemon LNS failures to the CLI.

Perhaps the errors are too techy and there should be a translation layer inbetween but I think this is a good step forward.