### PR TITLE
Blockchain init respect read only flag

### DIFF
--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -319,11 +319,6 @@ namespace cryptonote
         ADD_CHECKPOINT(checkpoint.height, checkpoint.hash);
       }
     }
-    else if (nettype == TESTNET)
-    {
-      auto guard = db_wtxn_guard(m_db);
-      m_db->remove_block_checkpoint(127028);
-    }
 #endif
 
     return true;

--- a/src/checkpoints/checkpoints.cpp
+++ b/src/checkpoints/checkpoints.cpp
@@ -307,6 +307,9 @@ namespace cryptonote
     m_db      = db;
     m_nettype = nettype;
 
+    if (db->is_read_only())
+      return true;
+
 #if !defined(LOKI_ENABLE_INTEGRATION_TEST_HOOKS)
     if (nettype == MAINNET)
     {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -593,7 +593,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *lns_db, const network_type nett
   for (InitHook* hook : m_init_hooks)
     hook->init();
 
-  if (!load_missing_blocks_into_loki_subsystems())
+  if (!m_db->is_read_only() && !load_missing_blocks_into_loki_subsystems())
   {
     MERROR("Failed to load blocks into loki subsystems");
     return false;


### PR DESCRIPTION
On blockchain init avoid writing data to the DB if we're in read only mode otherwise we abort with failing to open write transactions. 