### PR TITLE
Make contrib work in a xenial chroot

### DIFF
--- a/contrib/depends/packages/sqlite3.mk
+++ b/contrib/depends/packages/sqlite3.mk
@@ -5,8 +5,8 @@ $(package)_file_name=sqlite-autoconf-$($(package)_version).tar.gz
 $(package)_sha256_hash=62284efebc05a76f909c580ffa5c008a7d22a1287285d68b7825a2b6b51949ae
 
 define $(package)_set_vars
-  $(package)_cflags=-Wformat -Wformat-security -fstack-protector -fstack-protector-strong
-  $(package)_cxxflags=-std=C++11 -Wformat -Wformat-security -fstack-protector -fstack-protector-strong
+  $(package)_cflags=-Wformat -Wformat-security -fstack-protector -fstack-protector-strong -fPIC
+  $(package)_cxxflags=-std=C++11 -Wformat -Wformat-security -fstack-protector -fstack-protector-strong -fPIC
   $(package)_config_opts=--prefix=$(host_prefix) --disable-shared
   $(package)_ldflags=-pie
 endef


### PR DESCRIPTION
Without -fPIC here sqlite3 fails to link during the build in a xenial chroot using

    make depends target=x86_64-linux-gnu

This fixes it, and got me binaries.