### PR TITLE
LNS: Remove the wallet's ed25519 key, we support wallet addresses

### DIFF
--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -38,7 +38,6 @@
 extern "C"
 {
 #include "crypto/keccak.h"
-#include <sodium.h>
 }
 #include "cryptonote_basic_impl.h"
 #include "cryptonote_format_utils.h"
@@ -156,12 +155,6 @@ DISABLE_VS_WARNINGS(4244 4345)
     m_keys.m_multisig_keys.clear();
   }
   //-----------------------------------------------------------------
-  void account_base::generate_public_edkey()
-  {
-    crypto::ed25519_secret_key unused_skey;
-    crypto_sign_ed25519_seed_keypair(m_keys.m_ed25519_public_key.data, unused_skey.data, reinterpret_cast<unsigned char const *>(&m_keys.m_spend_secret_key));
-  }
-  //-----------------------------------------------------------------
   static uint64_t creation_timestamp(bool use_genesis_timestamp)
   {
     uint64_t result = 0;
@@ -193,7 +186,6 @@ DISABLE_VS_WARNINGS(4244 4345)
     keccak((uint8_t *)&m_keys.m_spend_secret_key, sizeof(crypto::secret_key), (uint8_t *)&second, sizeof(crypto::secret_key));
 
     generate_keys(m_keys.m_account_address.m_view_public_key, m_keys.m_view_secret_key, second, two_random ? false : true);
-    generate_public_edkey();
     m_creation_timestamp = creation_timestamp(recover /*use_genesis_timestamp*/);
     return first;
   }
@@ -203,7 +195,6 @@ DISABLE_VS_WARNINGS(4244 4345)
     m_keys.m_account_address = address;
     m_keys.m_spend_secret_key = spendkey;
     m_keys.m_view_secret_key = viewkey;
-    generate_public_edkey();
     m_creation_timestamp = creation_timestamp(true /*use_genesis_timestamp*/);
   }
 
@@ -228,7 +219,6 @@ DISABLE_VS_WARNINGS(4244 4345)
       hwdev.disconnect();
       throw;
     }
-    generate_public_edkey();
     m_creation_timestamp = creation_timestamp(true /*use_genesis_timestamp*/);
   }
 
@@ -246,7 +236,6 @@ DISABLE_VS_WARNINGS(4244 4345)
     m_keys.m_view_secret_key = view_secret_key;
     m_keys.m_spend_secret_key = spend_secret_key;
     m_keys.m_multisig_keys = multisig_keys;
-    generate_public_edkey();
     return crypto::secret_key_to_public_key(view_secret_key, m_keys.m_account_address.m_view_public_key);
   }
   //-----------------------------------------------------------------

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -46,7 +46,6 @@ namespace cryptonote
     hw::device *m_device = &hw::get_device("default");
     crypto::chacha_iv m_encryption_iv;
 
-    crypto::ed25519_public_key m_ed25519_public_key; // NOTE: Not serialized, derived at load
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(m_account_address)
       KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(m_spend_secret_key)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8791,7 +8791,6 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
         return td.m_subaddr_index == cryptonote::subaddress_index{ m_current_subaddress_account, index };
       }) != transfers.end();
     success_msg_writer() << index << "  " << m_wallet->get_subaddress_as_str({m_current_subaddress_account, index}) << "  " << (index == 0 ? tr("Primary address") : m_wallet->get_subaddress_label({m_current_subaddress_account, index})) << " " << (used ? tr("(used)") : "");
-    success_msg_writer() << "0  " << epee::string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_ed25519_public_key) << "  " << tr("Ed25519 Key");
   };
 
   uint32_t index = 0;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4256,7 +4256,6 @@ bool wallet2::load_keys(const std::string& keys_file_name, const epee::wipeable_
     }
   }
 
-  m_account.generate_public_edkey();
   const cryptonote::account_keys& keys = m_account.get_keys();
   hw::device &hwdev = m_account.get_device();
   r = r && hwdev.verify_keys(keys.m_view_secret_key,  keys.m_account_address.m_view_public_key);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -428,7 +428,6 @@ namespace tools
         info.address_index = index.minor;
         info.used = std::find_if(transfers.begin(), transfers.end(), [&](const tools::wallet2::transfer_details& td) { return td.m_subaddr_index == index; }) != transfers.end();
       }
-      res.ed25519_key = epee::string_tools::pod_to_hex(m_wallet->get_account().get_keys().m_ed25519_public_key);
       res.address = m_wallet->get_subaddress_as_str({req.account_index, 0});
     }
     catch (const std::exception& e)

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -153,12 +153,10 @@ namespace wallet_rpc
     {
       std::string address;                  // (Deprecated) Remains to be compatible with older RPC format
       std::vector<address_info> addresses;  // Addresses informations.
-      std::string ed25519_key;              // The public ed25519 wallet key
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(address)
         KV_SERIALIZE(addresses)
-        KV_SERIALIZE(ed25519_key)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
Don't need to generate the ed25519 key based off the wallet spend key anymore since we support wallet addresses as the owner in LNS.