### PR TITLE
LNS: Revise name validation on client side

### DIFF
--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -1117,4 +1117,11 @@ std::string get_nix_version_display_string()
     const std::uint64_t divisor = size->bytes / 1000;
     return (boost::format(size->format) % (double(bytes) / divisor)).str();
   }
+
+  std::string lowercase_ascii_string(std::string src)
+  {
+    for (char &ch : src)
+      if (ch >= 'A' && ch <= 'Z') ch = ch + ('a' - 'A');
+    return src;
+  }
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -316,4 +316,5 @@ namespace tools
   template <typename Enum>
   constexpr Enum enum_top = static_cast<Enum>(enum_count<Enum> - 1);
 
+  std::string lowercase_ascii_string(std::string src);
 }

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -65,7 +65,7 @@ sqlite3       *init_loki_name_system(char const *file_path);
 uint64_t constexpr NO_EXPIRY = static_cast<uint64_t>(-1);
 // return: The number of blocks until expiry from the registration height, if there is no expiration NO_EXPIRY is returned.
 uint64_t     expiry_blocks(cryptonote::network_type nettype, mapping_type type, uint64_t *renew_window = nullptr);
-bool         validate_lns_name(mapping_type type, std::string const &name, std::string *reason = nullptr);
+bool         validate_lns_name(mapping_type type, std::string name, std::string *reason = nullptr);
 
 crypto::generic_signature  make_monero_signature(crypto::hash const &hash, crypto::public_key const &pkey, crypto::secret_key const &skey);
 crypto::generic_signature  make_ed25519_signature(crypto::hash const &hash, crypto::ed25519_secret_key const &skey);

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3392,31 +3392,31 @@ namespace cryptonote
       if (exceeds_quantity_limit(ctx, error_resp, m_restricted, request.types.size(), COMMAND_RPC_LNS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES, "types"))
         return false;
 
-      for (uint16_t type : request.types)
+      std::string name = tools::lowercase_ascii_string(request.name);
+      for (uint16_t type16 : request.types)
       {
-        if (!lns::validate_lns_name(static_cast<lns::mapping_type>(type), request.name, &error_resp.message))
+        if (!lns::validate_lns_name(static_cast<lns::mapping_type>(type16), name, &error_resp.message))
         {
           error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
           return false;
         }
       }
 
-      std::string name_hash = lns::name_to_base64_hash(request.name);
+      std::string name_hash                    = lns::name_to_base64_hash(name);
       std::vector<lns::mapping_record> records = db.get_mappings(request.types, name_hash);
-      res.entries.reserve(records.size());
-      for (auto &record : records)
+      for (auto const &record : records)
       {
         res.entries.emplace_back();
         COMMAND_RPC_LNS_NAMES_TO_OWNERS::response_entry &entry = res.entries.back();
         entry.entry_index                                      = request_index;
         entry.type                                             = static_cast<uint16_t>(record.type);
-        entry.name_hash                                        = std::move(record.name_hash);
+        entry.name_hash                                        = record.name_hash;
         entry.owner                                            = epee::string_tools::pod_to_hex(record.owner);
         if (record.backup_owner) entry.backup_owner            = epee::string_tools::pod_to_hex(record.backup_owner);
         entry.encrypted_value                                  = epee::to_hex::string(record.encrypted_value.to_span());
         entry.register_height                                  = record.register_height;
         entry.txid                                             = epee::string_tools::pod_to_hex(record.txid);
-        if (record.prev_txid) entry.prev_txid                   = epee::string_tools::pod_to_hex(record.prev_txid);
+        if (record.prev_txid) entry.prev_txid                  = epee::string_tools::pod_to_hex(record.prev_txid);
       }
     }
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3392,6 +3392,15 @@ namespace cryptonote
       if (exceeds_quantity_limit(ctx, error_resp, m_restricted, request.types.size(), COMMAND_RPC_LNS_NAMES_TO_OWNERS::MAX_TYPE_REQUEST_ENTRIES, "types"))
         return false;
 
+      for (uint16_t type : request.types)
+      {
+        if (!lns::validate_lns_name(static_cast<lns::mapping_type>(type), request.name, &error_resp.message))
+        {
+          error_resp.code = CORE_RPC_ERROR_CODE_WRONG_PARAM;
+          return false;
+        }
+      }
+
       std::string name_hash = lns::name_to_base64_hash(request.name);
       std::vector<lns::mapping_record> records = db.get_mappings(request.types, name_hash);
       res.entries.reserve(records.size());

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -3466,7 +3466,7 @@ constexpr char const CORE_RPC_STATUS_TX_LONG_POLL_MAX_CONNECTIONS[] = "Daemon ma
   struct COMMAND_RPC_LNS_NAMES_TO_OWNERS
   {
     static size_t const MAX_REQUEST_ENTRIES      = 256;
-    static size_t const MAX_TYPE_REQUEST_ENTRIES = 16;
+    static size_t const MAX_TYPE_REQUEST_ENTRIES = 8;
     struct request_entry
     {
       std::string name;            // The name to resolve to a public key via Loki Name Service

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6373,7 +6373,7 @@ bool simple_wallet::lns_buy_mapping(const std::vector<std::string>& args)
   std::string owner        = eat_named_argument(local_args, LNS_OWNER_PREFIX, loki::char_count(LNS_OWNER_PREFIX));
   std::string backup_owner = eat_named_argument(local_args, LNS_BACKUP_OWNER_PREFIX, loki::char_count(LNS_BACKUP_OWNER_PREFIX));
 
-  if (local_args.size() < 2)
+  if (local_args.size() != 2)
   {
     PRINT_USAGE(USAGE_LNS_BUY_MAPPING);
     return true;

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6379,20 +6379,8 @@ bool simple_wallet::lns_buy_mapping(const std::vector<std::string>& args)
     return true;
   }
 
-<<<<<<< HEAD
-  std::string const &value = local_args[local_args.size() - 1];
-  std::string name;
-
-  size_t first_word_index = 0;
-  size_t last_word_index  = local_args.size() - 2;
-  if (!parse_lns_name_string(USAGE_LNS_BUY_MAPPING, local_args, first_word_index, last_word_index, name))
-    return false;
-=======
-  std::string owner        = eat_named_argument(local_args, LNS_OWNER_PREFIX, loki::char_count(LNS_OWNER_PREFIX));
-  std::string backup_owner = eat_named_argument(local_args, LNS_BACKUP_OWNER_PREFIX, loki::char_count(LNS_BACKUP_OWNER_PREFIX));
   std::string const &name  = local_args[0];
   std::string const &value = local_args[1];
->>>>>>> LNS: Remove parse_lns_name from CLI wallet
 
   SCOPED_WALLET_UNLOCK();
   std::string reason;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8441,7 +8441,7 @@ struct lns_prepared_args
 static lns_prepared_args prepare_tx_extra_loki_name_system_values(wallet2 const &wallet,
                                                                   lns::mapping_type type,
                                                                   uint32_t priority,
-                                                                  std::string const &name,
+                                                                  std::string &name,
                                                                   std::string const *value,
                                                                   std::string const *owner,
                                                                   std::string const *backup_owner,
@@ -8455,10 +8455,11 @@ static lns_prepared_args prepare_tx_extra_loki_name_system_values(wallet2 const 
     return result;
   }
 
+  name = tools::lowercase_ascii_string(name);
   if (!lns::validate_lns_name(type, name, reason))
     return result;
-  result.name_hash = lns::name_to_hash(name);
 
+  result.name_hash = lns::name_to_hash(name);
   if (value)
   {
     lns::mapping_value binary_value = {};
@@ -8518,7 +8519,7 @@ static lns_prepared_args prepare_tx_extra_loki_name_system_values(wallet2 const 
 std::vector<wallet2::pending_tx> wallet2::lns_create_buy_mapping_tx(lns::mapping_type type,
                                                                     std::string const *owner,
                                                                     std::string const *backup_owner,
-                                                                    std::string const &name,
+                                                                    std::string name,
                                                                     std::string const &value,
                                                                     std::string *reason,
                                                                     uint32_t priority,
@@ -8577,7 +8578,7 @@ std::vector<wallet2::pending_tx> wallet2::lns_create_buy_mapping_tx(std::string 
 }
 
 std::vector<wallet2::pending_tx> wallet2::lns_create_update_mapping_tx(lns::mapping_type type,
-                                                                       std::string const &name,
+                                                                       std::string name,
                                                                        std::string const *value,
                                                                        std::string const *owner,
                                                                        std::string const *backup_owner,
@@ -8676,7 +8677,7 @@ bool wallet2::unlock_keys_file()
 }
 
 bool wallet2::lns_make_update_mapping_signature(lns::mapping_type type,
-                                                std::string const &name,
+                                                std::string name,
                                                 std::string const *value,
                                                 std::string const *owner,
                                                 std::string const *backup_owner,

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1538,16 +1538,16 @@ private:
       pending_tx  ptx;
     };
     request_stake_unlock_result can_request_stake_unlock(const crypto::public_key &sn_key);
-    std::vector<wallet2::pending_tx> lns_create_buy_mapping_tx(lns::mapping_type type, std::string const *owner, std::string const *backup_owner, std::string const &name, std::string const &value, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
+    std::vector<wallet2::pending_tx> lns_create_buy_mapping_tx(lns::mapping_type type, std::string const *owner, std::string const *backup_owner, std::string name, std::string const &value, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
     std::vector<wallet2::pending_tx> lns_create_buy_mapping_tx(std::string const &type, std::string const *owner, std::string const *backup_owner, std::string const &name, std::string const &value, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
 
     // signature: (Optional) If set, use the signature given, otherwise by default derive the signature from the wallet spend key as an ed25519 key.
     //            The signature is derived from the hash of the previous txid blob and previous value blob of the mapping. By default this is signed using the wallet's spend key as an ed25519 keypair.
-    std::vector<wallet2::pending_tx> lns_create_update_mapping_tx(lns::mapping_type type, std::string const &name, std::string const *value, std::string const *owner, std::string const *backup_owner, std::string const *signature, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
+    std::vector<wallet2::pending_tx> lns_create_update_mapping_tx(lns::mapping_type type, std::string name, std::string const *value, std::string const *owner, std::string const *backup_owner, std::string const *signature, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
     std::vector<wallet2::pending_tx> lns_create_update_mapping_tx(std::string const &type, std::string const &name, std::string const *value, std::string const *owner, std::string const *backup_owner, std::string const *signature, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
 
     // Generate just the signature required for putting into lns_update_mapping command in the wallet
-    bool lns_make_update_mapping_signature(lns::mapping_type type, std::string const &name, std::string const *value, std::string const *owner, std::string const *backup_owner, crypto::generic_signature &signature, std::string *reason = nullptr);
+    bool lns_make_update_mapping_signature(lns::mapping_type type, std::string name, std::string const *value, std::string const *owner, std::string const *backup_owner, crypto::generic_signature &signature, std::string *reason = nullptr);
 
     void freeze(size_t idx);
     void thaw(size_t idx);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -2125,7 +2125,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
     owner1.type = crypto::generic_key_sig_type::ed25519;
     owner2.type = crypto::generic_key_sig_type::ed25519;
 
-    std::string name      = "Hello World";
+    std::string name      = "Hello_World";
     std::string name_hash = lns::name_to_base64_hash(name);
     cryptonote::transaction tx1 = gen.create_and_add_loki_name_system_tx(miner, lns::mapping_type::session, name, miner_key.session_value, &owner1, &owner2);
     gen.create_and_add_next_block({tx1});
@@ -2199,7 +2199,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
     owner1.type = crypto::generic_key_sig_type::monero;
     owner2.type = crypto::generic_key_sig_type::monero;
 
-    std::string name            = "Hello Sailor";
+    std::string name            = "Hello_Sailor";
     std::string name_hash = lns::name_to_base64_hash(name);
     cryptonote::transaction tx1 = gen.create_and_add_loki_name_system_tx(miner, lns::mapping_type::session, name, miner_key.session_value, &owner1, &owner2);
     gen.create_and_add_next_block({tx1});
@@ -2264,7 +2264,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
     owner1.type = crypto::generic_key_sig_type::ed25519;
     owner2.type = crypto::generic_key_sig_type::monero;
 
-    std::string name = "Hello Driver";
+    std::string name = "Hello_Driver";
     std::string name_hash = lns::name_to_base64_hash(name);
     cryptonote::transaction tx1 = gen.create_and_add_loki_name_system_tx(miner, lns::mapping_type::session, name, miner_key.session_value, &owner1, &owner2);
     gen.create_and_add_next_block({tx1});
@@ -2328,7 +2328,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
     owner1.type = crypto::generic_key_sig_type::monero;
     owner2.type = crypto::generic_key_sig_type::ed25519;
 
-    std::string name = "Hello Passenger";
+    std::string name = "Hello_Passenger";
     std::string name_hash = lns::name_to_base64_hash(name);
     cryptonote::transaction tx1 = gen.create_and_add_loki_name_system_tx(miner, lns::mapping_type::session, name, miner_key.session_value, &owner1, &owner2);
     gen.create_and_add_next_block({tx1});

--- a/tests/unit_tests/loki_name_system.cpp
+++ b/tests/unit_tests/loki_name_system.cpp
@@ -22,6 +22,12 @@ TEST(loki_name_system, name_tests)
       {"a.loko", false},
       {"a domain name.loki", false},
       {"-.loki", false},
+      {"a_b.loki", false},
+      {" a.loki", false},
+      {"a.loki ", false},
+      {" a.loki ", false},
+      {"localhost.loki", false},
+      {"localhost", false},
   };
 
   name_test const session_wallet_names[] = {

--- a/tests/unit_tests/loki_name_system.cpp
+++ b/tests/unit_tests/loki_name_system.cpp
@@ -3,63 +3,66 @@
 #include "common/loki.h"
 #include "cryptonote_core/loki_name_system.h"
 
-TEST(loki_name_system, lokinet_domain_names)
+TEST(loki_name_system, name_tests)
 {
-
-  char domain_edkeys[lns::LOKINET_ADDRESS_BINARY_LENGTH * 2] = {};
-  memset(domain_edkeys, 'a', sizeof(domain_edkeys));
-  lns::mapping_type const lokinet = lns::mapping_type::lokinet_1year;
-
-  // Should work
+  struct name_test
   {
-    std::string const name = "mydomain.loki";
-    ASSERT_TRUE(lns::validate_lns_name(lokinet, name));
-  }
+    std::string name;
+    bool allowed;
+  };
 
-  {
-    std::string const name = "a.loki";
-    ASSERT_TRUE(lns::validate_lns_name(lokinet, name));
-  }
+  name_test const lokinet_names[] = {
+      {"a.loki", true},
+      {"domain.loki", true},
+      {"xn--tda.loki", true},
+      {"xn--Mchen-Ost-9db-u6b.loki", true},
 
-  {
-    std::string const name = "xn--bcher-kva.loki";
-    ASSERT_TRUE(lns::validate_lns_name(lokinet, name));
-  }
+      {"abc.domain.loki", false},
+      {"a", false},
+      {"a.loko", false},
+      {"a domain name.loki", false},
+      {"-.loki", false},
+  };
 
-  // Should fail
-  {
-    std::string const name = "";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
+  name_test const session_wallet_names[] = {
+      {"Hello", true},
+      {"1Hello", true},
+      {"1Hello1", true},
+      {"_Hello1", true},
+      {"1Hello_", true},
+      {"_Hello_", true},
+      {"999", true},
+      {"xn--tda", true},
+      {"xn--Mchen-Ost-9db-u6b", true},
 
-  {
-    std::string const name = "mydomain.loki.example";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
+      {"-", false},
+      {"@", false},
+      {"'Hello", false},
+      {"@Hello", false},
+      {"[Hello", false},
+      {"]Hello", false},
+      {"Hello ", false},
+      {" Hello", false},
+      {" Hello ", false},
 
-  {
-    std::string const name = "mydomain.loki.com";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
+      {"Hello World", false},
+      {"Hello\\ World", false},
+      {"\"hello\"", false},
+      {"hello\"", false},
+      {"\"hello", false},
+  };
 
+  for (uint16_t type16 = 0; type16 < static_cast<uint16_t>(lns::mapping_type::_count); type16++)
   {
-    std::string const name = "mydomain.com";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
+    auto type = static_cast<lns::mapping_type>(type16);
+    name_test const *names = lns::is_lokinet_type(type) ? lokinet_names : session_wallet_names;
+    size_t names_count     = lns::is_lokinet_type(type) ? loki::char_count(lokinet_names) : loki::char_count(session_wallet_names);
 
-  {
-    std::string const name = "mydomain";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
-
-  {
-    std::string const name = "xn--bcher-kva.lok";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
-  }
-
-  {
-    std::string const name = "a_b_c.loki";
-    ASSERT_FALSE(lns::validate_lns_name(lokinet, name));
+    for (size_t i = 0; i < names_count; i++)
+    {
+      name_test const &entry = names[i];
+      ASSERT_EQ(lns::validate_lns_name(type, entry.name), entry.allowed) << "Values were {type=" << type << ", name=\"" << entry.name << "\"}";
+    }
   }
 }
 


### PR DESCRIPTION
In summary

```
SESSION or WALLET
Name has to start with a (alphanumeric or underscore), and can have
(alphanumeric, hyphens or underscores) in between and must end with
a (alphanumeric or underscore)

LOKINET
Domain has to start with an alphanumeric, and can have (alphanumeric or
hyphens) in between must end with a '.loki'
```

Also add a check to the LNS query command, to early disconnect the request if they request an invalid name via RPC.