### PR TITLE
LNS: Commit to db more conservatively instead of every block

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -863,7 +863,7 @@ namespace cryptonote
       m_checkpoints_path = checkpoint_json_hashfile_fullpath.string();
     }
 
-    sqlite3 *lns_db = lns::init_loki_name_system(lns_db_file_path.c_str());
+    sqlite3 *lns_db = lns::init_loki_name_system(lns_db_file_path.c_str(), db->is_read_only());
     if (!lns_db) return false;
 
     const difficulty_type fixed_difficulty = command_line::get_arg(vm, arg_fixed_difficulty);

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -552,7 +552,7 @@ sql_compiled_statement::~sql_compiled_statement()
   sqlite3_finalize(statement);
 }
 
-sqlite3 *init_loki_name_system(char const *file_path)
+sqlite3 *init_loki_name_system(char const *file_path, bool read_only)
 {
   sqlite3 *result = nullptr;
   int sql_init    = sqlite3_initialize();
@@ -562,7 +562,8 @@ sqlite3 *init_loki_name_system(char const *file_path)
     return nullptr;
   }
 
-  int sql_open = sqlite3_open(file_path, &result);
+  int const flags = read_only ? SQLITE_OPEN_READONLY : SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE;
+  int sql_open    = sqlite3_open_v2(file_path, &result, flags, nullptr);
   if (sql_open != SQLITE_OK)
   {
     MERROR("Failed to open LNS db at: " << file_path << ", reason: " << sqlite3_errstr(sql_open));

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -61,7 +61,7 @@ inline char const *mapping_type_str(mapping_type type)
 inline std::ostream &operator<<(std::ostream &os, mapping_type type) { return os << mapping_type_str(type); }
 constexpr bool mapping_type_allowed(uint8_t hf_version, mapping_type type) { return type == mapping_type::session; }
 constexpr bool is_lokinet_type     (lns::mapping_type type)                { return type >= mapping_type::lokinet_1year && type <= mapping_type::lokinet_10years; }
-sqlite3       *init_loki_name_system(char const *file_path);
+sqlite3       *init_loki_name_system(char const *file_path, bool read_only);
 
 uint64_t constexpr NO_EXPIRY = static_cast<uint64_t>(-1);
 // return: The number of blocks until expiry from the registration height, if there is no expiration NO_EXPIRY is returned.

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -219,6 +219,7 @@ struct name_system_db
 private:
   cryptonote::network_type nettype;
   uint64_t last_processed_height = 0;
+  crypto::hash last_processed_hash = crypto::null_hash;
   sql_compiled_statement save_owner_sql{*this};
   sql_compiled_statement save_mapping_sql{*this};
   sql_compiled_statement save_settings_sql{*this};

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -135,7 +135,7 @@ loki_chain_generator::loki_chain_generator(std::vector<test_event_entry> &events
 : events_(events)
 , hard_forks_(hard_forks)
 {
-  bool init = lns_db_->init(nullptr, cryptonote::FAKECHAIN, lns::init_loki_name_system(""));
+  bool init = lns_db_->init(nullptr, cryptonote::FAKECHAIN, lns::init_loki_name_system("", false /*read_only*/));
   assert(init);
 
   first_miner_.generate();


### PR DESCRIPTION
Instead of committing every block, commit everytime we know the DB has
changed and on shutdown. Upon profiling, every block added was taking an
additional ~9ms from HF15 because of `save_settings(...)` writing the
block hash and height to the DB.

If the daemon crashes during operation, then LNS only needs to scan
empty blocks up until that point which shouldn't be too slow and the
exception, not the norm.