### PR TITLE
Remove hardcoded checkpoint on testnet

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -74,11 +74,6 @@ namespace cryptonote
     {301187, "e23e4cf3a2fe3e9f0ffced5cc76426e5bdffd3aad822268f4ad63d82cb958559"},
   };
 
-  height_to_hash const HARDCODED_TESTNET_CHECKPOINTS[] =
-  {
-    {127028, "83f6ea8d62601733a257d2f075fd960edd80886dc090d8751478c0a738caa09e"},
-  };
-
   crypto::hash get_newest_hardcoded_checkpoint(cryptonote::network_type nettype, uint64_t *height)
   {
     crypto::hash result = crypto::null_hash;
@@ -94,15 +89,6 @@ namespace cryptonote
       if (epee::string_tools::hex_to_pod(entry.hash, result))
         *height = entry.height;
     }
-    else
-    {
-      uint64_t last_index         = loki::array_count(HARDCODED_TESTNET_CHECKPOINTS) - 1;
-      height_to_hash const &entry = HARDCODED_TESTNET_CHECKPOINTS[last_index];
-
-      if (epee::string_tools::hex_to_pod(entry.hash, result))
-        *height = entry.height;
-    }
-
     return result;
   }
 
@@ -332,11 +318,8 @@ namespace cryptonote
     }
     else if (nettype == TESTNET)
     {
-      for (size_t i = 0; i < loki::array_count(HARDCODED_TESTNET_CHECKPOINTS); ++i)
-      {
-        height_to_hash const &checkpoint = HARDCODED_TESTNET_CHECKPOINTS[i];
-        ADD_CHECKPOINT(checkpoint.height, checkpoint.hash);
-      }
+      auto guard = db_wtxn_guard(m_db);
+      m_db->remove_block_checkpoint(127028);
     }
 #endif
 


### PR DESCRIPTION
Hardcoded checkpoints are not expected after HF13. At some point during
the previous releases's testing period we added a hardcoded checkpoint
because we redid the hardforking blocks on testnet due to some
incompatible changes- but were tenable to reboot the network on a small
network like the testnet.

This commit deletes the checkpoint instead of adding an exception so as
to not require letting the service node list accept hardcoded
checkpoints after HF13, or worse, if somehow a corrupt checkpoint was
added to the DB somehow, and on retrieval we return a checkpoint with no
signatures, this could sneak through as it'd be detected as a hardcoded
checkpoint once loaded from the DB.

We could provide an exception if it was a checkpoint on height 127XXX
and it was testnet, but this is too intrusive change to the conditional
for an insignifcant testing change.