### PR TITLE
SN: Remove old vote blob serialisation fixes

### DIFF
--- a/src/cryptonote_core/service_node_voting.cpp
+++ b/src/cryptonote_core/service_node_voting.cpp
@@ -626,62 +626,6 @@ namespace service_nodes
     return false;
   }
 
-  void vote_to_blob(const quorum_vote_t& vote, unsigned char blob[])
-  {
-    blob[0] = vote.version;
-    blob[1] = static_cast<uint8_t>(vote.type);
-    for (size_t i = 2; i < 8; i++)
-      blob[i] = 0; // padding
-    {
-      uint64_t height = boost::endian::native_to_little(vote.block_height);
-      std::memcpy(&blob[8], &height, 8);
-    }
-    blob[16] = static_cast<uint8_t>(vote.group);
-    blob[17] = 0; // padding
-    {
-      uint16_t iig = boost::endian::native_to_little(vote.index_in_group);
-      std::memcpy(&blob[18], &iig, 2);
-    }
-    std::memcpy(&blob[20], &vote.signature, 64);
-    for (size_t i = 84; i < 88; i++)
-      blob[i] = 0; // padding
-    if (vote.type == quorum_type::checkpointing)
-    {
-      std::memcpy(&blob[84], &vote.checkpoint, 32);
-      for (size_t i = 116; i < 120; i++)
-        blob[i] = 0; // padding
-    }
-    else
-    {
-      uint16_t wi = boost::endian::native_to_little(vote.state_change.worker_index);
-      uint16_t st = boost::endian::native_to_little(static_cast<uint16_t>(vote.state_change.state));
-      std::memcpy(&blob[84], &wi, 2);
-      std::memcpy(&blob[86], &st, 2);
-      for (size_t i = 88; i < 120; i++)
-        blob[i] = 0;
-    }
-  }
-
-  void blob_to_vote(const unsigned char blob[], quorum_vote_t& vote)
-  {
-    vote.version = blob[0];
-    vote.type = static_cast<quorum_type>(blob[1]);
-    std::memcpy(&vote.block_height, &blob[8], 8); boost::endian::little_to_native_inplace(vote.block_height);
-    vote.group = static_cast<quorum_group>(blob[16]);
-    std::memcpy(&vote.index_in_group, &blob[18], 2); boost::endian::little_to_native_inplace(vote.index_in_group);
-    std::memcpy(&vote.signature, &blob[20], 64);
-    if (vote.type == quorum_type::checkpointing)
-    {
-      std::memcpy(&vote.checkpoint, &blob[84], 32);
-    }
-    else
-    {
-      std::memcpy(&vote.state_change.worker_index, &blob[84], 2); boost::endian::little_to_native_inplace(vote.state_change.worker_index);
-      uint16_t st;
-      std::memcpy(&st, &blob[86], 2); vote.state_change.state = static_cast<new_state>(boost::endian::little_to_native(st));
-    }
-  }
-
     KV_SERIALIZE_MAP_CODE_BEGIN(quorum_vote_t)
       KV_SERIALIZE(version)
       KV_SERIALIZE_ENUM(type)

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -78,11 +78,6 @@ namespace service_nodes
   enum struct quorum_group : uint8_t { invalid, validator, worker, _count };
   struct quorum_vote_t
   {
-    // Note: This type has various padding and alignment and was mistakingly serialized as a blob
-    // (padding and all, and not portable).  To remain compatible, we have to reproduce the blob
-    // data byte-for-byte as expected in the loki 5.x struct memory layout on AMD64, via the
-    // vote_to_blob functions below.
-
     uint8_t           version = 0;
     quorum_type       type;
     uint64_t          block_height;
@@ -104,9 +99,6 @@ namespace service_nodes
     template <class Archive>
     void serialize(Archive &ar, const unsigned int /*version*/) { }
   };
-
-  void vote_to_blob(const quorum_vote_t& vote, unsigned char blob[]);
-  void blob_to_vote(const unsigned char blob[], quorum_vote_t& vote);
 
   struct voter_to_signature
   {
@@ -134,17 +126,6 @@ namespace service_nodes
   bool               verify_vote_signature              (uint8_t hf_version, const quorum_vote_t& vote, cryptonote::vote_verification_context &vvc, const service_nodes::quorum &quorum);
   crypto::signature  make_signature_from_vote           (quorum_vote_t const &vote, const service_node_keys &keys);
   crypto::signature  make_signature_from_tx_state_change(cryptonote::tx_extra_service_node_state_change const &state_change, const service_node_keys &keys);
-
-  // NOTE: This preserves the deregister vote format pre-checkpointing so that
-  // up to the hardfork, we can still deserialize and serialize until we switch
-  // over to the new format
-  struct legacy_deregister_vote
-  {
-    uint64_t          block_height;
-    uint32_t          service_node_index;
-    uint32_t          voters_quorum_index;
-    crypto::signature signature;
-  };
 
   struct pool_vote_entry
   {

--- a/src/cryptonote_protocol/cryptonote_protocol_defs.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_defs.h
@@ -40,10 +40,7 @@
 
 namespace service_nodes
 {
-  struct legacy_deregister_vote;
   struct quorum_vote_t;
-  void vote_to_blob(const quorum_vote_t& vote, unsigned char blob[]);
-  void blob_to_vote(const unsigned char blob[], quorum_vote_t& vote);
 };
 
 namespace cryptonote


### PR DESCRIPTION
Votes are ephemeral and the backwards compat fixes are only needed at
the time of the hard fork.