### PR TITLE
LNS: Support subaddresses properly in the wallet

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6618,13 +6618,17 @@ bool simple_wallet::lns_print_owners_to_names(const std::vector<std::string>& ar
     return false;
 
   boost::optional<std::string> failed;
+  std::vector<std::vector<cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::response_entry>> rpc_results;
+  std::vector<cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::request> requests(1);
 
-  std::string my_key;
-  cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::request request = {};
   if (args.size() == 0)
   {
-    my_key = m_wallet->get_subaddress_as_str({m_current_subaddress_account, 0});
-    request.entries.push_back(my_key);
+    for (uint32_t index = 0; index < m_wallet->get_num_subaddresses(m_current_subaddress_account); ++index)
+    {
+      if (requests.back().entries.size() >= cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::MAX_REQUEST_ENTRIES)
+        requests.emplace_back();
+      requests.back().entries.push_back(m_wallet->get_subaddress_as_str({m_current_subaddress_account, index}));
+    }
   }
   else
   {
@@ -6641,40 +6645,49 @@ bool simple_wallet::lns_print_owners_to_names(const std::vector<std::string>& ar
         fail_msg_writer() << "arg contains non-hex characters: " << arg;
         return false;
       }
-      request.entries.push_back(arg);
+
+      if (requests.back().entries.size() >= cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::MAX_REQUEST_ENTRIES)
+        requests.emplace_back();
+      requests.back().entries.push_back(arg);
     }
   }
 
-  std::vector<cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::response_entry> entries = m_wallet->lns_owners_to_names(request, failed);
-  if (failed)
+  rpc_results.reserve(requests.size());
+  for (auto const &request : requests)
   {
-    fail_msg_writer() << *failed;
-    return false;
+    std::vector<cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::response_entry> result = m_wallet->lns_owners_to_names(request, failed);
+    if (failed)
+    {
+      fail_msg_writer() << *failed;
+      return false;
+    }
+    rpc_results.emplace_back(std::move(result));
   }
 
-  for (cryptonote::COMMAND_RPC_LNS_OWNERS_TO_NAMES::response_entry const &entry : entries)
+  for (size_t i = 0; i < rpc_results.size(); i++)
   {
-    std::string const *owner = &my_key;
-    if (args.size()) // If specified owner to look up, retrieve it
+    auto const &rpc = rpc_results[i];
+    for (auto const &entry : rpc)
     {
+      std::string const *owner = nullptr;
       try
       {
-        owner = &args.at(entry.request_index);
+        owner = &requests[i].entries.at(entry.request_index);
       }
       catch (std::exception const &e)
       {
         fail_msg_writer() << "Daemon returned an invalid owner index = " << entry.request_index << " skipping mapping";
         continue;
       }
-    }
 
-    tools::msg_writer() << "owner=" << *owner
-                        << ", backup_owner=" << (entry.backup_owner.empty() ? NULL_STR : entry.backup_owner)
-                        << ", type=" << static_cast<lns::mapping_type>(entry.type)
-                        << ", height=" << entry.register_height
-                        << ", name_hash=" << entry.name_hash
-                        << ", encrypted_value=" << entry.encrypted_value
-                        << ", prev_txid=" << (entry.prev_txid.empty() ? NULL_STR : entry.prev_txid);
+      tools::msg_writer() << "owner=" << *owner
+                          << ", backup_owner=" << (entry.backup_owner.empty() ? NULL_STR : entry.backup_owner)
+                          << ", type=" << static_cast<lns::mapping_type>(entry.type)
+                          << ", height=" << entry.register_height
+                          << ", name_hash=" << entry.name_hash
+                          << ", encrypted_value=" << entry.encrypted_value
+                          << ", prev_txid=" << (entry.prev_txid.empty() ? NULL_STR : entry.prev_txid);
+    }
   }
   return true;
 }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8439,6 +8439,36 @@ struct lns_prepared_args
   crypto::hash            prev_txid;
 };
 
+static bool try_generate_lns_signature(wallet2 const &wallet, std::string const &curr_owner, std::string const *new_owner, std::string const *new_backup_owner, lns_prepared_args &result)
+{
+  cryptonote::address_parse_info curr_owner_parsed = {};
+  if (!cryptonote::get_account_address_from_str(curr_owner_parsed, wallet.nettype(), curr_owner))
+      return false;
+
+  boost::optional<cryptonote::subaddress_index> index = wallet.get_subaddress_index(curr_owner_parsed.address);
+  if (!index) return false;
+
+  // TODO(doyle): Taken from wallet2.cpp::get_reserve_proof
+  crypto::secret_key skey = wallet.get_account().get_keys().m_spend_secret_key;
+  if (!index->is_zero())
+  {
+    crypto::secret_key m = wallet.get_account().get_device().get_subaddress_secret_key(wallet.get_account().get_keys().m_view_secret_key, *index);
+    crypto::secret_key tmp = skey;
+    sc_add((unsigned char*)&skey, (unsigned char*)&m, (unsigned char*)&tmp);
+  }
+
+  crypto::public_key pkey;
+  crypto::secret_key_to_public_key(skey, pkey);
+
+  crypto::hash hash = lns::tx_extra_signature_hash(result.encrypted_value.to_span(),
+                                                   new_owner ? &result.owner : nullptr,
+                                                   new_backup_owner ? &result.backup_owner : nullptr,
+                                                   result.prev_txid);
+  if (!hash) return false;
+  result.signature = lns::make_monero_signature(hash, pkey, skey);
+  return true;
+}
+
 static lns_prepared_args prepare_tx_extra_loki_name_system_values(wallet2 const &wallet,
                                                                   lns::mapping_type type,
                                                                   uint32_t priority,
@@ -8506,27 +8536,32 @@ static lns_prepared_args prepare_tx_extra_loki_name_system_values(wallet2 const 
         return result;
       }
     }
-  }
 
-  if (make_signature)
-  {
-    cryptonote::subaddress_index const index = {account_index, 0};
-
-    // TODO(doyle): Taken from wallet2.cpp::get_reserve_proof
-    crypto::secret_key skey = wallet.get_account().get_keys().m_spend_secret_key;
-    if (!index.is_zero())
+    if (make_signature)
     {
-      crypto::secret_key m = wallet.get_account().get_device().get_subaddress_secret_key(wallet.get_account().get_keys().m_view_secret_key, index);
-      crypto::secret_key tmp = skey;
-      sc_add((unsigned char*)&skey, (unsigned char*)&m, (unsigned char*)&tmp);
+      if (response.empty())
+      {
+        if (reason) *reason = "Signature requested when preparing LNS TX but record to update does not exist";
+        return result;
+      }
+
+      cryptonote::address_parse_info curr_owner_parsed        = {};
+      cryptonote::address_parse_info curr_backup_owner_parsed = {};
+      bool curr_owner        = cryptonote::get_account_address_from_str(curr_owner_parsed, wallet.nettype(), response[0].owner);
+      bool curr_backup_owner = cryptonote::get_account_address_from_str(curr_backup_owner_parsed, wallet.nettype(), response[0].backup_owner);
+      if (!try_generate_lns_signature(wallet, response[0].owner, owner, backup_owner, result))
+      {
+        if (!try_generate_lns_signature(wallet, response[0].backup_owner, owner, backup_owner, result))
+        {
+          if (reason)
+          {
+            *reason = "Signature requested when preparing LNS TX, but this wallet is not the owner of the record owner=" + response[0].owner;
+            if (response[0].backup_owner.size()) *reason += ", backup_owner=" + response[0].backup_owner;
+          }
+          return result;
+        }
+      }
     }
-
-    crypto::public_key pkey;
-    crypto::secret_key_to_public_key(skey, pkey);
-
-    crypto::hash hash = lns::tx_extra_signature_hash(result.encrypted_value.to_span(), owner ? &result.owner : nullptr, backup_owner ? &result.backup_owner : nullptr, result.prev_txid);
-    if (!hash) return result;
-    result.signature = lns::make_monero_signature(hash, pkey, skey);
   }
 
   result.prepared = true;


### PR DESCRIPTION
```
Before this patch only LNS records bought with subaddresses with a minor
index of 0 were properly supported (in that you can buy and update the
mapping). Since we didn't respect the minor index of the address, if you
had updated a transaction using an address from "address new" the wallet
didn't use the minor index to generate the secret key, only the major index.

This would lock out users from updating. In this patch we search up the
subaddress in our wallet, and if it's found, we use that to generate the
correct secret key to sign the transaction.
```