### PR TITLE
Add storage server lokimq port

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -6162,6 +6162,7 @@ struct service_node_proof_serialized
     : timestamp{native_to_little(info.timestamp)},
       ip{native_to_little(info.public_ip)},
       storage_port{native_to_little(info.storage_port)},
+      storage_lmq_port{native_to_little(info.storage_lmq_port)},
       quorumnet_port{native_to_little(info.quorumnet_port)},
       version{native_to_little(info.version[0]), native_to_little(info.version[1]), native_to_little(info.version[2])},
       pubkey_ed25519{info.pubkey_ed25519}
@@ -6173,6 +6174,7 @@ struct service_node_proof_serialized
       info.effective_timestamp = info.timestamp;
     info.public_ip = little_to_native(ip);
     info.storage_port = little_to_native(storage_port);
+    info.storage_lmq_port = little_to_native(storage_lmq_port);
     info.quorumnet_port = little_to_native(quorumnet_port);
     for (size_t i = 0; i < info.version.size(); i++)
       info.version[i] = little_to_native(version[i]);
@@ -6190,7 +6192,7 @@ struct service_node_proof_serialized
   uint16_t storage_port;
   uint16_t quorumnet_port;
   uint16_t version[3];
-  uint16_t _padding{0};
+  uint16_t storage_lmq_port; // used to be "padding"
   crypto::ed25519_public_key pubkey_ed25519;
 };
 static_assert(sizeof(service_node_proof_serialized) == 56, "service node serialization struct has unexpected size and/or padding");

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -6192,7 +6192,7 @@ struct service_node_proof_serialized
   uint16_t storage_port;
   uint16_t quorumnet_port;
   uint16_t version[3];
-  uint16_t storage_lmq_port; // used to be "padding"
+  uint16_t storage_lmq_port;
   crypto::ed25519_public_key pubkey_ed25519;
 };
 static_assert(sizeof(service_node_proof_serialized) == 56, "service node serialization struct has unexpected size and/or padding");

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -200,12 +200,6 @@ namespace cryptonote
     "storage server is required for service nodes. (This option is specified "
     "automatically when using Loki Launcher.)"
   , 0};
-  static const command_line::arg_descriptor<uint16_t> arg_storage_server_lmq_port = {
-    "storage-server-lmq-port"
-  , "The port on which this service node's storage server (the lokimq interface) is accessible. "
-    "A listening storage server is required for service nodes. (This option is specified "
-    "automatically when using Loki Launcher.)"
-  , 0};
   static const command_line::arg_descriptor<uint16_t, false, true, 2> arg_quorumnet_port = {
     "quorumnet-port"
   , "The port on which this service node listen for direct connections from other "
@@ -374,7 +368,6 @@ namespace cryptonote
     command_line::add_arg(desc, arg_service_node);
     command_line::add_arg(desc, arg_public_ip);
     command_line::add_arg(desc, arg_storage_server_port);
-    command_line::add_arg(desc, arg_storage_server_lmq_port);
     command_line::add_arg(desc, arg_quorumnet_port);
     command_line::add_arg(desc, arg_pad_transactions);
     command_line::add_arg(desc, arg_block_notify);
@@ -424,19 +417,12 @@ namespace cryptonote
 
       /// TODO: parse these options early, before we start p2p server etc?
       m_storage_port = command_line::get_arg(vm, arg_storage_server_port);
-      m_storage_lmq_port = command_line::get_arg(vm, arg_storage_server_lmq_port);
 
       m_quorumnet_port = command_line::get_arg(vm, arg_quorumnet_port);
 
       bool storage_ok = true;
       if (m_storage_port == 0) {
         MERROR("Please specify the port on which the storage server is listening with: '--" << arg_storage_server_port.name << " <port>'");
-        storage_ok = false;
-      }
-
-      if (m_storage_lmq_port == 0 || m_storage_lmq_port == m_storage_port) {
-        MERROR("Please specify the port on which the storage server is listening with: '--"
-               << arg_storage_server_lmq_port.name << " <port>' (distinct from " << arg_storage_server_port.name << ")");
         storage_ok = false;
       }
 
@@ -477,8 +463,6 @@ namespace cryptonote
       MGINFO("Storage server endpoint is set to: "
              << (epee::net_utils::ipv4_network_address{ m_sn_public_ip, m_storage_port }).str());
 
-      MGINFO("Storage server (LMQ) endpoint is set to: "
-             << (epee::net_utils::ipv4_network_address{ m_sn_public_ip, m_storage_lmq_port }).str());
     }
 
     epee::debug::g_test_dbg_lock_sleep() = command_line::get_arg(vm, arg_test_dbg_lock_sleep);

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -200,6 +200,12 @@ namespace cryptonote
     "storage server is required for service nodes. (This option is specified "
     "automatically when using Loki Launcher.)"
   , 0};
+  static const command_line::arg_descriptor<uint16_t> arg_storage_server_lmq_port = {
+    "storage-server-lmq-port"
+  , "The port on which this service node's storage server (the lokimq interface) is accessible. "
+    "A listening storage server is required for service nodes. (This option is specified "
+    "automatically when using Loki Launcher.)"
+  , 0};
   static const command_line::arg_descriptor<uint16_t, false, true, 2> arg_quorumnet_port = {
     "quorumnet-port"
   , "The port on which this service node listen for direct connections from other "
@@ -368,6 +374,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_service_node);
     command_line::add_arg(desc, arg_public_ip);
     command_line::add_arg(desc, arg_storage_server_port);
+    command_line::add_arg(desc, arg_storage_server_lmq_port);
     command_line::add_arg(desc, arg_quorumnet_port);
     command_line::add_arg(desc, arg_pad_transactions);
     command_line::add_arg(desc, arg_block_notify);
@@ -417,12 +424,19 @@ namespace cryptonote
 
       /// TODO: parse these options early, before we start p2p server etc?
       m_storage_port = command_line::get_arg(vm, arg_storage_server_port);
+      m_storage_lmq_port = command_line::get_arg(vm, arg_storage_server_lmq_port);
 
       m_quorumnet_port = command_line::get_arg(vm, arg_quorumnet_port);
 
       bool storage_ok = true;
       if (m_storage_port == 0) {
         MERROR("Please specify the port on which the storage server is listening with: '--" << arg_storage_server_port.name << " <port>'");
+        storage_ok = false;
+      }
+
+      if (m_storage_lmq_port == 0 || m_storage_lmq_port == m_storage_port) {
+        MERROR("Please specify the port on which the storage server is listening with: '--"
+               << arg_storage_server_lmq_port.name << " <port>' (distinct from " << arg_storage_server_port.name << ")");
         storage_ok = false;
       }
 
@@ -462,6 +476,9 @@ namespace cryptonote
 
       MGINFO("Storage server endpoint is set to: "
              << (epee::net_utils::ipv4_network_address{ m_sn_public_ip, m_storage_port }).str());
+
+      MGINFO("Storage server (LMQ) endpoint is set to: "
+             << (epee::net_utils::ipv4_network_address{ m_sn_public_ip, m_storage_lmq_port }).str());
     }
 
     epee::debug::g_test_dbg_lock_sleep() = command_line::get_arg(vm, arg_test_dbg_lock_sleep);
@@ -1717,7 +1734,7 @@ namespace cryptonote
     if (!m_service_node_keys)
       return true;
 
-    NOTIFY_UPTIME_PROOF::request req = m_service_node_list.generate_uptime_proof(*m_service_node_keys, m_sn_public_ip, m_storage_port, m_quorumnet_port);
+    NOTIFY_UPTIME_PROOF::request req = m_service_node_list.generate_uptime_proof(*m_service_node_keys, m_sn_public_ip, m_storage_port, m_storage_lmq_port, m_quorumnet_port);
 
     cryptonote_connection_context fake_context{};
     bool relayed = get_protocol()->relay_uptime_proof(req, fake_context);

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -955,6 +955,7 @@ namespace cryptonote
 
      /// Time point at which the storage server and lokinet last pinged us
      std::atomic<time_t> m_last_storage_server_ping, m_last_lokinet_ping;
+     std::atomic<uint16_t> m_storage_lmq_port;
 
      /**
       * @brief attempts to relay any transactions in the mempool which need it
@@ -1137,7 +1138,6 @@ namespace cryptonote
      /// Service Node's public IP and storage server port (http and lokimq)
      uint32_t m_sn_public_ip;
      uint16_t m_storage_port;
-     uint16_t m_storage_lmq_port;
      uint16_t m_quorumnet_port;
 
      std::string m_quorumnet_bind_ip; // Currently just copied from p2p-bind-ip

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1134,9 +1134,10 @@ namespace cryptonote
 
      std::unique_ptr<service_node_keys> m_service_node_keys;
 
-     /// Service Node's public IP and storage server port
+     /// Service Node's public IP and storage server port (http and lokimq)
      uint32_t m_sn_public_ip;
      uint16_t m_storage_port;
+     uint16_t m_storage_lmq_port;
      uint16_t m_quorumnet_port;
 
      std::string m_quorumnet_bind_ip; // Currently just copied from p2p-bind-ip

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1892,7 +1892,7 @@ namespace service_nodes
 
   static crypto::hash hash_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, uint8_t hf_version)
   {
-    auto buf = tools::memcpy_le(proof.pubkey.data, proof.timestamp, proof.public_ip, proof.storage_port, proof.pubkey_ed25519.data, proof.qnet_port);
+    auto buf = tools::memcpy_le(proof.pubkey.data, proof.timestamp, proof.public_ip, proof.storage_port, proof.storage_lmq_port, proof.pubkey_ed25519.data, proof.qnet_port);
     size_t buf_size = buf.size();
 
     crypto::hash result;
@@ -1901,7 +1901,7 @@ namespace service_nodes
   }
 
   cryptonote::NOTIFY_UPTIME_PROOF::request service_node_list::generate_uptime_proof(
-      const service_node_keys &keys, uint32_t public_ip, uint16_t storage_port, uint16_t quorumnet_port) const
+      const service_node_keys &keys, uint32_t public_ip, uint16_t storage_port, uint16_t storage_lmq_port, uint16_t quorumnet_port) const
   {
     cryptonote::NOTIFY_UPTIME_PROOF::request result = {};
     result.snode_version                            = LOKI_VERSION;
@@ -1909,6 +1909,7 @@ namespace service_nodes
     result.pubkey                                   = keys.pub;
     result.public_ip                                = public_ip;
     result.storage_port                             = storage_port;
+    result.storage_lmq_port                         = storage_lmq_port;
     result.qnet_port                                = quorumnet_port;
     result.pubkey_ed25519                           = keys.pub_ed25519;
 
@@ -1960,12 +1961,20 @@ namespace service_nodes
     db.set_service_node_proof(pubkey, *this);
   }
 
-  bool proof_info::update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2)
+  bool proof_info::update(uint64_t ts,
+                          uint32_t ip,
+                          uint16_t s_port,
+                          uint16_t s_lmq_port,
+                          uint16_t q_port,
+                          std::array<uint16_t, 3> ver,
+                          const crypto::ed25519_public_key& pk_ed,
+                          const crypto::x25519_public_key& pk_x2)
   {
     bool update_db = false;
     update_db |= update_val(timestamp, ts);
     update_db |= update_val(public_ip, ip);
     update_db |= update_val(storage_port, s_port);
+    update_db |= update_val(storage_lmq_port, s_lmq_port);
     update_db |= update_val(quorumnet_port, q_port);
     update_db |= update_val(version, ver);
     update_db |= update_val(pubkey_ed25519, pk_ed);
@@ -2069,7 +2078,7 @@ namespace service_nodes
     }
 
     auto old_x25519 = iproof.pubkey_x25519;
-    if (iproof.update(now, proof.public_ip, proof.storage_port, proof.qnet_port, proof.snode_version, proof.pubkey_ed25519, derived_x25519_pubkey))
+    if (iproof.update(now, proof.public_ip, proof.storage_port, proof.storage_lmq_port, proof.qnet_port, proof.snode_version, proof.pubkey_ed25519, derived_x25519_pubkey))
       iproof.store(proof.pubkey, m_blockchain);
 
     if ((uint64_t) x25519_map_last_pruned + X25519_MAP_PRUNING_INTERVAL <= now)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1892,8 +1892,11 @@ namespace service_nodes
 
   static crypto::hash hash_uptime_proof(const cryptonote::NOTIFY_UPTIME_PROOF::request &proof, uint8_t hf_version)
   {
-    auto buf = tools::memcpy_le(proof.pubkey.data, proof.timestamp, proof.public_ip, proof.storage_port, proof.storage_lmq_port, proof.pubkey_ed25519.data, proof.qnet_port);
+    auto buf = tools::memcpy_le(proof.pubkey.data, proof.timestamp, proof.public_ip, proof.storage_port, proof.pubkey_ed25519.data, proof.qnet_port, proof.storage_lmq_port);
     size_t buf_size = buf.size();
+
+    if (hf_version < cryptonote::network_version_15_lns) // TODO - can be removed post-HF15
+      buf_size -= sizeof(proof.storage_lmq_port);
 
     crypto::hash result;
     crypto::cn_fast_hash(buf.data(), buf_size, result);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -74,9 +74,10 @@ namespace service_nodes
     proof_info() { votes.fill({}); }
 
     // Unlike all of the above (except for timestamp), these values *do* get serialized
-    uint32_t public_ip      = 0;
-    uint16_t storage_port   = 0;
-    uint16_t quorumnet_port = 0;
+    uint32_t public_ip        = 0;
+    uint16_t storage_port     = 0;
+    uint16_t storage_lmq_port = 0;
+    uint16_t quorumnet_port   = 0;
     std::array<uint16_t, 3> version{{0,0,0}};
     crypto::ed25519_public_key pubkey_ed25519 = crypto::ed25519_public_key::null();
 
@@ -92,7 +93,7 @@ namespace service_nodes
     // Returns true if serializable data is changed (in which case `store()` should be called).
     // Note that this does not update the m_x25519_to_pub map if the x25519 key changes (that's the
     // caller's responsibility).
-    bool update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2);
+    bool update(uint64_t ts, uint32_t ip, uint16_t s_port, uint16_t s_lmq_port, uint16_t q_port, std::array<uint16_t, 3> ver, const crypto::ed25519_public_key &pk_ed, const crypto::x25519_public_key &pk_x2);
 
     // Stores this record in the database.
     void store(const crypto::public_key &pubkey, cryptonote::Blockchain &blockchain);
@@ -375,7 +376,11 @@ namespace service_nodes
     bool store();
 
     /// Record public ip and storage port and add them to the service node list
-    cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(const service_node_keys &keys, uint32_t public_ip, uint16_t storage_port, uint16_t quorumnet_port) const;
+    cryptonote::NOTIFY_UPTIME_PROOF::request generate_uptime_proof(const service_node_keys& keys,
+                                                                   uint32_t public_ip,
+                                                                   uint16_t storage_port,
+                                                                   uint16_t storage_lmq_port,
+                                                                   uint16_t quorumnet_port) const;
     bool handle_uptime_proof        (cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation);
     void record_checkpoint_vote     (crypto::public_key const &pubkey, uint64_t height, bool voted);
 

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -329,6 +329,7 @@ namespace cryptonote
       crypto::ed25519_signature sig_ed25519;
       uint32_t public_ip;
       uint16_t storage_port;
+      uint16_t storage_lmq_port;
       uint16_t qnet_port;
 
       BEGIN_KV_SERIALIZE_MAP()
@@ -338,6 +339,7 @@ namespace cryptonote
         KV_SERIALIZE(timestamp)
         KV_SERIALIZE(public_ip)
         KV_SERIALIZE(storage_port)
+        KV_SERIALIZE(storage_lmq_port)
         KV_SERIALIZE(qnet_port)
         KV_SERIALIZE_VAL_POD_AS_BLOB(pubkey)
         KV_SERIALIZE_VAL_POD_AS_BLOB(sig)

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2527,7 +2527,8 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     if (entry.public_ip == "0.0.0.0")
       stream << "(Awaiting confirmation from network)";
     else
-      stream << entry.public_ip << " :" << entry.storage_port << " (storage), :" << entry.quorumnet_port << " (quorumnet)";
+      stream << entry.public_ip << " :" << entry.storage_port << " (storage), :" << entry.storage_lmq_port
+             << " (storage lmq), :" << entry.quorumnet_port << " (quorumnet)";
 
     stream << "\n";
     if (detailed_view)

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2865,6 +2865,7 @@ namespace cryptonote
         entry.service_node_version     = proof.version;
         entry.public_ip                = string_tools::get_ip_string_from_int32(proof.public_ip);
         entry.storage_port             = proof.storage_port;
+        entry.storage_lmq_port         = proof.storage_lmq_port;
         entry.storage_server_reachable = proof.storage_server_reachable;
         entry.pubkey_ed25519           = proof.pubkey_ed25519 ? string_tools::pod_to_hex(proof.pubkey_ed25519) : "";
         entry.pubkey_x25519            = proof.pubkey_x25519 ? string_tools::pod_to_hex(proof.pubkey_x25519) : "";

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3152,6 +3152,9 @@ namespace cryptonote
     if (handle_ping({req.version_major, req.version_minor, req.version_patch}, service_nodes::MIN_STORAGE_SERVER_VERSION,
           "Storage Server", m_core.m_last_storage_server_ping, STORAGE_SERVER_PING_LIFETIME, res))
       m_core.reset_proof_interval();
+
+      m_core.m_storage_lmq_port = req.storage_lmq_port;
+
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2807,6 +2807,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
         std::string                           operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
         std::string                           public_ip;                     // The public ip address of the service node
         uint16_t                              storage_port;                  // The port number associated with the storage server
+        uint16_t                              storage_lmq_port;              // The port number associated with the storage server (lokimq interface)
         uint16_t                              quorumnet_port;                // The port for direct SN-to-SN communication
         std::string                           pubkey_ed25519;                // The service node's ed25519 public key for auxiliary services
         std::string                           pubkey_x25519;                 // The service node's x25519 public key for auxiliary services
@@ -2843,6 +2844,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
             KV_SERIALIZE(operator_address)
             KV_SERIALIZE(public_ip)
             KV_SERIALIZE(storage_port)
+            KV_SERIALIZE(storage_lmq_port)
             KV_SERIALIZE(quorumnet_port)
             KV_SERIALIZE(pubkey_ed25519)
             KV_SERIALIZE(pubkey_x25519)
@@ -2946,6 +2948,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       bool operator_address;
       bool public_ip;
       bool storage_port;
+      bool storage_lmq_port;
       bool quorumnet_port;
       bool pubkey_ed25519;
       bool pubkey_x25519;
@@ -2985,6 +2988,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
         KV_SERIALIZE_OPT2(operator_address, false)
         KV_SERIALIZE_OPT2(public_ip, false)
         KV_SERIALIZE_OPT2(storage_port, false)
+        KV_SERIALIZE_OPT2(storage_lmq_port, false)
         KV_SERIALIZE_OPT2(quorumnet_port, false)
         KV_SERIALIZE_OPT2(pubkey_ed25519, false)
         KV_SERIALIZE_OPT2(pubkey_x25519, false)
@@ -3051,6 +3055,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
         std::string                           operator_address;              // The wallet address of the operator to which the operator cut of the staking reward is sent to.
         std::string                           public_ip;                     // The public ip address of the service node
         uint16_t                              storage_port;                  // The port number associated with the storage server
+        uint16_t                              storage_lmq_port;              // The port number associated with the storage server (lokimq interface)
         uint16_t                              quorumnet_port;                // The port for direct SN-to-SN communication
         std::string                           pubkey_ed25519;                // The service node's ed25519 public key for auxiliary services
         std::string                           pubkey_x25519;                 // The service node's x25519 public key for auxiliary services
@@ -3086,6 +3091,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(operator_address);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(public_ip);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(storage_port);
+          KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(storage_lmq_port);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(quorumnet_port);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(pubkey_ed25519);
           KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(pubkey_x25519);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3150,10 +3150,12 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
       int version_major; // Storage Server Major version
       int version_minor; // Storage Server Minor version
       int version_patch; // Storage Server Patch version
+      uint16_t storage_lmq_port; // Storage Server lmq port to include in uptime proofs
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(version_major);
         KV_SERIALIZE(version_minor);
         KV_SERIALIZE(version_patch);
+        KV_SERIALIZE(storage_lmq_port);
       END_KV_SERIALIZE_MAP()
     };
 


### PR DESCRIPTION
- adds mandatory for service nodes `--storage-server-lmq-port` option that should match a corresponding port in loki-storage-server.
- adds `storage_lmq_port` to uptime proofs