### PR TITLE
Fix blink priority in cli wallet

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -5550,6 +5550,13 @@ bool simple_wallet::transfer_main(Transfer transfer_type, const std::vector<std:
   std::set<uint32_t> subaddr_indices  = {};
   if (!parse_subaddr_indices_and_priority(*m_wallet, local_args, subaddr_indices, priority)) return false;
 
+  if (priority == 0)
+  {
+    priority = m_wallet->get_default_priority();
+    if (priority == 0)
+      priority = transfer_type == Transfer::Locked ? tools::tx_priority_unimportant : tools::tx_priority_blink;
+  }
+
   const size_t min_args = (transfer_type == Transfer::Locked) ? 2 : 1;
   if(local_args.size() < min_args)
   {
@@ -6816,6 +6823,13 @@ bool simple_wallet::sweep_main(uint64_t below, Transfer transfer_type, const std
   std::set<uint32_t> subaddr_indices  = {};
   if (!parse_subaddr_indices_and_priority(*m_wallet, local_args, subaddr_indices, priority)) return false;
 
+  if (priority == 0)
+  {
+    priority = m_wallet->get_default_priority();
+    if (priority == 0)
+      priority = transfer_type == Transfer::Locked ? tools::tx_priority_unimportant : tools::tx_priority_blink;
+  }
+
   uint64_t unlock_block = 0;
   if (transfer_type == Transfer::Locked) {
     if (priority == tools::tx_priority_blink) {
@@ -6967,6 +6981,13 @@ bool simple_wallet::sweep_single(const std::vector<std::string> &args_)
   uint32_t priority = 0;
   if (local_args.size() > 0 && tools::parse_priority(local_args[0], priority))
     local_args.erase(local_args.begin());
+
+  if (priority == 0)
+  {
+    priority = m_wallet->get_default_priority();
+    if (priority == 0)
+      priority = tools::tx_priority_blink;
+  }
 
   size_t outputs = 1;
   if (local_args.size() > 0 && local_args[0].substr(0, 8) == "outputs=")

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7539,14 +7539,14 @@ uint64_t wallet2::get_fee_percent(uint32_t priority, txtype type) const
 
   const bool blinkable = type == txtype::standard;
 
-  if (priority == 0)
+  if (priority == 0) // 0 means no explicit priority was given, so use the wallet default
   {
-    priority = m_default_priority;
-    if ((priority == tx_priority_blink && !blinkable) || priority == 0)
-      priority = tx_priority_unimportant;
+    priority = m_default_priority > 0 ? m_default_priority : (uint32_t) tx_priority_blink;
+    if (priority == tx_priority_blink && !blinkable)
+      priority = tx_priority_unimportant; // The blink default is unusable for this tx, so fall back to unimportant
   }
 
-  // If it's a blinkable tx then we only have two relevant priorities: unimportant, and blink.
+  // If it's a blinkable tx then we blink it for everything priority other than unimportant.
   if (blinkable && priority != tx_priority_unimportant)
     priority = tx_priority_blink;
 


### PR DESCRIPTION
simplewallet needs to recognize 0 (for both unspecified and default priority) as meaning blink for blinkable transactions.

Fixes #1165 