### PR TITLE
console_handler: Fix wallets not exiting

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -273,14 +273,6 @@ eof:
     std::condition_variable m_response_cv;
   };
 
-
-  template<class t_server>
-  bool empty_commands_handler(t_server* psrv, const std::string& command)
-  {
-    return true;
-  }
-
-
   class async_console_handler
   {
   public:
@@ -397,59 +389,6 @@ eof:
     std::atomic<bool> m_running = {true};
     std::function<std::string(void)> m_prompt;
   };
-
-
-  template<class t_server, class t_handler>
-  bool start_default_console(t_server* ptsrv, t_handler handlr, std::function<std::string(void)> prompt, const std::string& usage = "")
-  {
-    std::shared_ptr<async_console_handler> console_handler = std::make_shared<async_console_handler>();
-    std::thread([=](){console_handler->run<t_server, t_handler>(ptsrv, handlr, prompt, usage);}).detach();
-    return true;
-  }
-
-  template<class t_server, class t_handler>
-  bool start_default_console(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    return start_default_console(ptsrv, handlr, [prompt](){ return prompt; }, usage);
-  }
-
-  template<class t_server>
-  bool start_default_console(t_server* ptsrv, const std::string& prompt, const std::string& usage = "")
-  {
-    return start_default_console(ptsrv, empty_commands_handler<t_server>, prompt, usage);
-  }
-
-  template<class t_server, class t_handler>
-    bool no_srv_param_adapter(t_server* ptsrv, const std::string& cmd, t_handler handlr)
-    {
-      return handlr(cmd);
-    }
-
-  template<class t_server, class t_handler>
-  bool run_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, std::function<std::string(void)> prompt, const std::string& usage = "")
-  {
-    async_console_handler console_handler;
-    return console_handler.run(ptsrv, [=](auto& a, auto& b) { return no_srv_param_adapter<t_server, t_handler>(a, b, handlr); }, prompt, usage);
-  }
-
-  template<class t_server, class t_handler>
-  bool run_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    return run_default_console_handler_no_srv_param(ptsrv, handlr, [prompt](){return prompt;},usage);
-  }
-
-  template<class t_server, class t_handler>
-  bool start_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, std::function<std::string(void)> prompt, const std::string& usage = "")
-  {
-    std::thread( std::bind(run_default_console_handler_no_srv_param<t_server, t_handler>, ptsrv, handlr, prompt, usage) );
-    return true;
-  }
-
-  template<class t_server, class t_handler>
-  bool start_default_console_handler_no_srv_param(t_server* ptsrv, t_handler handlr, const std::string& prompt, const std::string& usage = "")
-  {
-    return start_default_console_handler_no_srv_param(ptsrv, handlr, [prompt](){return prompt;}, usage);
-  }
 
   class command_handler {
   public:

--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -357,13 +357,13 @@ eof:
           {
             continue;
           }
-          else if(cmd_handler(command))
-          {
-            continue;
-          }
           else if(0 == command.compare("exit") || 0 == command.compare("q"))
           {
             continue_handle = false;
+          }
+          else if(cmd_handler(command))
+          {
+            continue;
           }
           else
           {

--- a/src/daemon/command_server.h
+++ b/src/daemon/command_server.h
@@ -56,7 +56,7 @@ public:
   command_server(cryptonote::rpc::core_rpc_server& rpc_server);
 
   template <typename... T>
-  bool process_command(T&&... args) { return m_command_lookup.process_command(std::forward<T>(args)...); }
+  bool process_command_and_log(T&&... args) { return m_command_lookup.process_command_and_log(std::forward<T>(args)...); }
 
   bool start_handling(std::function<void(void)> exit_handler = {});
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -271,17 +271,7 @@ int main(int argc, char const * argv[])
           return 1;
 
         daemonize::command_server rpc_commands{rpc_ip, rpc_port, std::move(login), std::move(*ssl_options)};
-
-        try {
-          if (rpc_commands.process_command(command))
-            return 0;
-        } catch (const std::out_of_range& e) {
-#ifdef HAVE_READLINE
-          rdln::suspend_readline pause_readline;
-#endif
-          std::cout << "Unknown command: " << e.what() << ".  Try 'help' for available commands\n";
-        }
-        return 1;
+        return rpc_commands.process_command_and_log(command) ? 0 : 1;
       }
     }
 

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -84,7 +84,8 @@ namespace cryptonote
     void interrupt();
 
     //wallet *create_wallet();
-    bool process_command(const std::vector<std::string> &args);
+    bool process_command_and_log(const std::vector<std::string> &args) { return m_cmd_binder.process_command_and_log(args); }
+//----------------------------------------------------------------------------------------------------
     std::string get_commands_str();
     std::string get_command_usage(const std::vector<std::string> &args);
   private:
@@ -92,8 +93,6 @@ namespace cryptonote
     enum ResetType { ResetNone, ResetSoft, ResetHard, ResetSoftKeepKI };
 
     bool handle_command_line(const boost::program_options::variables_map& vm);
-
-    bool run_console_handler();
 
     void wallet_idle_thread();
 


### PR DESCRIPTION
- In simplewallet, we don't report invalid/missing commands to the
CLI because we throw and catch errors that are logged silently. Now we
always log the to the user unless it's thrown by something other than
the wallet.

- Add invalid_command exception to distinguish between an error thrown
by the console_handler (i.e. missing/empty command) versus an actual
std::out_of_range thrown by wallet code (previously would have
incorrectly reported "Unknown command ... ", when it was a known command).

- Catch exceptions thrown via commands sent by RPC over the terminal and
shut down the wallet properly.

- In console_handler don't react to cmd_handler failing. Previously, if
a command failed it'd assume invalid command and log or try the next
branch which was detecting application exit.