### PR TITLE
Warn and refuse to submit proofs if we detect duplicate ed/x25519 keys

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -2060,6 +2060,15 @@ namespace cryptonote
         if ((uint64_t) std::time(nullptr) < next_proof_time)
           return;
 
+        auto pubkey = m_service_node_list.get_pubkey_from_x25519(m_service_node_keys->pub_x25519);
+        if (pubkey != crypto::null_pkey && pubkey != m_service_node_keys->pub)
+        {
+          MGINFO_RED(
+              "Failed to submit uptime proof: another service node on the network is using the same ed/x25519 keys as "
+              "this service node. This typically means both have the same 'key_ed25519' private key file.");
+          return;
+        }
+
         if (!check_external_ping(m_last_storage_server_ping, STORAGE_SERVER_PING_LIFETIME, "the storage server"))
         {
           MGINFO_RED(

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2066,6 +2066,10 @@ namespace service_nodes
     {
       my_uptime_proof_confirmation = false;
       LOG_PRINT_L2("Accepted uptime proof from " << proof.pubkey);
+
+      if (m_service_node_keys && proof.pubkey_ed25519 == m_service_node_keys->pub_ed25519)
+        MGINFO_RED("Uptime proof from SN " << proof.pubkey << " is not us, but is using our ed/x25519 keys; "
+            "this is likely to lead to deregistration of one or both service nodes.");
     }
 
     auto old_x25519 = iproof.pubkey_x25519;


### PR DESCRIPTION
This PR warns loudly on duplicate ed25519 broadcasts, and refuses to submit an uptime proof if someone else has submitted one using the same key.


Currently on the network there are 14 nodes sending 3 ed25519 (and thus also x25519) keys in uptime proofs:

0c66842a5fb034c4679448e6e64fcf3ff60500422dca4db6b778934f60f2481c
5610318b4567381ef4bed4c821ebe45906648eb1820cd0284328e0dfa41d22b7
7b333770e01fed6224d6784a681e4b5cbec950f0f974fdad36d679a28061b850

088e6b8cfd6d4f5bfd24e91f8a663b871515611faecb089e95cccf3f52784a03
62ec28bb1b5de06d6f48f1aaa3b23b9762c2ed79ac8423b1bba37e25539bb74e
a70f3eaf9778effeb9b2c30e5672392c1eae14faa5ed6a39e926c4d9bf5aed8f
ac548aa80d9c009ea76e11fcea6b7154fcc51005ecf68539e087ffde15659d18
b4c60c397c156ef823409bb69a49ffeedb5bd8c8e9b4c36b63b2fed1b9efc7b5
ea7c8448c6d8ec8359766f9f0a7dafedf83885605f216cfc6df78a7bc91e6ae3
ea849c49734bec070ad4db12e824d74ca23042e5d68c627b9b98b2d3343a25e2
f82551b9a3875ed852c453e19a60252502d951e86dcdc4c6acb099ea5925f0fc

2743ac918345a7f53e1ce1a8203f81b99179f1ed9865c22e2b5726a7f07d4509
28a706b99d5605a4026a94bce026ea25ff8e89c573b6680e0caad928fb9f5e1c
adf124230779fbd6c3125f3f276c190a35570f02c5fd0b1c25b1a4e7b82522ed

This is almost certainly breaking lokinet (paths through these routers will not work since there will be conflicting RCs on the network), and storage server is likely breaking as well (different connections from the same x25519 pubkey will replace each other because ZMQ thinks the same node is reconnecting after a failure).

The SS failure is quite possibly the source of many of the recent decommissions and deregistrations.