### PR TITLE
fix segfault when exiting cli wallet due to running long poll thread

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8499,22 +8499,8 @@ bool simple_wallet::run()
   m_auto_refresh_enabled = m_wallet->auto_refresh();
   m_idle_thread          = boost::thread([&] { wallet_idle_thread(); });
 
-  if (!m_wallet->m_long_poll_disabled)
-  {
-    m_long_poll_thread = boost::thread([&] {
-      for (;;)
-      {
-        try
-        {
-          if (m_auto_refresh_enabled && m_wallet->long_poll_pool_state())
-            m_idle_cond.notify_one();
-        }
-        catch (...)
-        {
-        }
-      }
-    });
-  }
+  long_poll_thread_t long_poll_thread(*this);
+  if (!m_wallet->m_long_poll_disabled) long_poll_thread.start();
 
   message_writer(console_color_green, false) << "Background refresh thread started";
 
@@ -8539,7 +8525,6 @@ bool simple_wallet::run()
     }
   }
 #endif
-
   return m_cmd_binder.run_handling([this]() {return get_prompt(); }, "");
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -339,9 +339,6 @@ namespace cryptonote
 
     class long_poll_thread_t
     {
-      cryptonote::simple_wallet& m_simple_wallet;
-      boost::atomic<bool> m_polling_done;
-      boost::thread m_long_poll_thread;
     public:
       long_poll_thread_t(cryptonote::simple_wallet& simple_wallet)
         : m_simple_wallet(simple_wallet), m_polling_done(true) { }
@@ -367,6 +364,11 @@ namespace cryptonote
             }
           });
       }
+
+    private:
+      cryptonote::simple_wallet& m_simple_wallet;
+      boost::atomic<bool> m_polling_done;
+      boost::thread m_long_poll_thread;
     };
 
     friend class refresh_progress_reporter_t;

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -344,7 +344,7 @@ namespace cryptonote
       boost::thread m_long_poll_thread;
     public:
       long_poll_thread_t(cryptonote::simple_wallet& simple_wallet)
-        : m_simple_wallet(simple_wallet), m_polling_done(true) {}
+        : m_simple_wallet(simple_wallet), m_polling_done(true) { }
       ~long_poll_thread_t()
       {
         if (m_polling_done || !m_long_poll_thread.joinable()) return;
@@ -359,13 +359,11 @@ namespace cryptonote
             while (!m_polling_done)
             {
               try
-                {
-                  if (m_simple_wallet.m_auto_refresh_enabled && m_simple_wallet.m_wallet->long_poll_pool_state())
-                    m_simple_wallet.m_idle_cond.notify_one();
-                }
-              catch (...)
               {
+                if (m_simple_wallet.m_auto_refresh_enabled && m_simple_wallet.m_wallet->long_poll_pool_state())
+                  m_simple_wallet.m_idle_cond.notify_one();
               }
+              catch (...) { }
             }
           });
       }

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -337,6 +337,40 @@ namespace cryptonote
     virtual boost::optional<epee::wipeable_string> on_device_passphrase_request(bool on_device);
     //----------------------------------------------------------
 
+    class long_poll_thread_t
+    {
+      cryptonote::simple_wallet& m_simple_wallet;
+      boost::atomic<bool> m_polling_done;
+      boost::thread m_long_poll_thread;
+    public:
+      long_poll_thread_t(cryptonote::simple_wallet& simple_wallet)
+        : m_simple_wallet(simple_wallet), m_polling_done(true) {}
+      ~long_poll_thread_t()
+      {
+        if (m_polling_done || !m_long_poll_thread.joinable()) return;
+        m_polling_done = true;
+        m_long_poll_thread.join();
+      }
+
+      void start()
+      {
+        m_polling_done = false;
+        m_long_poll_thread = boost::thread([&] {
+            while (!m_polling_done)
+            {
+              try
+                {
+                  if (m_simple_wallet.m_auto_refresh_enabled && m_simple_wallet.m_wallet->long_poll_pool_state())
+                    m_simple_wallet.m_idle_cond.notify_one();
+                }
+              catch (...)
+              {
+              }
+            }
+          });
+      }
+    };
+
     friend class refresh_progress_reporter_t;
 
     class refresh_progress_reporter_t
@@ -424,7 +458,6 @@ namespace cryptonote
 
     std::atomic<bool> m_idle_run;
     boost::thread m_idle_thread;
-    boost::thread m_long_poll_thread;
     boost::mutex m_idle_mutex;
     boost::condition_variable m_idle_cond;
 


### PR DESCRIPTION
loki-wallet-cli consistently segfaults on exit because the long_poll thread isn't shut down before simplewallet's destructor is invoked.  This fix ensures the long_poll thread is always properly shut down via RAII. 