### PR TITLE
Add arm64 build to allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
   allow_failures:
       - name: "Windows cross-compile"
       - arch: ppc64le
+      - arch: arm64
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH" PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"; fi


### PR DESCRIPTION
It often hits the 50 minute limit (it seems to require some luck and/or
ccache'ed previous compilations) to consistently finish on time, so move
it to allowed failures so it doesn't cause github ci failures.