### PR TITLE
Fix upgrade, memory leak, abstract sqlite3 interface

### DIFF
--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1053,7 +1053,9 @@ namespace cryptonote
      */
     bool blink_rollback(uint64_t rollback_height);
 
-    lns::name_system_db const &name_system_db() { return m_lns_db; }
+    lns::name_system_db &name_system_db() { return m_lns_db; }
+
+    const lns::name_system_db &name_system_db() const { return m_lns_db; }
 
 #ifndef IN_UNIT_TESTS
   private:

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -1544,6 +1544,13 @@ AND NOT EXISTS   (SELECT * FROM "mappings" WHERE "owner"."id" = "mappings"."back
   return true;
 }
 
+name_system_db::~name_system_db()
+{
+  // close_v2 starts shutting down; the actual shutdown occurs once the last prepared statement is
+  // finalized (which should happen when the ..._sql members get destructed, right after this).
+  sqlite3_close_v2(db);
+}
+
 static int64_t add_or_get_owner_id(lns::name_system_db &lns_db, crypto::hash const &tx_hash, cryptonote::tx_extra_loki_name_system const &entry, lns::generic_owner const &key)
 {
   int64_t result = 0;

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -180,6 +180,7 @@ bool bind(sql_compiled_statement& s, int index, lokimq::string_view text)
   return SQLITE_OK == sqlite3_bind_text(s.statement, index, text.data(), text.size(), nullptr /*dtor*/);
 }
 
+/* Currently unused; comment out until needed to avoid a compiler warning
 // text, from a temporary std::string; ownership of the string data is transferred to sqlite3
 bool bind(sql_compiled_statement& s, int index, std::string&& text)
 {
@@ -191,11 +192,13 @@ bool bind(sql_compiled_statement& s, int index, std::string&& text)
   delete local_text;
   return false;
 }
+*/
 
 template <typename T, typename SFINAE = void>
 struct is_int_enum : std::false_type {};
 template <typename T>
-struct is_int_enum<T, std::enable_if_t<std::is_enum<T>::value && std::is_same<std::underlying_type_t<T>, int>::value>> : std::true_type {};
+struct is_int_enum<T, std::enable_if_t<std::is_enum<T>::value>>
+: std::integral_constant<bool, std::is_same<std::underlying_type_t<T>, int>::value> {};
 
 // Binds, but gives index as an enum class
 template <typename T, typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>
@@ -218,6 +221,7 @@ bool bind_blob(sql_compiled_statement& s, int index, lokimq::string_view blob)
   return SQLITE_OK == sqlite3_bind_blob(s.statement, index, blob.data(), blob.size(), nullptr /*dtor*/);
 }
 
+/* Currently unused; comment out until needed to avoid a compiler warning
 // From a std::string rvalue; sqlite3 manages ownership
 bool bind_blob(sql_compiled_statement& s, int index, std::string&& blob)
 {
@@ -229,6 +233,7 @@ bool bind_blob(sql_compiled_statement& s, int index, std::string&& blob)
   delete local_blob;
   return false;
 }
+*/
 
 // Wrapper for bind_blob with an enum index
 template <typename... T, typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -124,7 +124,9 @@ std::string lns::mapping_value::to_readable_value(cryptonote::network_type netty
   return result;
 }
 
-static std::string lns_extra_string(cryptonote::network_type nettype, cryptonote::tx_extra_loki_name_system const &data)
+namespace {
+
+std::string lns_extra_string(cryptonote::network_type nettype, cryptonote::tx_extra_loki_name_system const &data)
 {
   std::stringstream stream;
   stream << "LNS Extra={";
@@ -140,59 +142,254 @@ static std::string lns_extra_string(cryptonote::network_type nettype, cryptonote
   return stream.str();
 }
 
-static bool sql_copy_blob(sqlite3_stmt *statement, int column, void *dest, int dest_size)
-{
-  void const *blob = sqlite3_column_blob(statement, column);
-  int blob_len     = sqlite3_column_bytes(statement, column);
-  if (blob_len != dest_size)
-  {
-    LOG_PRINT_L0("Unexpected blob size=" << blob_len << ", in LNS DB does not match expected size=" << dest_size);
-    assert(blob_len == dest_size);
-    return false;
-  }
+/// Clears any existing bindings
+bool clear_bindings(sql_compiled_statement& s) {
+  return SQLITE_OK == sqlite3_clear_bindings(s.statement);
+}
 
-  memcpy(dest, blob, blob_len);
+/// Resets
+bool reset(sql_compiled_statement& s) {
+  return SQLITE_OK == sqlite3_reset(s.statement);
+}
+
+int step(sql_compiled_statement& s)
+{
+  return sqlite3_step(s.statement);
+}
+
+
+/// `bind()` binds a particular parameter to a statement by index.  The bind type is inferred from
+/// the argument.
+
+// Small (<=32 bits) integers
+template <typename T, std::enable_if_t<std::is_integral<T>::value && (sizeof(T) <= 32), int> = 0>
+bool bind(sql_compiled_statement& s, int index, const T& val) { return SQLITE_OK == sqlite3_bind_int(s.statement, index, val); }
+
+// Big (>32 bits) integers
+template <typename T, std::enable_if_t<std::is_integral<T>::value && (sizeof(T) > 32), int> = 0>
+bool bind(sql_compiled_statement& s, int index, const T& val) { return SQLITE_OK == sqlite3_bind_int64(s.statement, index, val); }
+
+// Floats/doubles
+template <typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+bool bind(sql_compiled_statement& s, int index, const T& val) { return SQLITE_OK == sqlite3_bind_double(s.statement, index, val); }
+
+
+// text, from a referenced string (which must be kept alive)
+bool bind(sql_compiled_statement& s, int index, lokimq::string_view text)
+{
+  return SQLITE_OK == sqlite3_bind_text(s.statement, index, text.data(), text.size(), nullptr /*dtor*/);
+}
+
+// text, from a temporary std::string; ownership of the string data is transferred to sqlite3
+bool bind(sql_compiled_statement& s, int index, std::string&& text)
+{
+  // Assume ownership and let sqlite3 destroy when finished
+  auto local_text = new std::string{std::move(text)};
+  if (SQLITE_OK == sqlite3_bind_text(s.statement, index, local_text->data(), local_text->size(),
+      [](void* local) { delete reinterpret_cast<std::string*>(local); }))
+    return true;
+  delete local_text;
+  return false;
+}
+
+template <typename T, typename SFINAE = void>
+struct is_int_enum : std::false_type {};
+template <typename T>
+struct is_int_enum<T, std::enable_if_t<std::is_enum<T>::value && std::is_same<std::underlying_type_t<T>, int>::value>> : std::true_type {};
+
+// Binds, but gives index as an enum class
+template <typename T, typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>
+bool bind(sql_compiled_statement& s, I index, T&& val)
+{
+  return lns::bind(s, static_cast<int>(index), std::forward<T>(val));
+}
+
+// Blob binding; these have a different name so as to not conflict with text binding.
+//
+// from a referenced pointer and length (NOTE THE _blob SUFFIX IN THE NAME)
+bool bind_blob(sql_compiled_statement& s, int index, const void* data, size_t len)
+{
+  return SQLITE_OK == sqlite3_bind_blob(s.statement, index, data, len, nullptr /*dtor*/);
+}
+
+// from a string_view
+bool bind_blob(sql_compiled_statement& s, int index, lokimq::string_view blob)
+{
+  return SQLITE_OK == sqlite3_bind_blob(s.statement, index, blob.data(), blob.size(), nullptr /*dtor*/);
+}
+
+// From a std::string rvalue; sqlite3 manages ownership
+bool bind_blob(sql_compiled_statement& s, int index, std::string&& blob)
+{
+  // Assume ownership and let sqlite3 destroy when finished
+  auto local_blob = new std::string{std::move(blob)};
+  if (SQLITE_OK == sqlite3_bind_blob(s.statement, index, local_blob->data(), local_blob->size(),
+      [](void* local) { delete reinterpret_cast<std::string*>(local); }))
+    return true;
+  delete local_blob;
+  return false;
+}
+
+// Wrapper for bind_blob with an enum index
+template <typename... T, typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>
+bool bind_blob(sql_compiled_statement& s, I index, T&&... args)
+{
+  return bind_blob(s, static_cast<int>(index), std::forward<T>(args)...);
+}
+
+// Simple wrapper around a string_view so that you can pass a blob into `bind_all` by wrapping it
+// with a `blob_view` such as:
+//
+// bind_all(s, 123, "text", blob_view{data, size});
+//
+struct blob_view {
+  lokimq::string_view data;
+  /// Constructor that simply forwards anything to the `data` member constructor
+  template <typename... T> explicit blob_view(T&&... args) : data{std::forward<T>(args)...} {}
+};
+template <typename I>
+bool bind(sql_compiled_statement& s, I index, blob_view blob) {
+  return bind_blob(s, index, blob.data);
+}
+
+template <int... I, typename... T>
+bool bind_all_impl(sql_compiled_statement& s, std::integer_sequence<int, I...>, T&&... args) {
+  clear_bindings(s);
+  for (bool r : {lns::bind(s, I+1, std::forward<T>(args))...})
+    if (!r)
+      return false;
   return true;
 }
 
-static mapping_record sql_get_mapping_from_statement(sqlite3_stmt *statement)
+// Full statement binding; this lets you do something like:
+//
+// bind_all(st, 1, "hi", 123);
+//
+// which is equivalent to:
+//
+// clear_bindings(st);
+// st.bind(st, 1, 1);
+// st.bind(st, 2, "hi");
+// st.bind(st, 3, 123);
+//
+// (Binding of blobs through this interface is not supported).
+template <typename... T>
+bool bind_all(sql_compiled_statement& s, T&&... args)
+{
+  return bind_all_impl(s, std::make_integer_sequence<int, sizeof...(T)>{}, std::forward<T>(args)...);
+}
+
+
+/// Retrieve a type from an executed statement.
+
+// Small (<=32 bits) integers
+template <typename T, std::enable_if_t<std::is_integral<T>::value && (sizeof(T) <= 32), int> = 0>
+T get(sql_compiled_statement& s, int index) { return static_cast<T>(sqlite3_column_int(s.statement, index)); }
+
+// Big (>32 bits) integers
+template <typename T, std::enable_if_t<std::is_integral<T>::value && (sizeof(T) > 32), int> = 0>
+T get(sql_compiled_statement& s, int index) { return static_cast<T>(sqlite3_column_int64(s.statement, index)); }
+
+// Floats/doubles
+template <typename T, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+T get(sql_compiled_statement& s, int index) { return static_cast<T>(sqlite3_column_double(s.statement, index)); }
+
+// text, via a string_view pointing at the text data
+template <typename T, std::enable_if_t<std::is_same<T, lokimq::string_view>::value, int> = 0>
+lokimq::string_view get(sql_compiled_statement& s, int index)
+{
+  return {reinterpret_cast<const char*>(sqlite3_column_text(s.statement, index)),
+          static_cast<size_t>(sqlite3_column_bytes(s.statement, index))};
+}
+
+// text, copied into a std::string
+template <typename T, std::enable_if_t<std::is_same<T, std::string>::value, int> = 0>
+std::string get(sql_compiled_statement& s, int index)
+{
+  return {reinterpret_cast<const char*>(sqlite3_column_text(s.statement, index)),
+          static_cast<size_t>(sqlite3_column_bytes(s.statement, index))};
+}
+
+// Forwards to any of the above, but takes an enum class instead of an int
+template <typename T, typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>
+T get(sql_compiled_statement& s, I index)
+{
+  return get<T>(s, static_cast<int>(index));
+}
+
+
+// Wrapper around get that assigns to the given reference.
+//     get(st, 3, myvar);
+// is equivalent to:
+//     myvar = get<decltype(myvar)>(st, 3)
+template <typename T, typename I>
+void get(sql_compiled_statement& s, I index, T& val) { val = get<T>(s, index); }
+
+// blob, via a string_view
+lokimq::string_view get_blob(sql_compiled_statement& s, int index)
+{
+  return {reinterpret_cast<const char*>(sqlite3_column_blob(s.statement, index)),
+          static_cast<size_t>(sqlite3_column_bytes(s.statement, index))};
+}
+
+// blob, via a string_view
+template <typename I, std::enable_if_t<is_int_enum<I>::value, int> = 0>
+lokimq::string_view get_blob(sql_compiled_statement& s, I index)
+{
+  return get_blob(s, static_cast<int>(index));
+}
+
+template <typename I>
+bool sql_copy_blob(sql_compiled_statement& statement, I column, void *dest, size_t dest_size)
+{
+  auto blob = get_blob(statement, column);
+  if (blob.size() != dest_size)
+  {
+    LOG_PRINT_L0("Unexpected blob size=" << blob.size() << ", in LNS DB does not match expected size=" << dest_size);
+    assert(blob.size() == dest_size);
+    return false;
+  }
+
+  memcpy(dest, blob.data(), blob.size());
+  return true;
+}
+
+mapping_record sql_get_mapping_from_statement(sql_compiled_statement& statement)
 {
   mapping_record result = {};
-  int type_int = static_cast<uint16_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_column::type)));
+  auto type_int = get<uint16_t>(statement, mapping_record_column::type);
   if (type_int >= tools::enum_count<mapping_type>)
     return result;
 
-  result.type            = static_cast<mapping_type>(type_int);
-  result.id              = static_cast<int64_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_column::id)));
-  result.register_height = static_cast<uint64_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_column::register_height)));
-  result.update_height   = static_cast<uint64_t>(sqlite3_column_int(statement, static_cast<int>(mapping_record_column::update_height)));
-  result.owner_id        = sqlite3_column_int(statement, static_cast<int>(mapping_record_column::owner_id));
-  result.backup_owner_id = sqlite3_column_int(statement, static_cast<int>(mapping_record_column::backup_owner_id));
+  result.type = static_cast<mapping_type>(type_int);
+  get(statement, mapping_record_column::id, result.id);
+  get(statement, mapping_record_column::register_height, result.register_height);
+  get(statement, mapping_record_column::update_height, result.update_height);
+  get(statement, mapping_record_column::owner_id, result.owner_id);
+  get(statement, mapping_record_column::backup_owner_id, result.backup_owner_id);
 
   // Copy encrypted_value
   {
-    size_t value_len = static_cast<size_t>(sqlite3_column_bytes(statement, static_cast<int>(mapping_record_column::encrypted_value)));
-    auto *value      = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_column::encrypted_value)));
-    if (value_len > result.encrypted_value.buffer.size())
+    auto value = get<lokimq::string_view>(statement, mapping_record_column::encrypted_value);
+    if (value.size() > result.encrypted_value.buffer.size())
     {
-      MERROR("Unexpected encrypted value blob with size=" << value_len << ", in LNS db larger than the available size=" << result.encrypted_value.buffer.size());
+      MERROR("Unexpected encrypted value blob with size=" << value.size() << ", in LNS db larger than the available size=" << result.encrypted_value.buffer.size());
       return result;
     }
-    result.encrypted_value.len = value_len;
-    memcpy(&result.encrypted_value.buffer[0], value, value_len);
+    result.encrypted_value.len = value.size();
+    memcpy(&result.encrypted_value.buffer[0], value.data(), value.size());
   }
 
   // Copy name hash
   {
-    size_t value_len = static_cast<size_t>(sqlite3_column_bytes(statement, static_cast<int>(mapping_record_column::name_hash)));
-    auto *value      = reinterpret_cast<char const *>(sqlite3_column_text(statement, static_cast<int>(mapping_record_column::name_hash)));
-    result.name_hash.append(value, value_len);
+    auto value = get<lokimq::string_view>(statement, mapping_record_column::name_hash);
+    result.name_hash.append(value.data(), value.size());
   }
 
-  if (!sql_copy_blob(statement, static_cast<int>(mapping_record_column::txid), result.txid.data, sizeof(result.txid)))
+  if (!sql_copy_blob(statement, mapping_record_column::txid, result.txid.data, sizeof(result.txid)))
     return result;
 
-  if (!sql_copy_blob(statement, static_cast<int>(mapping_record_column::prev_txid), result.prev_txid.data, sizeof(result.prev_txid)))
+  if (!sql_copy_blob(statement, mapping_record_column::prev_txid, result.prev_txid.data, sizeof(result.prev_txid)))
     return result;
 
   int owner_column = tools::enum_count<mapping_record_column>;
@@ -209,14 +406,15 @@ static mapping_record sql_get_mapping_from_statement(sqlite3_stmt *statement)
   return result;
 }
 
-static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type type, sqlite3_stmt *statement, void *context)
+bool sql_run_statement(lns_sql_type type, sql_compiled_statement& statement, void *context)
 {
+  assert(statement);
   bool data_loaded = false;
   bool result      = false;
 
   for (bool infinite_loop = true; infinite_loop;)
   {
-    int step_result = sqlite3_step(statement);
+    int step_result = step(statement);
     switch (step_result)
     {
       case SQLITE_ROW:
@@ -229,8 +427,8 @@ static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type typ
           case lns_sql_type::get_owner:
           {
             auto *entry = reinterpret_cast<owner_record *>(context);
-            entry->id   = sqlite3_column_int(statement, static_cast<int>(owner_record_column::id));
-            if (!sql_copy_blob(statement, static_cast<int>(owner_record_column::address), reinterpret_cast<void *>(&entry->address), sizeof(entry->address)))
+            get(statement, owner_record_column::id, entry->id);
+            if (!sql_copy_blob(statement, owner_record_column::address, reinterpret_cast<void *>(&entry->address), sizeof(entry->address)))
               return false;
             data_loaded = true;
           }
@@ -239,10 +437,10 @@ static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type typ
           case lns_sql_type::get_setting:
           {
             auto *entry       = reinterpret_cast<settings_record *>(context);
-            entry->top_height = static_cast<uint64_t>(sqlite3_column_int64(statement, static_cast<int>(lns_db_setting_column::top_height)));
-            if (!sql_copy_blob(statement, static_cast<int>(lns_db_setting_column::top_hash), entry->top_hash.data, sizeof(entry->top_hash.data)))
+            get(statement, lns_db_setting_column::top_height, entry->top_height);
+            if (!sql_copy_blob(statement, lns_db_setting_column::top_hash, entry->top_hash.data, sizeof(entry->top_hash.data)))
               return false;
-            entry->version = sqlite3_column_int(statement, static_cast<int>(lns_db_setting_column::version));
+            get(statement, lns_db_setting_column::version, entry->version);
             data_loaded = true;
           }
           break;
@@ -283,17 +481,31 @@ static bool sql_run_statement(cryptonote::network_type nettype, lns_sql_type typ
 
       default:
       {
-        LOG_PRINT_L1("Failed to execute statement: " << sqlite3_sql(statement) <<", reason: " << sqlite3_errstr(step_result));
+        LOG_PRINT_L1("Failed to execute statement: " << sqlite3_sql(statement.statement) <<", reason: " << sqlite3_errstr(step_result));
         infinite_loop = false;
         break;
       }
     }
   }
 
-  sqlite3_reset(statement);
-  sqlite3_clear_bindings(statement);
+  reset(statement);
+  clear_bindings(statement);
   return result;
 }
+
+/// Does a clear_bindings, bind_all, and then sql_run_statement.  First three arguments go to
+/// sql_run_statement, the rest go to bind_all(statement, ...) (which does the clear_bindings).
+template <typename... T>
+bool bind_and_run(lns_sql_type type, sql_compiled_statement& statement, void *context,
+    T&&... bind_args)
+{
+  bind_all(statement, std::forward<T>(bind_args)...);
+  return sql_run_statement(type, statement, context);
+}
+
+
+} // end anonymous namespace
+
 
 bool mapping_record::active(cryptonote::network_type nettype, uint64_t blockchain_height) const
 {
@@ -303,17 +515,36 @@ bool mapping_record::active(cryptonote::network_type nettype, uint64_t blockchai
   return last_active_height >= (blockchain_height - 1);
 }
 
-static bool sql_compile_statement(sqlite3 *db, char const *query, int query_len, sqlite3_stmt **statement, bool optimise_for_multiple_usage = true)
+bool sql_compiled_statement::compile(lokimq::string_view query, bool optimise_for_multiple_usage)
 {
+  sqlite3_stmt* st;
 #if SQLITE_VERSION_NUMBER >= 3020000
-  int prepare_result = sqlite3_prepare_v3(db, query, query_len, optimise_for_multiple_usage ? SQLITE_PREPARE_PERSISTENT : 0, statement, nullptr /*pzTail*/);
+  int prepare_result = sqlite3_prepare_v3(nsdb.db, query.data(), query.size(), optimise_for_multiple_usage ? SQLITE_PREPARE_PERSISTENT : 0, &st, nullptr /*pzTail*/);
 #else
-  int prepare_result = sqlite3_prepare_v2(db, query, query_len, statement, nullptr /*pzTail*/);
+  int prepare_result = sqlite3_prepare_v2(nsdb.db, query.data(), query.size(), &st, nullptr /*pzTail*/);
 #endif
 
-  bool result        = prepare_result == SQLITE_OK;
-  if (!result) MERROR("Can not compile SQL statement:\n" << query << "\nReason: " << sqlite3_errstr(prepare_result));
-  return result;
+  if (prepare_result != SQLITE_OK) {
+    MERROR("Can not compile SQL statement:\n" << query << "\nReason: " << sqlite3_errstr(prepare_result));
+    return false;
+  }
+  if (statement)
+    sqlite3_finalize(statement);
+  statement = st;
+  return true;
+}
+
+sql_compiled_statement& sql_compiled_statement::operator=(sql_compiled_statement&& from)
+{
+  sqlite3_finalize(statement);
+  statement = from.statement;
+  from.statement = nullptr;
+  return *this;
+}
+
+sql_compiled_statement::~sql_compiled_statement()
+{
+  sqlite3_finalize(statement);
 }
 
 sqlite3 *init_loki_name_system(char const *file_path)
@@ -752,7 +983,7 @@ static bool verify_lns_signature(crypto::hash const &hash, lns::generic_signatur
   }
 }
 
-static bool validate_against_previous_mapping(lns::name_system_db const &lns_db, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system const &lns_extra, std::string *reason = nullptr)
+static bool validate_against_previous_mapping(lns::name_system_db &lns_db, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system const &lns_extra, std::string *reason = nullptr)
 {
   std::stringstream err_stream;
   LOKI_DEFER { if (reason && reason->empty()) *reason = err_stream.str(); };
@@ -850,7 +1081,7 @@ static bool validate_against_previous_mapping(lns::name_system_db const &lns_db,
   return true;
 }
 
-bool name_system_db::validate_lns_tx(uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system *lns_extra, std::string *reason) const
+bool name_system_db::validate_lns_tx(uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system *lns_extra, std::string *reason)
 {
   // -----------------------------------------------------------------------------------------------
   // Pull out LNS Extra from TX
@@ -1056,7 +1287,7 @@ CREATE TABLE IF NOT EXISTS "mappings" (
     "txid" BLOB NOT NULL,
     "prev_txid" BLOB NOT NULL,
     "register_height" INTEGER NOT NULL,
-    "update_height" INTEGER NOT NULL,
+    "update_height" INTEGER NOT NULL DEFAULT "register_height",
     "owner_id" INTEGER NOT NULL REFERENCES "owner" ("id"),
     "backup_owner_id" INTEGER REFERENCES "owner" ("id")
 );
@@ -1077,7 +1308,7 @@ CREATE INDEX IF NOT EXISTS "backup_owner_id_index" ON mappings("backup_owner_ind
   return true;
 }
 
-static std::string sql_cmd_combine_mappings_and_owner_table(char const *suffix)
+static std::string sql_cmd_combine_mappings_and_owner_table(char const *suffix = nullptr)
 {
   std::stringstream stream;
   stream <<
@@ -1164,33 +1395,24 @@ R"(DELETE FROM "owner"
 WHERE NOT EXISTS (SELECT * FROM "mappings" WHERE "owner"."id" = "mappings"."owner_id")
 AND NOT EXISTS   (SELECT * FROM "mappings" WHERE "owner"."id" = "mappings"."backup_owner_id"))";
 
-  char constexpr SAVE_MAPPING_STR[]  = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "encrypted_value", "txid", "prev_txid", "register_height", "owner_id", "backup_owner_id") VALUES (?,?,?,?,?,?,?,?))";
+  char constexpr SAVE_MAPPING_STR[]  = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "encrypted_value", "txid", "prev_txid", "register_height", "update_height", "owner_id", "backup_owner_id") VALUES (?,?,?,?,?,?,?,?,?))";
   char constexpr SAVE_OWNER_STR[]    = R"(INSERT INTO "owner" ("address") VALUES (?))";
   char constexpr SAVE_SETTINGS_STR[] = R"(INSERT OR REPLACE INTO "settings" ("id", "top_height", "top_hash", "version") VALUES (1,?,?,?))";
 
   if (!build_default_tables(db))
     return false;
 
-  if (
-      !sql_compile_statement(db, get_mappings_by_owner_str.c_str(),            get_mappings_by_owner_str.size(),            &get_mappings_by_owner_sql) ||
-      !sql_compile_statement(db, get_mappings_on_height_and_newer_str.c_str(), get_mappings_on_height_and_newer_str.size(), &get_mappings_on_height_and_newer_sql) ||
-      !sql_compile_statement(db, get_mapping_str.c_str(),                      get_mapping_str.size(),                      &get_mapping_sql) ||
-      !sql_compile_statement(db, GET_SETTINGS_STR,                             loki::array_count(GET_SETTINGS_STR),         &get_settings_sql) ||
-      !sql_compile_statement(db, GET_OWNER_BY_ID_STR,                          loki::array_count(GET_OWNER_BY_ID_STR),      &get_owner_by_id_sql) ||
-      !sql_compile_statement(db, GET_OWNER_BY_KEY_STR,                         loki::array_count(GET_OWNER_BY_KEY_STR),     &get_owner_by_key_sql) ||
-      !sql_compile_statement(db, PRUNE_MAPPINGS_STR,                           loki::array_count(PRUNE_MAPPINGS_STR),       &prune_mappings_sql) ||
-      !sql_compile_statement(db, PRUNE_OWNERS_STR,                             loki::array_count(PRUNE_OWNERS_STR),         &prune_owners_sql) ||
-      !sql_compile_statement(db, SAVE_MAPPING_STR,                             loki::array_count(SAVE_MAPPING_STR),         &save_mapping_sql) ||
-      !sql_compile_statement(db, SAVE_SETTINGS_STR,                            loki::array_count(SAVE_SETTINGS_STR),        &save_settings_sql) ||
-      !sql_compile_statement(db, SAVE_OWNER_STR,                               loki::array_count(SAVE_OWNER_STR),           &save_owner_sql)
-    )
-  {
+  if (!get_settings_sql.compile(GET_SETTINGS_STR) ||
+      !save_settings_sql.compile(SAVE_SETTINGS_STR))
     return false;
-  }
 
   // ---------------------------------------------------------------------------
   //
   // Migrate DB
+  //
+  // No statements (aside from settings) have been prepared yet, since the prepared statements we
+  // need may require migration.  This code must thus take care to locally execute or prepare
+  // whatever statements it needs.
   //
   // ---------------------------------------------------------------------------
   if (settings_record settings = get_settings())
@@ -1209,21 +1431,21 @@ AND NOT EXISTS   (SELECT * FROM "mappings" WHERE "owner"."id" = "mappings"."back
         return false;
       }
 
-      scoped_db_transaction db_transaction(*this);
-      if (!db_transaction) return false;
-      db_transaction.commit = true;
-
       if (settings.version == static_cast<decltype(settings.version)>(db_version::v0))
       {
-        char constexpr ADD_UPDATE_HEIGHT_SQL[] = R"(ALTER TABLE "mappings" ADD "update_height" INTEGER NOT NULL)";
+        scoped_db_transaction db_transaction(*this);
+        if (!db_transaction) return false;
+
+        char constexpr ADD_UPDATE_HEIGHT_SQL[] = R"(ALTER TABLE "mappings" ADD "update_height" INTEGER NOT NULL DEFAULT "register_height")";
+        // Don't check return here -- this one might fail because the column already exists; if so that's okay.
         sqlite3_exec(db, ADD_UPDATE_HEIGHT_SQL, nullptr /*callback*/, nullptr /*callback context*/, nullptr);
 
         std::vector<mapping_record> all_mappings = {};
         {
-          sqlite3_stmt *statement = get_mappings_on_height_and_newer_sql;
-          sqlite3_clear_bindings(statement);
-          sqlite3_bind_int(statement, 1 /*sql param index*/, 0);
-          sql_run_statement(nettype, lns_sql_type::get_mappings_on_height_and_newer, statement, &all_mappings);
+          sql_compiled_statement st{*this};
+          if (!st.compile(sql_cmd_combine_mappings_and_owner_table()))
+            return false;
+          sql_run_statement(lns_sql_type::get_mappings, st, &all_mappings);
         }
 
         std::vector<crypto::hash> hashes;
@@ -1232,35 +1454,41 @@ AND NOT EXISTS   (SELECT * FROM "mappings" WHERE "owner"."id" = "mappings"."back
             hashes.push_back(record.txid);
 
         char constexpr UPDATE_MAPPING_HEIGHT[] = R"(UPDATE "mappings" SET "update_height" = ? WHERE "id" = ?)";
-        sqlite3_stmt *update_mapping_height    = nullptr;
-        if (!sql_compile_statement(db, UPDATE_MAPPING_HEIGHT, loki::array_count(UPDATE_MAPPING_HEIGHT), &update_mapping_height))
-            return false;
+        sql_compiled_statement update_mapping_height{*this};
+        if (!update_mapping_height.compile(UPDATE_MAPPING_HEIGHT))
+          return false;
 
         std::vector<uint64_t> heights = blockchain->get_transactions_heights(hashes);
         for (size_t i = 0; i < all_mappings.size(); i++)
         {
-          sqlite3_clear_bindings(update_mapping_height);
-          sqlite3_bind_int(update_mapping_height, 1, heights[i]); break;
-          sqlite3_bind_int(update_mapping_height, 2, all_mappings[i].id); break;
-          sql_run_statement(nettype, lns_sql_type::internal_cmd, update_mapping_height, nullptr);
+
+          bind_and_run(lns_sql_type::internal_cmd, update_mapping_height, nullptr,
+              heights[i], all_mappings[i].id);
         }
 
         save_settings(settings.top_height, settings.top_hash, static_cast<int>(db_version::v1_track_updates));
+        db_transaction.commit = true;
       }
     }
   }
 
   // ---------------------------------------------------------------------------
   //
-  // Reupdate sql commands
+  // Prepare commonly executed sql statements
   //
   // ---------------------------------------------------------------------------
-  // Old DB's can't pre-compile statements referencing new fields if they don't have it yet
-  if (DB_VERSION >= db_version::v1_track_updates)
+  if (!get_mappings_by_owner_sql.compile(get_mappings_by_owner_str) ||
+      !get_mappings_on_height_and_newer_sql.compile(get_mappings_on_height_and_newer_str) ||
+      !get_mapping_sql.compile(get_mapping_str) ||
+      !get_owner_by_id_sql.compile(GET_OWNER_BY_ID_STR) ||
+      !get_owner_by_key_sql.compile(GET_OWNER_BY_KEY_STR) ||
+      !prune_mappings_sql.compile(PRUNE_MAPPINGS_STR) ||
+      !prune_owners_sql.compile(PRUNE_OWNERS_STR) ||
+      !save_mapping_sql.compile(SAVE_MAPPING_STR) ||
+      !save_owner_sql.compile(SAVE_OWNER_STR)
+    )
   {
-    char constexpr SAVE_MAPPING_STR_V2[] = R"(INSERT OR REPLACE INTO "mappings" ("type", "name_hash", "encrypted_value", "txid", "prev_txid", "register_height", "update_height", "owner_id", "backup_owner_id") VALUES (?,?,?,?,?,?,?,?,?))";
-    if (!sql_compile_statement(db, SAVE_MAPPING_STR_V2, loki::array_count(SAVE_MAPPING_STR_V2), &save_mapping_sql))
-      return false;
+    return false;
   }
 
   // ---------------------------------------------------------------------------
@@ -1421,35 +1649,34 @@ static bool add_lns_entry(lns::name_system_db &lns_db, uint64_t height, cryptono
 
     // Compile sql statement && bind parameters to statement
     std::string const name_hash   = hash_to_base64(entry.name_hash);
-    sqlite3_stmt *statement = nullptr;
+    sql_compiled_statement statement{lns_db};
     {
-      if (!sql_compile_statement(lns_db.db, sql_statement.c_str(), sql_statement.size(), &statement, false /*optimise_for_multiple_usage*/))
+      if (!statement.compile(sql_statement, false /*optimise_for_multiple_usage*/))
       {
         MERROR("Failed to compile SQL statement for updating LNS record=" << sql_statement);
         return false;
       }
 
       // Bind step
-      int sql_param_index = 1;
       for (size_t i = 0; i < column_count; i++)
       {
         auto column_type = columns[i];
         switch (column_type)
         {
-          case mapping_record_column::type:            sqlite3_bind_int  (statement, sql_param_index++, static_cast<uint16_t>(entry.type)); break;
-          case mapping_record_column::name_hash:       sqlite3_bind_text (statement, sql_param_index++, name_hash.data(), name_hash.size(), nullptr /*destructor*/); break;
-          case mapping_record_column::encrypted_value: sqlite3_bind_blob (statement, sql_param_index++, entry.encrypted_value.data(), entry.encrypted_value.size(), nullptr /*destructor*/); break;
-          case mapping_record_column::txid:            sqlite3_bind_blob (statement, sql_param_index++, tx_hash.data, sizeof(tx_hash), nullptr /*destructor*/); break;
-          case mapping_record_column::prev_txid:       sqlite3_bind_blob (statement, sql_param_index++, entry.prev_txid.data, sizeof(entry.prev_txid), nullptr /*destructor*/); break;
-          case mapping_record_column::owner_id:        sqlite3_bind_int64(statement, sql_param_index++, owner_id); break;
-          case mapping_record_column::backup_owner_id: sqlite3_bind_int64(statement, sql_param_index++, backup_owner_id); break;
-          case mapping_record_column::update_height:   sqlite3_bind_int64(statement, sql_param_index++, height); break;
+          case mapping_record_column::type:            bind(statement, i+1, static_cast<uint16_t>(entry.type)); break;
+          case mapping_record_column::name_hash:       bind(statement, i+1, lokimq::string_view{name_hash}); break;
+          case mapping_record_column::encrypted_value: bind(statement, i+1, blob_view{entry.encrypted_value}); break;
+          case mapping_record_column::txid:            bind(statement, i+1, blob_view{tx_hash.data, sizeof(tx_hash)}); break;
+          case mapping_record_column::prev_txid:       bind(statement, i+1, blob_view{entry.prev_txid.data, sizeof(entry.prev_txid)}); break;
+          case mapping_record_column::owner_id:        bind(statement, i+1, owner_id); break;
+          case mapping_record_column::backup_owner_id: bind(statement, i+1, backup_owner_id); break;
+          case mapping_record_column::update_height:   bind(statement, i+1, height); break;
           default: assert(false); return false;
         }
       }
     }
 
-    if (!sql_run_statement(lns_db.network_type(), lns_sql_type::save_mapping, statement, nullptr))
+    if (!sql_run_statement(lns_sql_type::save_mapping, statement, nullptr))
       return false;
   }
 
@@ -1606,12 +1833,8 @@ static std::vector<replay_lns_tx> find_lns_txs_to_replay(cryptonote::Blockchain 
 void name_system_db::block_detach(cryptonote::Blockchain const &blockchain, uint64_t new_blockchain_height)
 {
   std::vector<mapping_record> new_mappings = {};
-  {
-    sqlite3_stmt *statement = get_mappings_on_height_and_newer_sql;
-    sqlite3_clear_bindings(statement);
-    sqlite3_bind_int(statement, 1 /*sql param index*/, new_blockchain_height);
-    sql_run_statement(nettype, lns_sql_type::get_mappings_on_height_and_newer, statement, &new_mappings);
-  }
+  bind_and_run(lns_sql_type::get_mappings_on_height_and_newer, get_mappings_on_height_and_newer_sql, &new_mappings,
+      new_blockchain_height);
 
   std::vector<replay_lns_tx> txs_to_replay;
   for (auto const &mapping : new_mappings)
@@ -1631,10 +1854,9 @@ void name_system_db::block_detach(cryptonote::Blockchain const &blockchain, uint
 
 bool name_system_db::save_owner(lns::generic_owner const &owner, int64_t *row_id)
 {
-  sqlite3_stmt *statement = save_owner_sql;
-  sqlite3_clear_bindings(statement);
-  sqlite3_bind_blob(statement, 1 /*sql param index*/, &owner, sizeof(owner), nullptr /*destructor*/);
-  bool result = sql_run_statement(nettype, lns_sql_type::save_owner, statement, nullptr);
+  bool result = bind_and_run(lns_sql_type::save_owner, save_owner_sql, nullptr,
+      blob_view{reinterpret_cast<const char*>(&owner), sizeof(owner)});
+
   if (row_id) *row_id = sqlite3_last_insert_rowid(db);
   return result;
 }
@@ -1645,85 +1867,67 @@ bool name_system_db::save_mapping(crypto::hash const &tx_hash, cryptonote::tx_ex
     return false;
 
   std::string name_hash = hash_to_base64(src.name_hash);
-  sqlite3_stmt *statement = save_mapping_sql;
-  sqlite3_bind_int  (statement, static_cast<int>(mapping_record_column::type), static_cast<uint16_t>(src.type));
-  sqlite3_bind_text (statement, static_cast<int>(mapping_record_column::name_hash), name_hash.data(), name_hash.size(), nullptr /*destructor*/);
-  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_column::encrypted_value), src.encrypted_value.data(), src.encrypted_value.size(), nullptr /*destructor*/);
-  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_column::txid), tx_hash.data, sizeof(tx_hash), nullptr /*destructor*/);
-  sqlite3_bind_blob (statement, static_cast<int>(mapping_record_column::prev_txid), src.prev_txid.data, sizeof(src.prev_txid), nullptr /*destructor*/);
-  sqlite3_bind_int64(statement, static_cast<int>(mapping_record_column::register_height), static_cast<int64_t>(height));
-  sqlite3_bind_int64(statement, static_cast<int>(mapping_record_column::update_height), static_cast<int64_t>(height));
-  sqlite3_bind_int64(statement, static_cast<int>(mapping_record_column::owner_id), owner_id);
+  auto& statement = save_mapping_sql;
+  bind(statement, mapping_record_column::type, static_cast<uint16_t>(src.type));
+  bind(statement, mapping_record_column::name_hash, name_hash);
+  bind(statement, mapping_record_column::encrypted_value, blob_view{src.encrypted_value});
+  bind(statement, mapping_record_column::txid, blob_view{tx_hash.data, sizeof(tx_hash)});
+  bind(statement, mapping_record_column::prev_txid, blob_view{src.prev_txid.data, sizeof(src.prev_txid)});
+  bind(statement, mapping_record_column::register_height, height);
+  bind(statement, mapping_record_column::update_height, height);
+  bind(statement, mapping_record_column::owner_id, owner_id);
   if (backup_owner_id != 0)
   {
-    sqlite3_bind_int64(statement, static_cast<int>(mapping_record_column::backup_owner_id), backup_owner_id);
+    bind(statement, mapping_record_column::backup_owner_id, backup_owner_id);
   }
-  bool result = sql_run_statement(nettype, lns_sql_type::save_mapping, statement, nullptr);
+  bool result = sql_run_statement(lns_sql_type::save_mapping, statement, nullptr);
   return result;
 }
 
 bool name_system_db::save_settings(uint64_t top_height, crypto::hash const &top_hash, int version)
 {
-  sqlite3_stmt *statement = save_settings_sql;
-  sqlite3_bind_int64(statement, static_cast<int>(lns_db_setting_column::top_height), top_height);
-  sqlite3_bind_blob (statement, static_cast<int>(lns_db_setting_column::top_hash),   top_hash.data, sizeof(top_hash), nullptr /*destructor*/);
-  sqlite3_bind_int  (statement, static_cast<int>(lns_db_setting_column::version),    version);
-  bool result = sql_run_statement(nettype, lns_sql_type::save_setting, statement, nullptr);
+  auto& statement = save_settings_sql;
+  bind(statement, lns_db_setting_column::top_height, top_height);
+  bind(statement, lns_db_setting_column::top_hash, blob_view{top_hash.data, sizeof(top_hash)});
+  bind(statement, lns_db_setting_column::version, version);
+  bool result = sql_run_statement(lns_sql_type::save_setting, statement, nullptr);
   return result;
 }
 
 bool name_system_db::prune_db(uint64_t height)
 {
-  {
-    sqlite3_stmt *statement = prune_mappings_sql;
-    sqlite3_bind_int64(statement, 1 /*sql param index*/, height);
-    if (!sql_run_statement(nettype, lns_sql_type::pruning, statement, nullptr)) return false;
-  }
-
-  {
-    sqlite3_stmt *statement = prune_owners_sql;
-    if (!sql_run_statement(nettype, lns_sql_type::pruning, statement, nullptr)) return false;
-  }
+  if (!bind_and_run(lns_sql_type::pruning, prune_mappings_sql, nullptr, height)) return false;
+  if (!sql_run_statement(lns_sql_type::pruning, prune_owners_sql, nullptr)) return false;
 
   this->last_processed_height = (height - 1);
   return true;
 }
 
-owner_record name_system_db::get_owner_by_key(lns::generic_owner const &owner) const
+owner_record name_system_db::get_owner_by_key(lns::generic_owner const &owner)
 {
-  sqlite3_stmt *statement = get_owner_by_key_sql;
-  sqlite3_clear_bindings(statement);
-  sqlite3_bind_blob(statement, 1 /*sql param index*/, &owner, sizeof(owner), nullptr /*destructor*/);
-
   owner_record result = {};
-  result.loaded      = sql_run_statement(nettype, lns_sql_type::get_owner, statement, &result);
+  result.loaded       = bind_and_run(lns_sql_type::get_owner, get_owner_by_key_sql, &result,
+      blob_view{reinterpret_cast<const char*>(&owner), sizeof(owner)});
   return result;
 }
 
-owner_record name_system_db::get_owner_by_id(int64_t owner_id) const
+owner_record name_system_db::get_owner_by_id(int64_t owner_id)
 {
-  sqlite3_stmt *statement = get_owner_by_id_sql;
-  sqlite3_clear_bindings(statement);
-  sqlite3_bind_int(statement, 1 /*sql param index*/, owner_id);
-
   owner_record result = {};
-  result.loaded      = sql_run_statement(nettype, lns_sql_type::get_owner, statement, &result);
+  result.loaded       = bind_and_run(lns_sql_type::get_owner, get_owner_by_id_sql, &result,
+      owner_id);
   return result;
 }
 
-mapping_record name_system_db::get_mapping(mapping_type type, std::string const &name_base64_hash) const
+mapping_record name_system_db::get_mapping(mapping_type type, std::string const &name_base64_hash)
 {
-  sqlite3_stmt *statement = get_mapping_sql;
-  sqlite3_clear_bindings(statement);
-  sqlite3_bind_int(statement, 1 /*sql param index*/, static_cast<uint16_t>(type));
-  sqlite3_bind_text(statement, 2 /*sql param index*/, name_base64_hash.data(), name_base64_hash.size(), nullptr /*destructor*/);
-
   mapping_record result = {};
-  result.loaded         = sql_run_statement(nettype, lns_sql_type::get_mapping, statement, &result);
+  result.loaded         = bind_and_run(lns_sql_type::get_mapping, get_mapping_sql, &result,
+      static_cast<uint16_t>(type), name_base64_hash);
   return result;
 }
 
-std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> const &types, std::string const &name_base64_hash) const
+std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> const &types, std::string const &name_base64_hash)
 {
   std::vector<mapping_record> result;
   if (types.empty())
@@ -1748,87 +1952,68 @@ std::vector<mapping_record> name_system_db::get_mappings(std::vector<uint16_t> c
   }
 
   // Compile Statement
-  sqlite3_stmt *statement = nullptr;
-  if (!sql_compile_statement(db, sql_statement.c_str(), sql_statement.size(), &statement, false /*optimise_for_multiple_usage*/))
+  sql_compiled_statement statement{*this};
+  if (!statement.compile(sql_statement, false /*optimise_for_multiple_usage*/))
     return result;
 
-  sqlite3_bind_text(statement, 1 /*sql param index*/, name_base64_hash.data(), name_base64_hash.size(), nullptr /*destructor*/);
-
   // Execute
-  sql_run_statement(nettype, lns_sql_type::get_mappings, statement, &result);
+  bind_and_run(lns_sql_type::get_mappings, statement, &result,
+      name_base64_hash);
+
   return result;
 }
 
-std::vector<mapping_record> name_system_db::get_mappings_by_owners(std::vector<generic_owner> const &owners) const
-
+std::vector<mapping_record> name_system_db::get_mappings_by_owners(std::vector<generic_owner> const &owners)
 {
   std::string sql_statement;
   // Generate string statement
   {
     std::string const sql_prefix_str = sql_cmd_combine_mappings_and_owner_table(R"(WHERE "o1"."address" in ()");
-    char constexpr SQL_MIDDLE[]  = R"( OR "o2"."address" in ()";
+    char constexpr SQL_MIDDLE[]  = R"() OR "o2"."address" in ()";
     char constexpr SQL_SUFFIX[]  = R"())";
 
-    std::stringstream stream;
-    stream << sql_prefix_str;
+    std::string placeholders;
+    placeholders.reserve(3*owners.size());
     for (size_t i = 0; i < owners.size(); i++)
-    {
-      stream << "?";
-      if (i < (owners.size() - 1)) stream << ", ";
-    }
-    stream << SQL_SUFFIX;
+      placeholders += "?, ";
+    if (owners.size() > 0)
+      placeholders.resize(placeholders.size() - 2);
 
-    stream << SQL_MIDDLE;
-    for (size_t i = 0; i < owners.size(); i++)
-    {
-      stream << "?";
-      if (i < (owners.size() - 1)) stream << ", ";
-    }
-    stream << SQL_SUFFIX;
-
-    stream << SQL_MIDDLE;
-    for (size_t i = 0; i < owners.size(); i++)
-    {
-      stream << "?";
-      if (i < (owners.size() - 1)) stream << ", ";
-    }
-    stream << SQL_SUFFIX;
+    std::ostringstream stream;
+    stream << sql_prefix_str << placeholders << SQL_MIDDLE << placeholders << SQL_SUFFIX;
     sql_statement = stream.str();
   }
 
   // Compile Statement
   std::vector<mapping_record> result;
-  sqlite3_stmt *statement = nullptr;
-  if (!sql_compile_statement(db, sql_statement.c_str(), sql_statement.size(), &statement, false /*optimise_for_multiple_usage*/))
+  sql_compiled_statement statement{*this};
+  if (!statement.compile(sql_statement, false /*optimise_for_multiple_usage*/))
     return result;
 
   // Bind parameters statements
   int sql_param_index = 1;
   for (size_t i = 0; i < owners.size(); i++)
     for (auto const &owner : owners)
-      sqlite3_bind_blob(statement, sql_param_index++, &owner, sizeof(owner), nullptr /*destructor*/);
+      bind_blob(statement, sql_param_index++, &owner, sizeof(owner));
 
   // Execute
-  sql_run_statement(nettype, lns_sql_type::get_mappings_by_owners, statement, &result);
+  sql_run_statement(lns_sql_type::get_mappings_by_owners, statement, &result);
   return result;
 }
 
-std::vector<mapping_record> name_system_db::get_mappings_by_owner(generic_owner const &owner) const
+std::vector<mapping_record> name_system_db::get_mappings_by_owner(generic_owner const &owner)
 {
   std::vector<mapping_record> result = {};
-  sqlite3_stmt *statement = get_mappings_by_owner_sql;
-  sqlite3_clear_bindings(statement);
-  sqlite3_bind_blob(statement, 1 /*sql param index*/, &owner, sizeof(owner), nullptr /*destructor*/);
-  sqlite3_bind_blob(statement, 2 /*sql param index*/, &owner, sizeof(owner), nullptr /*destructor*/);
-  sql_run_statement(nettype, lns_sql_type::get_mappings_by_owner, statement, &result);
+  blob_view ownerblob{reinterpret_cast<const char*>(&owner), sizeof(owner)};
+  bind_and_run(lns_sql_type::get_mappings_by_owner, get_mappings_by_owner_sql, &result,
+      ownerblob, ownerblob);
   return result;
 }
 
-settings_record name_system_db::get_settings() const
+settings_record name_system_db::get_settings()
 {
-  sqlite3_stmt *statement = get_settings_sql;
   settings_record result  = {};
-  result.loaded           = sql_run_statement(nettype, lns_sql_type::get_setting, statement, &result);
+  result.loaded           = sql_run_statement(lns_sql_type::get_setting, get_settings_sql, &result);
   return result;
 }
 }; // namespace service_nodes

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -211,6 +211,9 @@ struct name_system_db
   // entry: (optional) if function returns true, the Loki Name System entry in the TX extra is copied into 'entry'
   bool                        validate_lns_tx       (uint8_t hf_version, uint64_t blockchain_height, cryptonote::transaction const &tx, cryptonote::tx_extra_loki_name_system *entry = nullptr, std::string *reason = nullptr);
 
+  // Destructor; closes the sqlite3 database if one is open
+  ~name_system_db();
+
   sqlite3 *db               = nullptr;
   bool    transaction_begun = false;
 private:

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3394,7 +3394,7 @@ namespace cryptonote
     if (exceeds_quantity_limit(ctx, error_resp, m_restricted, req.entries.size(), COMMAND_RPC_LNS_NAMES_TO_OWNERS::MAX_REQUEST_ENTRIES))
       return false;
 
-    lns::name_system_db const &db = m_core.get_blockchain_storage().name_system_db();
+    lns::name_system_db &db = m_core.get_blockchain_storage().name_system_db();
     for (size_t request_index = 0; request_index < req.entries.size(); request_index++)
     {
       COMMAND_RPC_LNS_NAMES_TO_OWNERS::request_entry const &request = req.entries[request_index];
@@ -3450,7 +3450,7 @@ namespace cryptonote
       owner_to_request_index[lns_owner] = request_index;
     }
 
-    lns::name_system_db const &db = m_core.get_blockchain_storage().name_system_db();
+    lns::name_system_db &db = m_core.get_blockchain_storage().name_system_db();
     std::vector<lns::mapping_record> records = db.get_mappings_by_owners(owners);
     for (auto &record : records)
     {

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -135,7 +135,7 @@ loki_chain_generator::loki_chain_generator(std::vector<test_event_entry> &events
 : events_(events)
 , hard_forks_(hard_forks)
 {
-  bool init = lns_db_.init(nullptr, cryptonote::FAKECHAIN, lns::init_loki_name_system(""));
+  bool init = lns_db_->init(nullptr, cryptonote::FAKECHAIN, lns::init_loki_name_system(""));
   assert(init);
 
   first_miner_.generate();
@@ -154,7 +154,9 @@ loki_chain_generator::loki_chain_generator(std::vector<test_event_entry> &events
 
 loki_chain_generator::~loki_chain_generator()
 {
-  sqlite3_close_v2(lns_db_.db);
+  // FIXME -- shouldn't this close by in name_system_db's destructor?
+  if (lns_db_.use_count() == 1)
+    sqlite3_close_v2(lns_db_->db);
 }
 
 service_nodes::quorum_manager loki_chain_generator::top_quorum() const
@@ -210,7 +212,7 @@ loki_blockchain_entry &loki_chain_generator::add_block(loki_blockchain_entry con
 
   if (can_be_added_to_blockchain && entry.block.major_version >= cryptonote::network_version_15_lns)
   {
-    lns_db_.add_block(entry.block, entry.txs);
+    lns_db_->add_block(entry.block, entry.txs);
   }
 
   // TODO(loki): State history culling and alt states
@@ -554,7 +556,7 @@ cryptonote::transaction loki_chain_generator::create_loki_name_system_tx(crypton
   crypto::hash name_hash       = lns::name_to_hash(name);
   std::string name_base64_hash = lns::name_to_base64_hash(name);
   crypto::hash prev_txid = crypto::null_hash;
-  if (lns::mapping_record mapping = lns_db_.get_mapping(type, name_base64_hash))
+  if (lns::mapping_record mapping = lns_db_->get_mapping(type, name_base64_hash))
     prev_txid = mapping.txid;
 
   lns::mapping_value encrypted_value = {};
@@ -588,7 +590,7 @@ cryptonote::transaction loki_chain_generator::create_loki_name_system_tx_update(
   crypto::hash prev_txid = {};
   {
     std::string name_base64_hash = lns::name_to_base64_hash(name);
-    lns::mapping_record mapping  = lns_db_.get_mapping(type, name_base64_hash);
+    lns::mapping_record mapping  = lns_db_->get_mapping(type, name_base64_hash);
     if (use_asserts) assert(mapping);
     prev_txid = mapping.txid;
   }

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -152,13 +152,6 @@ loki_chain_generator::loki_chain_generator(std::vector<test_event_entry> &events
   events_.push_back(settings);
 }
 
-loki_chain_generator::~loki_chain_generator()
-{
-  // FIXME -- shouldn't this close by in name_system_db's destructor?
-  if (lns_db_.use_count() == 1)
-    sqlite3_close_v2(lns_db_->db);
-}
-
 service_nodes::quorum_manager loki_chain_generator::top_quorum() const
 {
   service_nodes::quorum_manager result = top().service_node_state.quorums;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1385,7 +1385,7 @@ struct loki_chain_generator
   mutable std::unordered_map<crypto::public_key, crypto::secret_key> service_node_keys_;
   service_nodes::service_node_list::state_set                        state_history_;
   uint64_t                                                           last_cull_height_ = 0;
-  lns::name_system_db                                                lns_db_;
+  std::shared_ptr<lns::name_system_db>                               lns_db_ = std::make_shared<lns::name_system_db>();
   loki_chain_generator_db                                            db_;
   uint8_t                                                            hf_version_ = cryptonote::network_version_7;
   std::vector<test_event_entry>&                                     events_;

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1393,7 +1393,6 @@ struct loki_chain_generator
   cryptonote::account_base                                           first_miner_;
 
   loki_chain_generator(std::vector<test_event_entry> &events, const std::vector<std::pair<uint8_t, uint64_t>> &hard_forks);
-  ~loki_chain_generator();
 
   uint64_t                                             height()       const { return cryptonote::get_block_height(db_.blocks.back().block); }
   uint64_t                                             chain_height() const { return height() + 1; }

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -1156,7 +1156,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
       {
         DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
         CHECK_EQ(owner.loaded, true);
         CHECK_EQ(owner.id, 1);
@@ -1175,7 +1175,7 @@ bool loki_name_system_expiration::generate(std::vector<test_event_entry> &events
       loki_register_callback(events, "check_expired", [=, blockchain_height = gen.chain_height()](cryptonote::core &c, size_t ev_index)
       {
         DEFINE_TESTS_ERROR_CONTEXT("check_expired");
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
         // TODO(loki): We should probably expire owners that no longer have any mappings remaining
         lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
@@ -1263,7 +1263,7 @@ bool loki_name_system_get_mappings_by_owner::generate(std::vector<test_event_ent
   loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
   {
     const char* perr_context = "check_lns_entries";
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
     std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owner(bob_key.owner);
 
     size_t expected_size = 0;
@@ -1345,7 +1345,7 @@ bool loki_name_system_get_mappings_by_owners::generate(std::vector<test_event_en
   loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
     std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owners({bob_key.owner, miner_key.owner});
     CHECK_EQ(records.size(), 3);
     std::sort(records.begin(), records.end(), [](lns::mapping_record const &lhs, lns::mapping_record const &rhs) {
@@ -1393,7 +1393,7 @@ bool loki_name_system_get_mappings::generate(std::vector<test_event_entry> &even
   loki_register_callback(events, "check_lns_entries", [&events, bob_key, session_height, session_name1, session_tx_hash](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
     std::string session_name_hash = lns::name_to_base64_hash(session_name1);
     std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, session_name_hash);
     CHECK_EQ(records.size(), 1);
@@ -1452,7 +1452,7 @@ bool loki_name_system_handles_duplicate_in_lns_db::generate(std::vector<test_eve
   loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
     lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
     CHECK_EQ(owner.loaded, true);
@@ -1706,7 +1706,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     loki_register_callback(events, "check_first_lns_entries", [=](cryptonote::core &c, size_t ev_index)
     {
       DEFINE_TESTS_ERROR_CONTEXT("check_first_lns_entries");
-      lns::name_system_db const &lns_db        = c.get_blockchain_storage().name_system_db();
+      lns::name_system_db &lns_db        = c.get_blockchain_storage().name_system_db();
       std::vector<lns::mapping_record> records = lns_db.get_mappings_by_owner(miner_key.owner);
       CHECK_EQ(lns_db.height(), first_lns_height);
 
@@ -1760,7 +1760,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     loki_register_callback(events, "check_second_lns_entries", [=](cryptonote::core &c, size_t ev_index)
     {
       DEFINE_TESTS_ERROR_CONTEXT("check_second_lns_entries");
-      lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+      lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
       CHECK_EQ(lns_db.height(), second_lns_height);
 
       // NOTE: Check miner's record
@@ -1802,7 +1802,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     uint64_t curr_height   = blockchain.get_current_blockchain_height();
     uint64_t blocks_to_pop = curr_height - second_lns_height;
     blockchain.pop_blocks(blocks_to_pop);
-    lns::name_system_db const &lns_db  = blockchain.name_system_db();
+    lns::name_system_db &lns_db  = blockchain.name_system_db();
     CHECK_EQ(lns_db.height(), blockchain.get_current_blockchain_height() - 1);
 
     // NOTE: Check bob's records got removed due to popping back to before it existed
@@ -1849,7 +1849,7 @@ bool loki_name_system_large_reorg::generate(std::vector<test_event_entry> &event
     uint64_t curr_height   = blockchain.get_current_blockchain_height();
     uint64_t blocks_to_pop = curr_height - first_lns_height;
     blockchain.pop_blocks(blocks_to_pop);
-    lns::name_system_db const &lns_db  = blockchain.name_system_db();
+    lns::name_system_db &lns_db  = blockchain.name_system_db();
     CHECK_EQ(lns_db.height(), blockchain.get_current_blockchain_height() - 1);
 
     // NOTE: Check miner's records are gone
@@ -1894,7 +1894,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
   loki_register_callback(events, "check_lns_entries", [=](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_lns_entries");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
     lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
     CHECK_EQ(owner.loaded, true);
@@ -1921,7 +1921,7 @@ bool loki_name_system_name_renewal::generate(std::vector<test_event_entry> &even
   loki_register_callback(events, "check_renewed", [=](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_renewed");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
     lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
     CHECK_EQ(owner.loaded, true);
@@ -2046,7 +2046,7 @@ bool loki_name_system_update_mapping_after_expiry_fails::generate(std::vector<te
     loki_register_callback(events, "check_still_expired", [=](cryptonote::core &c, size_t ev_index)
     {
       DEFINE_TESTS_ERROR_CONTEXT("check_still_expired");
-      lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+      lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
       lns::owner_record owner = lns_db.get_owner_by_key(miner_key.owner);
       CHECK_EQ(owner.loaded, true);
@@ -2089,7 +2089,7 @@ bool loki_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
   loki_register_callback(events, "check_registered", [=](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_registered");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
     std::string name_hash = lns::name_to_base64_hash(session_name1);
     std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, name_hash);
@@ -2115,7 +2115,7 @@ bool loki_name_system_update_mapping::generate(std::vector<test_event_entry> &ev
   loki_register_callback(events, "check_updated", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
   {
     DEFINE_TESTS_ERROR_CONTEXT("check_updated");
-    lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+    lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
 
     std::string name_hash = lns::name_to_base64_hash(session_name1);
     std::vector<lns::mapping_record> records = lns_db.get_mappings({static_cast<uint16_t>(lns::mapping_type::session)}, name_hash);
@@ -2162,7 +2162,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
     loki_register_callback(events, "check_update0", [=](cryptonote::core &c, size_t ev_index)
     {
       const char* perr_context = "check_update0";
-      lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+      lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
       lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
       CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, miner_key.session_value, height, height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
       return true;
@@ -2183,7 +2183,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update1", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update1";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2205,7 +2205,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update2", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update2";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2243,7 +2243,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update3", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update3";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2265,7 +2265,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update3", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update3";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2307,7 +2307,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update4", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update4";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2329,7 +2329,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update5", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update5";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2371,7 +2371,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update6", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update6";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;
@@ -2394,7 +2394,7 @@ bool loki_name_system_update_mapping_multiple_owners::generate(std::vector<test_
       loki_register_callback(events, "check_update7", [=, blockchain_height = gen.height()](cryptonote::core &c, size_t ev_index)
       {
         const char* perr_context = "check_update7";
-        lns::name_system_db const &lns_db = c.get_blockchain_storage().name_system_db();
+        lns::name_system_db &lns_db = c.get_blockchain_storage().name_system_db();
         lns::mapping_record const record = lns_db.get_mapping(lns::mapping_type::session, name_hash);
         CHECK_TEST_CONDITION(verify_lns_mapping_record(perr_context, record, lns::mapping_type::session, name, temp_keys.session_value, height, blockchain_height, txid, prev_txid, owner1, owner2 /*backup_owner*/));
         return true;


### PR DESCRIPTION
I started this PR to just fix the upgrades, but when investigating I
found some problematic memory leaks as well and ended up adding a bunch
of nice abstraction layers to make the code nicer.

I'd normally separate these into multiple commits, but they ended up
quite interdependent to the point where it isn't really feasible to do
so; but here's the details on the changes:

- add a `DEFAULT "register_height"` for the new "update_height" field so
  that the alter table works
- reorganized the statement preparation and database migration so that
  all statement preparation happens *after* migration; otherwise
  statement preparation fails because some of the statements reference
  columns that aren't created until the migration.
- created a `sql_compiled_statement` class that manages sqlite statement
  pointers; there were several places that we were leaking them (the
  main ones were okay, but we also have some dynamically constructed
  ones for variable size queries).
- added a new abstraction layer around sqlite3 binding and value
  extraction that makes the actual sql interaction code much less
  verbose.
- removed the `nettype` argument from `sql_run_statement` as it wasn't
  being used.  (If something in the future needs it, the compiled
  statement class has a reference to the db object, so it can be
  obtained via `statement.nsdb.network_type()`)
- `bind(statement, 1, someval)` now does what
  `sqlite3_bind_whatever(statement, 1, someval, ...)` did before, except
  that it infers the "whatever" from the type (for everything except
  blobs), and does whatever "..." needs to happen.
- `bind(statement, 1, blob_view{someval.data(), size})` can do the same
  for a blob.  (There is also `bind_blob(statement, 1, someval.data(),
  size)` which does the same thing but is nicer in some contexts).
- `auto x = get<T>(statement, 1)` is the bind counterpart for extracting
  a known type (and similarly calls the right sqlite function based on
  `T`).  There is also a `get(statement, 1, x);` that does the same
  thing, but infers the type from whatever `x` is.  `get_blob` similarly
  gets a blob value, though currently this is only used in the existing
  `sql_copy_blob()` wrapper.
- All the `bind` and `get` forms accept an integer enum class as the
  position argument, so the code can now write just:

    bind(statement, lns_db_setting_column::top_height, value);

  instead of:

    bind(statement, static_cast<int>(lns_db_setting_column::top_height), value);

- bind_all lets you bind all the parameters in one go (and also clears
  existing bindings), letting you write things like:

      bind_all(statement, 123, "my string", my_u64_int);

  which previously would have needed:

      sqlite3_clear_bindings(statement);
      sqlite3_bind_int(statement, 1, 123);
      sqlite3_bind_text(statement, 2, "my string", 10, nullptr, nullptr);
      sqlite3_bind_int64(statement, 3, my_u64_int);

- Also there's a `bind_and_run` which combines this binding with a
  sql_run_statement.
- put all of the new binding code in an anonymous namespace, along with
  several existing `static` functions (this is equivalent, just easier
  than having to write static dozens of times).
- removed a superfluous extra "OR" clause in get_mappings_by_owners.  It
  was producing queries such as:

  ... WHERE o1.address IN (?, ?, ?) OR o2.address IN (?, ?, ?) OR o2.address IN (?, ?, ?)

  also simplified that part of the code down quite a bit with a
  pre-allocated string for the "?, ?, ?" part.
- Simplified some some pointer/size pairs with lokimq::string_view
  (which, internally, is just a pointer size pair already).
- Various methods got de-const'ed in this change.  They probably
  shouldn't have been const before because even though they only access
  data, they still mutate internal state of the stored statements, and
  making them all mutable would be a bit gross.  (They did this before,
  too, but since everything was pointers calling into C code I guess
  the compiler just allowed it).