### PR TITLE
Handle long poll shutdown properly

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -353,6 +353,7 @@ private:
 
     static bool has_testnet_option(const boost::program_options::variables_map& vm);
     static bool has_stagenet_option(const boost::program_options::variables_map& vm);
+    static bool has_disable_rpc_long_poll(const boost::program_options::variables_map& vm);
     static std::string device_name_option(const boost::program_options::variables_map& vm);
     static std::string device_derivation_path_option(const boost::program_options::variables_map &vm);
     static void init_options(boost::program_options::options_description& desc_params);
@@ -1580,7 +1581,7 @@ private:
     void set_offline(bool offline = true);
 
 
-    bool m_long_poll_disabled = false;
+    std::atomic<bool> m_long_poll_disabled;
   private:
     /*!
      * \brief  Stores wallet information to wallet file.

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -62,6 +62,7 @@ namespace tools
     bool run();
     void stop();
     void set_wallet(wallet2 *cr);
+    std::atomic<bool> m_long_poll_disabled;
 
   private:
 


### PR DESCRIPTION
Wait for thread to end before terminating wallet_rpc

- In RPC wallet, we need to track long polling shutting down separately
from the wallet as the RPC wallet can start up without instantiating
a wallet2 instance. If this is the case, shutting down the RPC wallet
will hang the long polling thread as the terminating variable can never
be retrieved from wallet2.

- Simplify RAII of the long polling thread by putting it into the
simple_wallet destructor

- Fix long poll thread constantly resetting the host. set_server() was
currently parsing host = "localhost:38157" such that get_host()
= "localhost" and port() = 38157 so that host != get_host().