### PR TITLE
Add get_service_node_status rpc endpoint

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2102,6 +2102,37 @@ namespace cryptonote
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
+  bool core_rpc_server::on_get_service_node_status(const COMMAND_RPC_GET_SERVICE_NODE_STATUS::request& req, COMMAND_RPC_GET_SERVICE_NODE_STATUS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
+  {
+    PERF_TIMER(on_get_service_node_status);
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_KEY::response get_service_node_key_res = {};
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODE_KEY::request get_service_node_key_req = {};
+    std::string fail_message = "Unsuccessful";
+
+    if (!on_get_service_node_key(get_service_node_key_req, get_service_node_key_res, error_resp, ctx))
+    {
+      return false;
+    }
+
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODES::request get_service_nodes_req;
+    cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response get_service_nodes_res;
+
+    get_service_nodes_req.service_node_pubkeys.push_back(get_service_node_key_res.service_node_pubkey);
+
+    if (!on_get_service_nodes(get_service_nodes_req, get_service_nodes_res, error_resp, ctx))
+    {
+      return false;
+    }
+
+    res.service_node_state = get_service_nodes_res.service_node_states[0];
+    res.height = get_service_nodes_res.height;
+    res.block_hash = get_service_nodes_res.block_hash;
+    res.status = get_service_nodes_res.status;
+    res.as_json = get_service_nodes_res.as_json;
+
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_coinbase_tx_sum(const COMMAND_RPC_GET_COINBASE_TX_SUM::request& req, COMMAND_RPC_GET_COINBASE_TX_SUM::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
   {
     PERF_TIMER(on_get_coinbase_tx_sum);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2107,7 +2107,6 @@ namespace cryptonote
     PERF_TIMER(on_get_service_node_status);
     cryptonote::COMMAND_RPC_GET_SERVICE_NODE_KEY::response get_service_node_key_res = {};
     cryptonote::COMMAND_RPC_GET_SERVICE_NODE_KEY::request get_service_node_key_req = {};
-    std::string fail_message = "Unsuccessful";
 
     if (!on_get_service_node_key(get_service_node_key_req, get_service_node_key_res, error_resp, ctx))
     {
@@ -2117,6 +2116,7 @@ namespace cryptonote
     cryptonote::COMMAND_RPC_GET_SERVICE_NODES::request get_service_nodes_req;
     cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response get_service_nodes_res;
 
+    get_service_nodes_req.include_json = req.include_json;
     get_service_nodes_req.service_node_pubkeys.push_back(get_service_node_key_res.service_node_pubkey);
 
     if (!on_get_service_nodes(get_service_nodes_req, get_service_nodes_res, error_resp, ctx))

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -183,6 +183,7 @@ namespace cryptonote
         MAP_JON_RPC_WE_IF("get_service_node_registration_cmd",      on_get_service_node_registration_cmd, COMMAND_RPC_GET_SERVICE_NODE_REGISTRATION_CMD, !m_restricted)
         MAP_JON_RPC_WE_IF("get_service_node_key",                   on_get_service_node_key, COMMAND_RPC_GET_SERVICE_NODE_KEY, !m_restricted)
         MAP_JON_RPC_WE_IF("get_service_node_privkey",               on_get_service_node_privkey, COMMAND_RPC_GET_SERVICE_NODE_PRIVKEY, !m_restricted)
+        MAP_JON_RPC_WE("get_service_node_status",                         on_get_service_node_status, COMMAND_RPC_GET_SERVICE_NODE_STATUS)
         MAP_JON_RPC_WE("get_service_nodes",                         on_get_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_all_service_nodes",                     on_get_all_service_nodes, COMMAND_RPC_GET_SERVICE_NODES)
         MAP_JON_RPC_WE("get_n_service_nodes",                       on_get_n_service_nodes, COMMAND_RPC_GET_N_SERVICE_NODES)
@@ -276,6 +277,7 @@ namespace cryptonote
     bool on_get_service_node_blacklisted_key_images(const COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::request& req, COMMAND_RPC_GET_SERVICE_NODE_BLACKLISTED_KEY_IMAGES::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_key(const COMMAND_RPC_GET_SERVICE_NODE_KEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_KEY::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
     bool on_get_service_node_privkey(const COMMAND_RPC_GET_SERVICE_NODE_PRIVKEY::request& req, COMMAND_RPC_GET_SERVICE_NODE_PRIVKEY::response& res, epee::json_rpc::error &error_resp, const connection_context *ctx = NULL);
+    bool on_get_service_node_status(const COMMAND_RPC_GET_SERVICE_NODE_STATUS::request& req, COMMAND_RPC_GET_SERVICE_NODE_STATUS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_n_service_nodes(const COMMAND_RPC_GET_N_SERVICE_NODES::request& req, COMMAND_RPC_GET_N_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_all_service_nodes(const COMMAND_RPC_GET_SERVICE_NODES::request& req, COMMAND_RPC_GET_SERVICE_NODES::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2875,6 +2875,41 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+  LOKI_RPC_DOC_INTROSPECT
+  // Get information on Service Node.
+  struct COMMAND_RPC_GET_SERVICE_NODE_STATUS
+  {
+    struct request_t
+    {
+      bool include_json;                             // When set, the response's as_json member is filled out.
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(include_json);
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+
+      struct cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response_t::entry service_node_state; // Service node registration information
+      uint64_t    height;                     // Current block's height.
+      std::string block_hash;                 // Current block's hash.
+      std::string status;                     // Generic RPC error code. "OK" is the success value.
+      std::string as_json;                    // If `include_json` is set in the request, this contains the json representation of the `entry` data structure
+
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(service_node_state)
+        KV_SERIALIZE(height)
+        KV_SERIALIZE(block_hash)
+        KV_SERIALIZE(status)
+        KV_SERIALIZE(as_json)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
   #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) \
   if (this_ref.requested_fields.var || !this_ref.requested_fields.explicitly_set) KV_SERIALIZE(var)
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2892,7 +2892,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
     struct response_t
     {
 
-      struct cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response_t::entry service_node_state; // Service node registration information
+      cryptonote::COMMAND_RPC_GET_SERVICE_NODES::response_t::entry service_node_state; // Service node registration information
       uint64_t    height;                     // Current block's height.
       std::string block_hash;                 // Current block's hash.
       std::string status;                     // Generic RPC error code. "OK" is the success value.


### PR DESCRIPTION
Creates a rpc endpoint to query the status of the service node currently being run by lokid

addresses #233