### PR TITLE
SN: Client side check signature

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -292,7 +292,7 @@ namespace service_nodes
     return false;
   }
 
-  bool reg_tx_extract_fields(const cryptonote::transaction& tx, std::vector<cryptonote::account_public_address>& addresses, uint64_t& portions_for_operator, std::vector<uint64_t>& portions, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature)
+  bool reg_tx_extract_fields(const cryptonote::transaction& tx, contributor_args_t &contributor_args, uint64_t& expiration_timestamp, crypto::public_key& service_node_key, crypto::signature& signature)
   {
     cryptonote::tx_extra_service_node_register registration;
     if (!get_service_node_register_from_tx_extra(tx.extra, registration))
@@ -300,18 +300,20 @@ namespace service_nodes
     if (!cryptonote::get_service_node_pubkey_from_tx_extra(tx.extra, service_node_key))
       return false;
 
-    addresses.clear();
-    addresses.reserve(registration.m_public_spend_keys.size());
+    contributor_args.addresses.clear();
+    contributor_args.addresses.reserve(registration.m_public_spend_keys.size());
     for (size_t i = 0; i < registration.m_public_spend_keys.size(); i++) {
-      addresses.emplace_back();
-      addresses.back().m_spend_public_key = registration.m_public_spend_keys[i];
-      addresses.back().m_view_public_key = registration.m_public_view_keys[i];
+      contributor_args.addresses.emplace_back();
+      contributor_args.addresses.back().m_spend_public_key = registration.m_public_spend_keys[i];
+      contributor_args.addresses.back().m_view_public_key  = registration.m_public_view_keys[i];
     }
 
-    portions_for_operator = registration.m_portions_for_operator;
-    portions = registration.m_portions;
+    contributor_args.portions_for_operator = registration.m_portions_for_operator;
+    contributor_args.portions              = registration.m_portions;
+    contributor_args.success               = true;
+
     expiration_timestamp = registration.m_expiration_timestamp;
-    signature = registration.m_service_node_signature;
+    signature            = registration.m_service_node_signature;
     return true;
   }
 
@@ -326,6 +328,128 @@ namespace service_nodes
     }
     return result;
   }
+
+  validate_contributor_args_result validate_contributor_args(uint8_t hf_version, contributor_args_t const &contributor_args, uint64_t const *expiration_timestamp, crypto::public_key const *service_node_key, crypto::signature const *signature)
+  {
+    using result_code = validate_contributor_args_result;
+    if (contributor_args.portions.size() != contributor_args.addresses.size() ||
+        contributor_args.portions.empty() ||
+        contributor_args.portions.size() > MAX_NUMBER_OF_CONTRIBUTORS)
+    {
+      return result_code::portions_mismatch;
+    }
+
+    if (!check_service_node_portions(hf_version, contributor_args.portions))
+      return result_code::incorrect_portions;
+
+    if (contributor_args.portions_for_operator > STAKING_PORTIONS)
+      return result_code::operator_portions_too_much;
+
+    //
+    // Signature Check
+    //
+    crypto::hash hash = {};
+    if (expiration_timestamp && service_node_key && signature)
+    {
+      if (!get_registration_hash(contributor_args.addresses, contributor_args.portions_for_operator, contributor_args.portions, *expiration_timestamp, hash))
+        return result_code::registration_hash_failed;
+
+      if (!crypto::check_key(*service_node_key))
+        return result_code::invalid_service_node_key;
+
+      if (!crypto::check_key(*service_node_key) || !crypto::check_signature(hash, *service_node_key, *signature))
+        return result_code::invalid_signature;
+    }
+
+    return result_code::success;
+  }
+
+  std::string validate_contributor_args_result_string(validate_contributor_args_result error, contributor_args_t const *context, crypto::public_key const *service_node_key, crypto::signature const *signature)
+  {
+    auto report_portions = [](std::stringstream &stream, contributor_args_t const *context) -> void
+    {
+      if (context)
+      {
+        stream << ". Portions: {";
+        for (size_t i = 0; i < context->portions.size(); i++)
+        {
+          if (i) stream << ",";
+          stream << context->portions[i];
+        }
+        stream << "}";
+      }
+    };
+
+    auto report_portion_and_address_sizes = [](std::stringstream &stream, contributor_args_t const *context) -> void
+    {
+      if (context) stream << ". Size: (" << context->portions.size() << "), Addresses Size: (" << context->addresses.size() << ")";
+    };
+
+    std::stringstream stream;
+    using result_code = validate_contributor_args_result;
+    switch(error)
+    {
+      case result_code::portions_mismatch:
+      {
+        stream << "Contribution portions array has an invalid or mismatching size with the contributor addresses";
+        report_portion_and_address_sizes(stream, context);
+      }
+      break;
+
+      case result_code::incorrect_portions:
+      {
+        stream << "One or more contribution portions values were incorrect";
+        report_portions(stream, context);
+      }
+      break;
+
+      case result_code::operator_portions_too_much:
+      {
+        stream << "Operator portions exceeded maximum portions: " << STAKING_PORTIONS;
+        if (context) stream << "Given portions: "<< context->portions_for_operator;
+      }
+      break;
+
+      case result_code::registration_hash_failed:
+      {
+        stream << "Failed to generate the registration hash, possible reasons: portions/addresses array sizes don't match or portions specified incorrect";
+        report_portion_and_address_sizes(stream, context);
+        report_portions(stream, context);
+      }
+      break;
+
+      case result_code::invalid_service_node_key:
+      {
+        stream << "Service Node Key was not a valid public key";
+        if (service_node_key) stream << ". " << *service_node_key;
+      }
+      break;
+
+      case result_code::invalid_signature:
+      {
+        stream << "Signature could not be verified with service node key";
+        if (service_node_key) stream << ". Service Node Key " << *service_node_key;
+        if (signature) stream << ". Signature " << *signature;
+      }
+      break;
+
+      case result_code::success: stream << "Validated successfully"; break;
+      default: stream << "xx: Unhandled error code: " << static_cast<int>(error);
+      break;
+    }
+
+    stream << ". ";
+    return stream.str();
+  }
+
+
+  struct parsed_tx_contribution
+  {
+    cryptonote::account_public_address address;
+    uint64_t transferred;
+    crypto::secret_key tx_key;
+    std::vector<service_node_info::contribution_t> locked_contributions;
+  };
 
   static uint64_t get_staking_output_contribution(const cryptonote::transaction& tx, int i, crypto::key_derivation const &derivation, hw::device& hwdev)
   {
@@ -805,48 +929,20 @@ namespace service_nodes
 
   bool is_registration_tx(cryptonote::network_type nettype, uint8_t hf_version, const cryptonote::transaction& tx, uint64_t block_timestamp, uint64_t block_height, uint32_t index, crypto::public_key& key, service_node_info& info)
   {
+    contributor_args_t contributor_args = {};
     crypto::public_key service_node_key;
-    std::vector<cryptonote::account_public_address> service_node_addresses;
-    std::vector<uint64_t> service_node_portions;
-    uint64_t portions_for_operator;
     uint64_t expiration_timestamp;
     crypto::signature signature;
 
-    if (!reg_tx_extract_fields(tx, service_node_addresses, portions_for_operator, service_node_portions, expiration_timestamp, service_node_key, signature))
+    if (!reg_tx_extract_fields(tx, contributor_args, expiration_timestamp, service_node_key, signature))
       return false;
 
-    if (service_node_portions.size() != service_node_addresses.size() || service_node_portions.empty())
+    validate_contributor_args_result validate_result = service_nodes::validate_contributor_args(hf_version, contributor_args, &expiration_timestamp, &service_node_key, &signature);
+    if (validate_result != validate_contributor_args_result::success)
     {
-      LOG_PRINT_L1("Register TX: Extracted portions size: (" << service_node_portions.size() <<
-                   ") was empty or did not match address size: (" << service_node_addresses.size() <<
-                   ") on height: " << block_height <<
-                   " for tx: " << cryptonote::get_transaction_hash(tx));
-      return false;
-    }
-
-    if (!check_service_node_portions(hf_version, service_node_portions)) return false;
-
-    if (portions_for_operator > STAKING_PORTIONS)
-    {
-      LOG_PRINT_L1("Register TX: Operator portions: " << portions_for_operator <<
-                   " exceeded staking portions: " << STAKING_PORTIONS <<
-                   " on height: " << block_height <<
-                   " for tx: " << cryptonote::get_transaction_hash(tx));
-      return false;
-    }
-
-    // check the signature is all good
-
-    crypto::hash hash;
-    if (!get_registration_hash(service_node_addresses, portions_for_operator, service_node_portions, expiration_timestamp, hash))
-    {
-      LOG_PRINT_L1("Register TX: Failed to extract registration hash, on height: " << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
-      return false;
-    }
-
-    if (!crypto::check_key(service_node_key) || !crypto::check_signature(hash, service_node_key, signature))
-    {
-      LOG_PRINT_L1("Register TX: Has invalid key and/or signature, on height: " << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
+      LOG_PRINT_L1("Register TX: " << cryptonote::get_transaction_hash(tx) <<
+                   ", Height: " << block_height << ". " <<
+                   validate_contributor_args_result_string(validate_result, &contributor_args, &service_node_key, &signature));
       return false;
     }
 
@@ -878,8 +974,8 @@ namespace service_nodes
       return false;
     }
 
-    size_t total_num_of_addr = service_node_addresses.size();
-    if (std::find(service_node_addresses.begin(), service_node_addresses.end(), stake.address) == service_node_addresses.end())
+    size_t total_num_of_addr = contributor_args.addresses.size();
+    if (std::find(contributor_args.addresses.begin(), contributor_args.addresses.end(), stake.address) == contributor_args.addresses.end())
       total_num_of_addr++;
 
     if (total_num_of_addr > MAX_NUMBER_OF_CONTRIBUTORS)
@@ -896,8 +992,8 @@ namespace service_nodes
     key = service_node_key;
 
     info.staking_requirement           = staking_requirement;
-    info.operator_address              = service_node_addresses[0];
-    info.portions_for_operator         = portions_for_operator;
+    info.operator_address              = contributor_args.addresses[0];
+    info.portions_for_operator         = contributor_args.portions_for_operator;
     info.registration_height           = block_height;
     info.registration_hf_version       = hf_version;
     info.last_reward_block_height      = block_height;
@@ -906,24 +1002,24 @@ namespace service_nodes
     info.last_ip_change_height         = block_height;
     info.version                       = get_min_service_node_info_version_for_hf(hf_version);
 
-    for (size_t i = 0; i < service_node_addresses.size(); i++)
+    for (size_t i = 0; i < contributor_args.addresses.size(); i++)
     {
       // Check for duplicates
-      auto iter = std::find(service_node_addresses.begin(), service_node_addresses.begin() + i, service_node_addresses[i]);
-      if (iter != service_node_addresses.begin() + i)
+      auto iter = std::find(contributor_args.addresses.begin(), contributor_args.addresses.begin() + i, contributor_args.addresses[i]);
+      if (iter != contributor_args.addresses.begin() + i)
       {
         LOG_PRINT_L1("Register TX: There was a duplicate participant for service node on height: " << block_height << " for tx: " << cryptonote::get_transaction_hash(tx));
         return false;
       }
 
       uint64_t hi, lo, resulthi, resultlo;
-      lo = mul128(info.staking_requirement, service_node_portions[i], &hi);
+      lo = mul128(info.staking_requirement, contributor_args.portions[i], &hi);
       div128_64(hi, lo, STAKING_PORTIONS, &resulthi, &resultlo);
 
       info.contributors.emplace_back();
       auto &contributor = info.contributors.back();
       contributor.reserved                         = resultlo;
-      contributor.address                          = service_node_addresses[i];
+      contributor.address                          = contributor_args.addresses[i];
       info.total_reserved += resultlo;
     }
 
@@ -2434,12 +2530,12 @@ namespace service_nodes
     return result;
   }
 
-  converted_registration_args convert_registration_args(cryptonote::network_type nettype,
-                                                        const std::vector<std::string>& args,
-                                                        uint64_t staking_requirement,
-                                                        uint8_t hf_version)
+  contributor_args_t convert_registration_args(cryptonote::network_type nettype,
+                                               const std::vector<std::string> &args,
+                                               uint64_t staking_requirement,
+                                               uint8_t hf_version)
   {
-    converted_registration_args result = {};
+    contributor_args_t result = {};
     if (args.size() % 2 == 0 || args.size() < 3)
     {
       result.err_msg = tr("Usage: <operator cut> <address> <fraction> [<address> <fraction> [...]]]");
@@ -2612,17 +2708,17 @@ namespace service_nodes
       boost::optional<std::string&> err_msg)
   {
 
-    converted_registration_args converted_args = convert_registration_args(nettype, args, staking_requirement, hf_version);
-    if (!converted_args.success)
+    contributor_args_t contributor_args = convert_registration_args(nettype, args, staking_requirement, hf_version);
+    if (!contributor_args.success)
     {
-      MERROR(tr("Could not convert registration args, reason: ") << converted_args.err_msg);
+      MERROR(tr("Could not convert registration args, reason: ") << contributor_args.err_msg);
       return false;
     }
 
     uint64_t exp_timestamp = time(nullptr) + STAKING_AUTHORIZATION_EXPIRATION_WINDOW;
 
     crypto::hash hash;
-    bool hashed = cryptonote::get_registration_hash(converted_args.addresses, converted_args.portions_for_operator, converted_args.portions, exp_timestamp, hash);
+    bool hashed = cryptonote::get_registration_hash(contributor_args.addresses, contributor_args.portions_for_operator, contributor_args.portions, exp_timestamp, hash);
     if (!hashed)
     {
       MERROR(tr("Could not make registration hash from addresses and portions"));

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -586,20 +586,10 @@ namespace service_nodes
                                                uint64_t staking_requirement,
                                                uint8_t hf_version);
 
-  enum struct validate_contributor_args_result
-  {
-    success,
-    portions_mismatch,
-    incorrect_portions,
-    operator_portions_too_much,
-    registration_hash_failed,
-    invalid_service_node_key,
-    invalid_signature,
-  };
-
-  // expiration_timestamp, service_node_key, signature: (Optional): If given, verify the signature with the registration hash using contributor args
-  validate_contributor_args_result validate_contributor_args(uint8_t hf_version, contributor_args_t const &contributor_args, uint64_t const *expiration_timestamp, crypto::public_key const *service_node_key, crypto::signature const *signature);
-  std::string                      validate_contributor_args_result_string(validate_contributor_args_result error, contributor_args_t const *context, crypto::public_key const *service_node_key, crypto::signature const *signature);
+  // validate_contributors_* functions throws invalid_contributions exception
+  struct invalid_contributions : std::invalid_argument { using std::invalid_argument::invalid_argument; };
+  void validate_contributor_args(uint8_t hf_version, contributor_args_t const &contributor_args);
+  void validate_contributor_args_signature(contributor_args_t const &contributor_args, uint64_t const expiration_timestamp, crypto::public_key const &service_node_key, crypto::signature const &signature);
 
   bool make_registration_cmd(cryptonote::network_type nettype,
       uint8_t hf_version,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8155,7 +8155,7 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
   }
 
   uint64_t staking_requirement = 0, bc_height = 0;
-  service_nodes::converted_registration_args converted_args = {};
+  service_nodes::contributor_args_t contributor_args = {};
   {
     std::string err, err2;
     bc_height = std::max(get_daemon_blockchain_height(err),
@@ -8178,18 +8178,18 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
     }
 
     staking_requirement = service_nodes::get_staking_requirement(nettype(), bc_height, *hf_version);
-    std::vector<std::string> const registration_args(local_args.begin(), local_args.begin() + local_args.size() - 3);
-    converted_args = service_nodes::convert_registration_args(nettype(), registration_args, staking_requirement, *hf_version);
+    std::vector<std::string> const args(local_args.begin(), local_args.begin() + local_args.size() - 3);
+    contributor_args = service_nodes::convert_registration_args(nettype(), args, staking_requirement, *hf_version);
 
-    if (!converted_args.success)
+    if (!contributor_args.success)
     {
       result.status = register_service_node_result_status::convert_registration_args_failed;
-      result.msg = tr("Could not convert registration args, reason: ") + converted_args.err_msg;
+      result.msg = tr("Could not convert registration args, reason: ") + contributor_args.err_msg;
       return result;
     }
   }
 
-  cryptonote::account_public_address address = converted_args.addresses[0];
+  cryptonote::account_public_address address = contributor_args.addresses[0];
   if (!contains_address(address))
   {
     result.status = register_service_node_result_status::first_address_must_be_primary_address;
@@ -8243,13 +8243,20 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
       result.msg = tr("Failed to parse service node signature");
       return result;
     }
+  }
 
+  auto validate_result = service_nodes::validate_contributor_args(*hf_version, contributor_args, &expiration_timestamp, &service_node_key, &signature); // Client side signature/contributor check
+  if (validate_result != service_nodes::validate_contributor_args_result::success)
+  {
+    result.status = register_service_node_result_status::validate_contributor_args_fail;
+    result.msg    = validate_contributor_args_result_string(validate_result, &contributor_args, &service_node_key, &signature);
+    return result;
   }
 
   std::vector<uint8_t> extra;
   add_service_node_contributor_to_tx_extra(extra, address);
   add_service_node_pubkey_to_tx_extra(extra, service_node_key);
-  if (!add_service_node_register_to_tx_extra(extra, converted_args.addresses, converted_args.portions_for_operator, converted_args.portions, expiration_timestamp, signature))
+  if (!add_service_node_register_to_tx_extra(extra, contributor_args.addresses, contributor_args.portions_for_operator, contributor_args.portions, expiration_timestamp, signature))
   {
     result.status = register_service_node_result_status::service_node_register_serialize_to_tx_extra_fail;
     result.msg    = tr("Failed to serialize service node registration tx extra");
@@ -8286,9 +8293,9 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
     {
       const uint64_t DUST                 = MAX_NUMBER_OF_CONTRIBUTORS;
       uint64_t amount_left                = staking_requirement;
-      for (size_t i = 0; i < converted_args.portions.size(); i++)
+      for (size_t i = 0; i < contributor_args.portions.size(); i++)
       {
-        uint64_t amount = service_nodes::portions_to_amount(staking_requirement, converted_args.portions[i]);
+        uint64_t amount = service_nodes::portions_to_amount(staking_requirement, contributor_args.portions[i]);
         if (i == 0) amount_payable_by_operator += amount;
         amount_left -= amount;
       }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8245,11 +8245,15 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
     }
   }
 
-  auto validate_result = service_nodes::validate_contributor_args(*hf_version, contributor_args, &expiration_timestamp, &service_node_key, &signature); // Client side signature/contributor check
-  if (validate_result != service_nodes::validate_contributor_args_result::success)
+  try
+  {
+      service_nodes::validate_contributor_args(*hf_version, contributor_args);
+      service_nodes::validate_contributor_args_signature(contributor_args, expiration_timestamp, service_node_key, signature);
+  }
+  catch(const service_nodes::invalid_contributions &e)
   {
     result.status = register_service_node_result_status::validate_contributor_args_fail;
-    result.msg    = validate_contributor_args_result_string(validate_result, &contributor_args, &service_node_key, &signature);
+    result.msg    = e.what();
     return result;
   }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1527,6 +1527,7 @@ private:
       convert_registration_args_failed,
       registration_timestamp_expired,
       registration_timestamp_parse_fail,
+      validate_contributor_args_fail,
       service_node_key_parse_fail,
       service_node_signature_parse_fail,
       service_node_register_serialize_to_tx_extra_fail,


### PR DESCRIPTION
This should catch copy paste errors from prepare_registration ever making it onto the blockchain.

- `converted_registration_args` -> `contributor_args_t`
- `reg_tx_extract_fields` uses `contributor_args_t` instead of requesting every field
- add new validate function for `contribution_args_t`
- `process_registration_tx` and `create_registration_tx` use the same validation check `validate_contribution_args(...) `