### PR TITLE
Update for LokiMQ 1.1.0's changes

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(PkgConfig REQUIRED)
 if(NOT STATIC)
   pkg_check_modules(MINIUPNPC miniupnpc>=2.1)
   pkg_check_modules(UNBOUND libunbound)
-  pkg_check_modules(LOKIMQ liblokimq>=1.0.4)
+  pkg_check_modules(LOKIMQ liblokimq>=1.1.0)
 endif()
 
 if(MINIUPNPC_FOUND)

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -267,11 +267,13 @@ namespace cryptonote
   }
   void *(*quorumnet_new)(core &, const std::string &bind);
   void (*quorumnet_delete)(void *&self);
+  void (*quorumnet_refresh_sns)(void *self);
   void (*quorumnet_relay_obligation_votes)(void *self, const std::vector<service_nodes::quorum_vote_t> &);
   std::future<std::pair<blink_result, std::string>> (*quorumnet_send_blink)(void *self, const std::string &tx_blob);
   static bool init_core_callback_stubs() {
     quorumnet_new = [](core &, const std::string &) -> void * { need_core_init(); };
     quorumnet_delete = [](void *&) { need_core_init(); };
+    quorumnet_refresh_sns = [](void *) { need_core_init(); };
     quorumnet_relay_obligation_votes = [](void *, const std::vector<service_nodes::quorum_vote_t> &) { need_core_init(); };
     quorumnet_send_blink = [](void *, const std::string &) -> std::future<std::pair<blink_result, std::string>> { need_core_init(); };
     return false;
@@ -1993,6 +1995,12 @@ namespace cryptonote
       return false;
     }
     return true;
+  }
+
+  void core::update_lmq_sns()
+  {
+    if (m_quorumnet_obj)
+      quorumnet_refresh_sns(m_quorumnet_obj);
   }
   //-----------------------------------------------------------------------------------------------
   crypto::hash core::get_tail_id() const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -85,6 +85,8 @@ namespace cryptonote
   extern void *(*quorumnet_new)(core &core, const std::string &bind);
   // Stops the quorumnet listener; is expected to delete the object and reset the pointer to nullptr.
   extern void (*quorumnet_delete)(void *&self);
+  // Called when a block is added to let LokiMQ update the active set of SNs
+  extern void (*quorumnet_refresh_sns)(void* self);
   // Relays votes via quorumnet.
   extern void (*quorumnet_relay_obligation_votes)(void *self, const std::vector<service_nodes::quorum_vote_t> &votes);
   // Sends a blink tx to the current blink quorum, returns a future that can be used to wait for the
@@ -318,6 +320,10 @@ namespace cryptonote
       * @return whether or not the block is too big
       */
      bool check_incoming_block_size(const blobdata& block_blob) const;
+
+     /// Called (from service_node_quorum_cop) to tell quorumnet that it need to refresh its list of
+     /// active SNs.
+     void update_lmq_sns();
 
      /**
       * @brief get the cryptonote protocol instance

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -371,6 +371,21 @@ namespace service_nodes
       }
     }
 
+    /// Copies x25519 pubkeys (as strings) of all currently active SNs into the given output iterator
+    template <typename OutputIt>
+    void copy_active_x25519_pubkeys(OutputIt out) const {
+      std::lock_guard<boost::recursive_mutex> lock(m_sn_mutex);
+      for (const auto& pk_info : m_state.service_nodes_infos) {
+        if (!pk_info.second->is_active())
+          continue;
+        auto it = proofs.find(pk_info.first);
+        if (it == proofs.end())
+          continue;
+        if (const auto& x2_pk = it->second.pubkey_x25519)
+          *out++ = std::string{reinterpret_cast<const char*>(&x2_pk), sizeof(x2_pk)};
+      }
+    }
+
     void set_my_service_node_keys(const service_node_keys *keys);
     void set_quorum_history_storage(uint64_t hist_size); // 0 = none (default), 1 = unlimited, N = # of blocks
     bool store();

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -479,6 +479,11 @@ namespace service_nodes
     uint64_t const height = cryptonote::get_block_height(block) + 1; // chain height = new top block height + 1
     m_vote_pool.remove_expired_votes(height);
     m_vote_pool.remove_used_votes(txs, block.major_version);
+
+    // These feels out of place here because the hook system sucks: TODO replace it with
+    // std::function hooks instead.
+    m_core.update_lmq_sns();
+
     return true;
   }
 


### PR DESCRIPTION
With the 1.1.0 update, rather than LokiMQ getting a callback that it
invokes on connection to get auth level for the duration of that
connection, it now checks authentication each time a command is invoked.
This improves message reliability (because on an invocation failure the
remote doesn't have to reconnect to be reauthenticated).

This helps storage server greatly (which has some tricky initialization
issue that requires it to initialize lokimq before it has the SN list);
it is less needed for quorumnet communications (which have been all
using connection-time authenciation for a while now), but this change
does some one "weirdness" that a remote client may be unable to issue a
command that they *can* issue if they reconnect.

The lokid update here piggypacks the call into quorumnet in quorum_cop's
`add_block` callback to make the call; this would be far cleaner if we
replaced the callbacks with stateful std::function's instead of
inherited base class pointers, but I didn't want to go that far in this
PR.

I *think* that only doing this on `block_added` should be enough; a rollback or a pop blocks should almost always be followed by an add_block which will update LokiMQ's list again (and most of the time won't change the set of active SNs anyway).