### PR TITLE
Add version to beginning of systemd status string

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -543,7 +543,8 @@ namespace cryptonote
   {
     std::string s;
     s.reserve(128);
-    s += "Height: ";
+    s += 'v'; s += LOKI_VERSION_STR;
+    s += "; Height: ";
     s += std::to_string(c.get_blockchain_storage().get_current_blockchain_height());
     s += ", SN: ";
     auto keys = c.get_service_node_keys();


### PR DESCRIPTION
Lokinet and storage server have this and it's nice to be able to tell at a glance at `systemd status loki-node` what the running lokid version is running.

This is already applied in the 7.1.x debs as a separate patch to give something like:
```
   Status: "v7.1.1; Height: 492064, SN: active, proof: 25s, storage: 2m34s, lokinet: 25s"
```