### PR TITLE
 Change block reward for HF15 & 16 as per LRC-6

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -95,8 +95,16 @@ namespace cryptonote {
   uint64_t block_reward_unpenalized_formula_v8(uint64_t height)
   {
     std::fesetround(FE_TONEAREST);
-    uint64_t result = 28000000000.0 + 100000000000.0 / loki::exp2(height / (720.0 * 90.0)); // halve every 90 days.
+    uint64_t result = 28'000'000'000. + 100'000'000'000. / loki::exp2(height / (720. * 90)); // halve every 90 days.
     return result;
+  }
+
+  constexpr uint64_t block_reward_unpenalized_formula_v15() {
+    return BLOCK_REWARD_HF15;
+  }
+
+  constexpr uint64_t block_reward_unpenalized_formula_v16() {
+    return BLOCK_REWARD_HF15;
   }
 
   bool get_base_block_reward(size_t median_weight, size_t current_block_weight, uint64_t already_generated_coins, uint64_t &reward, uint64_t &reward_unpenalized, uint8_t version, uint64_t height) {
@@ -104,15 +112,18 @@ namespace cryptonote {
     //premine reward
     if (already_generated_coins == 0)
     {
-      reward = 22500000000000000;
+      reward = 22'500'000 * COIN;
       return true;
     }
 
     static_assert(DIFFICULTY_TARGET_V2%60==0,"difficulty targets must be a multiple of 60");
 
-    uint64_t base_reward = version >= network_version_8
-                               ? block_reward_unpenalized_formula_v8(height)
-                               : block_reward_unpenalized_formula_v7(already_generated_coins, height);
+    uint64_t base_reward =
+      version >= network_version_16 ? BLOCK_REWARD_HF16 :
+      version >= network_version_15_lns ? BLOCK_REWARD_HF15 :
+      version >= network_version_8  ? block_reward_unpenalized_formula_v8(height) :
+        block_reward_unpenalized_formula_v7(already_generated_coins, height);
+
     uint64_t full_reward_zone = get_min_block_weight(version);
 
     //make it soft

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -99,14 +99,6 @@ namespace cryptonote {
     return result;
   }
 
-  constexpr uint64_t block_reward_unpenalized_formula_v15() {
-    return BLOCK_REWARD_HF15;
-  }
-
-  constexpr uint64_t block_reward_unpenalized_formula_v16() {
-    return BLOCK_REWARD_HF15;
-  }
-
   bool get_base_block_reward(size_t median_weight, size_t current_block_weight, uint64_t already_generated_coins, uint64_t &reward, uint64_t &reward_unpenalized, uint8_t version, uint64_t height) {
 
     //premine reward

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -265,6 +265,7 @@ namespace cryptonote
     network_version_13_enforce_checkpoints,
     network_version_14_blink,
     network_version_15_lns,
+    network_version_16, // future fork
 
     network_version_count,
   };

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -133,11 +133,11 @@ namespace cryptonote
     return correct_key == output_key;
   }
 
-  const int GOVERNANCE_BASE_REWARD_DIVISOR   = 20;
-  const int SERVICE_NODE_BASE_REWARD_DIVISOR = 2;
-  uint64_t governance_reward_formula(uint64_t base_reward)
+  uint64_t governance_reward_formula(uint64_t base_reward, uint8_t hf_version)
   {
-    return base_reward / GOVERNANCE_BASE_REWARD_DIVISOR;
+    return hf_version >= network_version_16     ? FOUNDATION_REWARD_HF16 :
+           hf_version >= network_version_15_lns ? FOUNDATION_REWARD_HF15 :
+           base_reward / 20;
   }
 
   bool block_has_governance_output(network_type nettype, cryptonote::block const &block)
@@ -146,7 +146,7 @@ namespace cryptonote
     return result;
   }
 
-  bool height_has_governance_output(network_type nettype, int hard_fork_version, uint64_t height)
+  bool height_has_governance_output(network_type nettype, uint8_t hard_fork_version, uint64_t height)
   {
     if (height == 0)
       return false;
@@ -163,11 +163,14 @@ namespace cryptonote
     return true;
   }
 
-  uint64_t derive_governance_from_block_reward(network_type nettype, const cryptonote::block &block)
+  uint64_t derive_governance_from_block_reward(network_type nettype, const cryptonote::block &block, uint8_t hf_version)
   {
+    if (hf_version >= 15)
+      return governance_reward_formula(0, hf_version);
+
     uint64_t result       = 0;
     uint64_t snode_reward = 0;
-    uint64_t vout_end     = block.miner_tx.vout.size();
+    size_t vout_end     = block.miner_tx.vout.size();
 
     if (block_has_governance_output(nettype, block))
       --vout_end; // skip the governance output, the governance may be the batched amount. we want the original base reward
@@ -178,16 +181,8 @@ namespace cryptonote
       snode_reward += output.amount;
     }
 
-    static_assert(SERVICE_NODE_BASE_REWARD_DIVISOR == 2 &&
-                  GOVERNANCE_BASE_REWARD_DIVISOR == 20,
-                  "Anytime this changes, you should revisit this code and "
-                  "check, because we rely on the service node reward being 50\% "
-                  "of the base reward, and does not receive any fees. This isn't "
-                  "exactly intuitive and so changes to the reward structure may "
-                  "make this assumption invalid.");
-
-    uint64_t base_reward  = snode_reward * SERVICE_NODE_BASE_REWARD_DIVISOR;
-    uint64_t governance   = governance_reward_formula(base_reward);
+    uint64_t base_reward  = snode_reward * 2; // pre-HF15, SN reward = half of base reward
+    uint64_t governance   = governance_reward_formula(base_reward, hf_version);
     uint64_t block_reward = base_reward - governance;
 
     uint64_t actual_reward = 0; // sanity check
@@ -202,9 +197,13 @@ namespace cryptonote
     return result;
   }
 
-  uint64_t service_node_reward_formula(uint64_t base_reward, int hard_fork_version)
+  uint64_t service_node_reward_formula(uint64_t base_reward, uint8_t hard_fork_version)
   {
-    return hard_fork_version >= 9 ? (base_reward / SERVICE_NODE_BASE_REWARD_DIVISOR) : 0;
+    return
+      hard_fork_version >= network_version_16              ? SN_REWARD_HF16 :
+      hard_fork_version >= network_version_15_lns          ? SN_REWARD_HF15 :
+      hard_fork_version >= network_version_9_service_nodes ? base_reward / 2 : // 50% of base reward up until HF15's fixed payout
+      0;
   }
 
   uint64_t get_portion_of_reward(uint64_t portions, uint64_t total_service_node_reward)
@@ -400,7 +399,7 @@ namespace cryptonote
     // There is a goverance fee due every block.  Beginning in hardfork 10 this is still subtracted
     // from the block reward as if it was paid, but the actual payments get batched into rare, large
     // accumulated payments.  (Before hardfork 10 they are included in every block, unbatched).
-    result.governance_due  = governance_reward_formula(result.original_base_reward);
+    result.governance_due  = governance_reward_formula(result.original_base_reward, hard_fork_version);
     result.governance_paid = hard_fork_version >= network_version_10_bulletproofs
         ? loki_context.batched_governance
         : result.governance_due;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -42,13 +42,13 @@ namespace cryptonote
   bool     get_deterministic_output_key         (const account_public_address& address, const keypair& tx_key, size_t output_index, crypto::public_key& output_key);
   bool     validate_governance_reward_key       (uint64_t height, const std::string& governance_wallet_address_str, size_t output_index, const crypto::public_key& output_key, const cryptonote::network_type nettype);
 
-  uint64_t governance_reward_formula            (uint64_t base_reward);
+  uint64_t governance_reward_formula            (uint64_t base_reward, uint8_t hf_version);
   bool     block_has_governance_output          (network_type nettype, cryptonote::block const &block);
-  bool     height_has_governance_output         (network_type nettype, int hard_fork_version, uint64_t height);
-  uint64_t derive_governance_from_block_reward  (network_type nettype, const cryptonote::block &block);
+  bool     height_has_governance_output         (network_type nettype, uint8_t hard_fork_version, uint64_t height);
+  uint64_t derive_governance_from_block_reward  (network_type nettype, const cryptonote::block &block, uint8_t hf_version);
 
   uint64_t get_portion_of_reward                (uint64_t portions, uint64_t total_service_node_reward);
-  uint64_t service_node_reward_formula          (uint64_t base_reward, int hard_fork_version);
+  uint64_t service_node_reward_formula          (uint64_t base_reward, uint8_t hard_fork_version);
 
   struct loki_miner_tx_context // NOTE(loki): All the custom fields required by Loki to use construct_miner_tx
   {

--- a/src/loki_economy.h
+++ b/src/loki_economy.h
@@ -1,10 +1,26 @@
 #pragma once
+#include <cstdint>
+
 constexpr uint64_t COIN                       = (uint64_t)1000000000; // 1 LOKI = pow(10, 9)
 constexpr uint64_t MONEY_SUPPLY               = ((uint64_t)(-1)); // MONEY_SUPPLY - total number coins to be generated
 constexpr uint64_t EMISSION_LINEAR_BASE       = ((uint64_t)(1) << 58);
 constexpr uint64_t EMISSION_SUPPLY_MULTIPLIER = 19;
 constexpr uint64_t EMISSION_SUPPLY_DIVISOR    = 10;
 constexpr uint64_t EMISSION_DIVISOR           = 2000000;
+
+// Transition (HF15) money supply parameters
+constexpr uint64_t BLOCK_REWARD_HF15      = 25 * COIN;
+constexpr uint64_t MINER_REWARD_HF15      = BLOCK_REWARD_HF15 * 24 / 100;
+constexpr uint64_t SN_REWARD_HF15         = BLOCK_REWARD_HF15 * 66 / 100;
+constexpr uint64_t FOUNDATION_REWARD_HF15 = BLOCK_REWARD_HF15 * 10 / 100;
+
+// New (HF16+) money supply parameters (tentative - HF16 not yet scheduled)
+constexpr uint64_t BLOCK_REWARD_HF16      = 21 * COIN;
+constexpr uint64_t SN_REWARD_HF16         = BLOCK_REWARD_HF16 * 90 / 100;
+constexpr uint64_t FOUNDATION_REWARD_HF16 = BLOCK_REWARD_HF16 * 10 / 100;
+
+static_assert(MINER_REWARD_HF15 + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF15, "math fail");
+static_assert(                    SN_REWARD_HF16 + FOUNDATION_REWARD_HF16 == BLOCK_REWARD_HF16, "math fail");
 
 // -------------------------------------------------------------------------------------------------
 //

--- a/src/loki_economy.h
+++ b/src/loki_economy.h
@@ -15,12 +15,19 @@ constexpr uint64_t SN_REWARD_HF15         = BLOCK_REWARD_HF15 * 66 / 100;
 constexpr uint64_t FOUNDATION_REWARD_HF15 = BLOCK_REWARD_HF15 * 10 / 100;
 
 // New (HF16+) money supply parameters (tentative - HF16 not yet scheduled)
-constexpr uint64_t BLOCK_REWARD_HF16      = 21 * COIN;
+constexpr uint64_t BLOCK_REWARD_HF16      = 21 * COIN + 1 /* TODO - see below */;
 constexpr uint64_t SN_REWARD_HF16         = BLOCK_REWARD_HF16 * 90 / 100;
 constexpr uint64_t FOUNDATION_REWARD_HF16 = BLOCK_REWARD_HF16 * 10 / 100;
 
+// TODO: For now we add 1 extra atomic loki to the HF16 block reward, above; ultimately with pulse
+// we want to just drop the miner reward output entirely when a tx has no transactions, but we don't
+// support that yet in the current code and if we put an output of 0 it currently breaks the test
+// suite (which assumes an output of 0 means ringct, which this is not).  Thus this +1 hack for now,
+// to keep the current test suite happy until we actually implement this for HF16.
+constexpr uint64_t MINER_REWARD_HF16 = 1;
+
 static_assert(MINER_REWARD_HF15 + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF15, "math fail");
-static_assert(                    SN_REWARD_HF16 + FOUNDATION_REWARD_HF16 == BLOCK_REWARD_HF16, "math fail");
+static_assert(MINER_REWARD_HF16 + SN_REWARD_HF16 + FOUNDATION_REWARD_HF16 == BLOCK_REWARD_HF16, "math fail");
 
 // -------------------------------------------------------------------------------------------------
 //

--- a/tests/core_tests/block_validation.cpp
+++ b/tests/core_tests/block_validation.cpp
@@ -447,7 +447,7 @@ static bool construct_miner_tx_with_extra_output(cryptonote::transaction& tx,
 
     uint64_t governance_reward = 0;
     if (already_generated_coins != 0) {
-        governance_reward = governance_reward_formula(block_reward);
+        governance_reward = governance_reward_formula(block_reward, hard_fork_version);
         block_reward -= governance_reward;
     }
 

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -115,6 +115,7 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(loki_checkpointing_service_node_checkpoint_from_votes);
     GENERATE_AND_PLAY(loki_checkpointing_service_node_checkpoints_check_reorg_windows);
     GENERATE_AND_PLAY(loki_core_block_reward_unpenalized);
+    GENERATE_AND_PLAY(loki_core_block_rewards_lrc6);
     GENERATE_AND_PLAY(loki_core_fee_burning);
     GENERATE_AND_PLAY(loki_core_governance_batched_reward);
     GENERATE_AND_PLAY(loki_core_test_deregister_preferred);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -749,7 +749,8 @@ bool loki_core_block_rewards_lrc6::generate(std::vector<test_event_entry>& event
     for (size_t block_height = hf16_height; block_height < height; ++block_height)
     {
       const cryptonote::block &block = blockchain[block_height];
-      CHECK_EQ(block.miner_tx.vout.at(0).amount, 0);
+      // TODO: this 1 sat miner fee is just a placeholder until we address this properly in HF16.
+      CHECK_EQ(block.miner_tx.vout.at(0).amount, 1);
       CHECK_EQ(block.miner_tx.vout.at(1).amount, SN_REWARD_HF16);
       if (cryptonote::block_has_governance_output(cryptonote::FAKECHAIN, block))
       {

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -45,6 +45,7 @@ struct loki_checkpointing_service_node_checkpoints_check_reorg_windows          
 struct loki_core_block_reward_unpenalized                                            : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_fee_burning                                                         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_governance_batched_reward                                           : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct loki_core_block_rewards_lrc6                                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_test_deregister_preferred                                           : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_test_deregister_safety_buffer                                       : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_test_deregister_too_old                                             : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };


### PR DESCRIPTION
This changes the formula for HF15 to 66% service nodes, 24% miner, 10% foundation, and changes the block reward from the current 28 and a bit to a fixed 25 LOKI per block.  SN reward and LF reward both increase, miner reward gets cut substantially.  This change is reflecting that with checkpoints and blink the security provided by miners is substantially reduced.

In HF16 (with pulse) we plan to become mining-free, with final rewards also included here for that fork of 21 LOKI per block with 90% to SNs and 10% to foundation.  (This is tentative assuming pulse is implemented in HF16).

For more discussion on this change see https://github.com/loki-project/loki-improvement-proposals/issues/20