### PR TITLE
Add missing checkpoints dep to cryptonote_core

### DIFF
--- a/src/cryptonote_core/CMakeLists.txt
+++ b/src/cryptonote_core/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(cryptonote_core
     multisig
     ringct
     device
+    checkpoints
     sqlite3
   PRIVATE
     Boost::program_options


### PR DESCRIPTION
The missing dep caused a linking failure while building debs.