### PR TITLE
Pulse: Generate Quorums

### DIFF
--- a/src/common/random.h
+++ b/src/common/random.h
@@ -44,11 +44,10 @@ uint64_t uniform_distribution_portable(std::mt19937_64& rng, uint64_t n);
 /// Uniformly shuffles all the elements in [begin, end) in a deterministic method so that, given the
 /// same seed, this will always produce the same result on any platform/compiler/etc.
 template<typename RandomIt>
-void shuffle_portable(RandomIt begin, RandomIt end, uint64_t seed)
+void shuffle_portable(RandomIt begin, RandomIt end, std::mt19937_64 &rng)
 {
   if (end <= begin + 1) return;
   const size_t size = std::distance(begin, end);
-  std::mt19937_64 rng{seed};
   for (size_t i = 1; i < size; i++)
   {
     size_t j = (size_t)uniform_distribution_portable(rng, i+1);

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -463,10 +463,9 @@ namespace cryptonote
       VARINT_FIELD(minor_version)
       VARINT_FIELD(timestamp)
       FIELD(prev_id)
-      if (major_version >= HF_VERSION_PULSE)
+      FIELD(nonce)
+      if (major_version >= cryptonote::network_version_16)
         FIELD(pulse)
-      else
-        FIELD(nonce)
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -435,6 +435,20 @@ namespace cryptonote
   /************************************************************************/
   /*                                                                      */
   /************************************************************************/
+  struct pulse_random_value { unsigned char data[16]; };
+  struct pulse_header
+  {
+    pulse_random_value random_value;
+    uint8_t            round;
+    uint16_t           validator_participation_bits;
+
+    BEGIN_SERIALIZE()
+      FIELD(random_value);
+      FIELD(round);
+      FIELD(validator_participation_bits);
+    END_SERIALIZE();
+  };
+
   struct block_header
   {
     uint8_t major_version = cryptonote::network_version_7;
@@ -442,13 +456,17 @@ namespace cryptonote
     uint64_t timestamp;
     crypto::hash  prev_id;
     uint32_t nonce;
+    pulse_header pulse;
 
     BEGIN_SERIALIZE()
       VARINT_FIELD(major_version)
       VARINT_FIELD(minor_version)
       VARINT_FIELD(timestamp)
       FIELD(prev_id)
-      FIELD(nonce)
+      if (major_version >= HF_VERSION_PULSE)
+        FIELD(pulse)
+      else
+        FIELD(nonce)
     END_SERIALIZE()
   };
 
@@ -614,6 +632,7 @@ namespace std {
 
 BLOB_SERIALIZER(cryptonote::txout_to_key);
 BLOB_SERIALIZER(cryptonote::txout_to_scripthash);
+BLOB_SERIALIZER(cryptonote::pulse_random_value);
 
 VARIANT_TAG(binary_archive, cryptonote::txin_gen, 0xff);
 VARIANT_TAG(binary_archive, cryptonote::txin_to_script, 0x0);

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -171,7 +171,6 @@ static_assert(STAKING_PORTIONS % 12 == 0, "Use a multiple of twelve, so that it 
 #define HF_VERSION_REJECT_SIGS_IN_COINBASE      cryptonote::network_version_16
 #define HF_VERSION_ENFORCE_MIN_AGE              cryptonote::network_version_16
 #define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY cryptonote::network_version_16
-#define HF_VERSION_PULSE cryptonote::network_version_16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -171,6 +171,7 @@ static_assert(STAKING_PORTIONS % 12 == 0, "Use a multiple of twelve, so that it 
 #define HF_VERSION_REJECT_SIGS_IN_COINBASE      cryptonote::network_version_16
 #define HF_VERSION_ENFORCE_MIN_AGE              cryptonote::network_version_16
 #define HF_VERSION_EFFECTIVE_SHORT_TERM_MEDIAN_IN_PENALTY cryptonote::network_version_16
+#define HF_VERSION_PULSE cryptonote::network_version_16
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1181,25 +1181,24 @@ namespace service_nodes
     return true;
   }
 
-  static uint64_t quorum_rng_seed(uint8_t hf_version, crypto::hash const &hash, quorum_type type)
+  static std::mt19937_64 quorum_rng(uint8_t hf_version, crypto::hash const &hash, quorum_type type)
   {
-    uint64_t result = 0;
+    std::mt19937_64 result;
     if (hf_version >= cryptonote::network_version_16)
     {
       std::array<uint32_t, (sizeof(hash) / sizeof(uint32_t)) + 1> src = {static_cast<uint32_t>(type)};
       std::memcpy(&src[1], &hash, sizeof(hash));
       for (uint32_t &val : src) boost::endian::little_to_native_inplace(val);
       std::seed_seq sequence(src.begin(), src.end());
-
-      uint32_t seeds[2];
-      sequence.generate(std::begin(seeds), std::end(seeds));
-      result = (static_cast<uint64_t>(seeds[1]) << 32) | static_cast<uint64_t>(seeds[0]);
+      result.seed(sequence);
     }
     else
     {
-      std::memcpy(&result, hash.data, sizeof(result));
-      boost::endian::little_to_native_inplace(result);
-      result += static_cast<uint64_t>(type);
+      uint64_t seed = 0;
+      std::memcpy(&seed, hash.data, sizeof(seed));
+      boost::endian::little_to_native_inplace(seed);
+      seed += static_cast<uint64_t>(type);
+      result.seed(seed);
     }
 
     return result;
@@ -1215,8 +1214,8 @@ namespace service_nodes
   {
     std::vector<size_t> result(list_size);
     std::iota(result.begin(), result.end(), 0);
+    std::mt19937_64 rng = quorum_rng(hf_version, block_hash, type);
 
-    uint64_t seed = quorum_rng_seed(hf_version, block_hash, type);
     //       Shuffle 2
     //       |=================================|
     //       |                                 |
@@ -1234,11 +1233,11 @@ namespace service_nodes
     // reuse the same seed for both partial shuffles, but again, that isn't an issue.
     if ((0 < sublist_size && sublist_size < list_size) && (0 < sublist_up_to && sublist_up_to < list_size)) {
       assert(sublist_size <= sublist_up_to); // Can't select N random items from M items when M < N
-      tools::shuffle_portable(result.begin(), result.begin() + sublist_up_to, seed);
-      tools::shuffle_portable(result.begin() + sublist_size, result.end(), seed);
+      tools::shuffle_portable(result.begin(), result.begin() + sublist_up_to, rng);
+      tools::shuffle_portable(result.begin() + sublist_size, result.end(), rng);
     }
     else {
-      tools::shuffle_portable(result.begin(), result.end(), seed);
+      tools::shuffle_portable(result.begin(), result.end(), rng);
     }
     return result;
   }
@@ -1393,7 +1392,8 @@ namespace service_nodes
 
             if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
             {
-              tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), quorum_rng_seed(hf_version, state.block_hash, type));
+              std::mt19937_64 rng = quorum_rng(hf_version, state.block_hash, type);
+              tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), rng);
               num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
             }
             // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
@@ -1460,7 +1460,7 @@ namespace service_nodes
           size_t const partition_index = pulse_candidates.size() / 2;
           for (crypto::hash const &entropy : pulse_entropy)
           {
-            std::mt19937_64 rng(quorum_rng_seed(hf_version, entropy, type));
+            std::mt19937_64 rng = quorum_rng(hf_version, entropy, type);
             size_t candidate_index = tools::uniform_distribution_portable(rng, partition_index - std::distance(pulse_candidates.begin(), running_it));
             std::swap(*running_it, *(pulse_candidates.begin() + candidate_index));
             running_it++;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1253,69 +1253,79 @@ namespace service_nodes
       auto quorum           = std::make_shared<service_nodes::quorum>();
       std::vector<size_t> pub_keys_indexes;
 
-      if (type == quorum_type::obligations)
+      switch(type)
       {
-        size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
-        num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
-        pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
-        result.obligations         = quorum;
-        size_t num_remaining_nodes = total_nodes - num_validators;
-        num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
-      }
-      else if (type == quorum_type::checkpointing)
-      {
-        // Checkpoint quorums only exist every CHECKPOINT_INTERVAL blocks, but the height that gets
-        // used to generate the quorum (i.e. the `height` variable here) is actually `H -
-        // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, where H is divisible by CHECKPOINT_INTERVAL, but
-        // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 is not (it equals 11).  Hence the addition here to
-        // "undo" the lag before checking to see if we're on an interval multiple:
-        if ((state.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL != 0)
-          continue; // Not on an interval multiple: no checkpointing quorum is defined.
-
-        size_t total_nodes = active_snode_list.size();
-
-        // TODO(loki): Soft fork, remove when testnet gets reset
-        if (nettype == cryptonote::TESTNET && state.height < 85357)
-          total_nodes = active_snode_list.size() + decomm_snode_list.size();
-
-        if (total_nodes >= CHECKPOINT_QUORUM_SIZE)
+        case quorum_type::obligations:
         {
-          pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
-          num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+          size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
+          num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
+          pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
+          result.obligations         = quorum;
+          size_t num_remaining_nodes = total_nodes - num_validators;
+          num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
         }
-        result.checkpointing = quorum;
-      }
-      else if (type == quorum_type::blink)
-      {
-        if (state.height % BLINK_QUORUM_INTERVAL != 0)
+        break;
+
+        case quorum_type::checkpointing:
+        {
+          // Checkpoint quorums only exist every CHECKPOINT_INTERVAL blocks, but the height that gets
+          // used to generate the quorum (i.e. the `height` variable here) is actually `H -
+          // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, where H is divisible by CHECKPOINT_INTERVAL, but
+          // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 is not (it equals 11).  Hence the addition here to
+          // "undo" the lag before checking to see if we're on an interval multiple:
+          if ((state.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL != 0)
+            continue; // Not on an interval multiple: no checkpointing quorum is defined.
+
+          size_t total_nodes = active_snode_list.size();
+
+          // TODO(loki): Soft fork, remove when testnet gets reset
+          if (nettype == cryptonote::TESTNET && state.height < 85357)
+            total_nodes = active_snode_list.size() + decomm_snode_list.size();
+
+          if (total_nodes >= CHECKPOINT_QUORUM_SIZE)
+          {
+            pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
+            num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+          }
+          result.checkpointing = quorum;
+        }
+        break;
+
+        case quorum_type::blink:
+        {
+          if (state.height % BLINK_QUORUM_INTERVAL != 0)
+            continue;
+
+          // Further filter the active SN list for the blink quorum to only include SNs that are not
+          // scheduled to finish unlocking between the quorum height and a few blocks after the
+          // associated blink height.
+          pub_keys_indexes.reserve(active_snode_list.size());
+          uint64_t const active_until = state.height + BLINK_EXPIRY_BUFFER;
+          for (size_t index = 0; index < active_snode_list.size(); index++)
+          {
+            pubkey_and_sninfo const &entry = active_snode_list[index];
+            uint64_t requested_unlock_height = entry.second->requested_unlock_height;
+            if (requested_unlock_height == KEY_IMAGE_AWAITING_UNLOCK_HEIGHT || requested_unlock_height > active_until)
+              pub_keys_indexes.push_back(index);
+          }
+
+          if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
+          {
+            tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), service_node_index_list_shuffle_seed(state.block_hash, type));
+            num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
+          }
+          // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
+          // distinguish it from an invalid height, which gets left as a nullptr)
+          result.blink = quorum;
+        }
+        break;
+
+        default:
+        {
+          MERROR("Unhandled quorum type enum with value: " << type_int);
           continue;
-
-        // Further filter the active SN list for the blink quorum to only include SNs that are not
-        // scheduled to finish unlocking between the quorum height and a few blocks after the
-        // associated blink height.
-        pub_keys_indexes.reserve(active_snode_list.size());
-        uint64_t const active_until = state.height + BLINK_EXPIRY_BUFFER;
-        for (size_t index = 0; index < active_snode_list.size(); index++)
-        {
-          pubkey_and_sninfo const &entry = active_snode_list[index];
-          uint64_t requested_unlock_height = entry.second->requested_unlock_height;
-          if (requested_unlock_height == KEY_IMAGE_AWAITING_UNLOCK_HEIGHT || requested_unlock_height > active_until)
-            pub_keys_indexes.push_back(index);
         }
-
-        if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
-        {
-          tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), service_node_index_list_shuffle_seed(state.block_hash, type));
-          num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
-        }
-        // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
-        // distinguish it from an invalid height, which gets left as a nullptr)
-        result.blink = quorum;
-      }
-      else
-      {
-        MERROR("Unhandled quorum type enum with value: " << type_int);
-        continue;
+        break;
       }
 
       quorum->validators.reserve(num_validators);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1181,16 +1181,32 @@ namespace service_nodes
     return true;
   }
 
-  static uint64_t quorum_rng_seed(crypto::hash const &hash, quorum_type type)
+  static uint64_t quorum_rng_seed(uint8_t hf_version, crypto::hash const &hash, quorum_type type)
   {
     uint64_t result = 0;
-    std::memcpy(&result, hash.data, sizeof(result));
-    boost::endian::little_to_native_inplace(result);
-    result += static_cast<uint64_t>(type);
+    if (hf_version >= cryptonote::network_version_16)
+    {
+      std::array<uint32_t, (sizeof(hash) / sizeof(uint32_t)) + 1> src = {static_cast<uint32_t>(type)};
+      std::memcpy(&src[1], &hash, sizeof(hash));
+      for (uint32_t &val : src) boost::endian::little_to_native_inplace(val);
+      std::seed_seq sequence(src.begin(), src.end());
+
+      uint32_t seeds[2];
+      sequence.generate(std::begin(seeds), std::end(seeds));
+      result = (static_cast<uint64_t>(seeds[1]) << 32) | static_cast<uint64_t>(seeds[0]);
+    }
+    else
+    {
+      std::memcpy(&result, hash.data, sizeof(result));
+      boost::endian::little_to_native_inplace(result);
+      result += static_cast<uint64_t>(type);
+    }
+
     return result;
   }
 
   static std::vector<size_t> generate_shuffled_service_node_index_list(
+      uint8_t hf_version,
       size_t list_size,
       crypto::hash const &block_hash,
       quorum_type type,
@@ -1200,7 +1216,7 @@ namespace service_nodes
     std::vector<size_t> result(list_size);
     std::iota(result.begin(), result.end(), 0);
 
-    uint64_t seed = quorum_rng_seed(block_hash, type);
+    uint64_t seed = quorum_rng_seed(hf_version, block_hash, type);
     //       Shuffle 2
     //       |=================================|
     //       |                                 |
@@ -1336,7 +1352,7 @@ namespace service_nodes
           {
             size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
             num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
-            pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
+            pub_keys_indexes           = generate_shuffled_service_node_index_list(hf_version, total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
             result.obligations         = quorum;
             size_t num_remaining_nodes = total_nodes - num_validators;
             num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
@@ -1359,7 +1375,7 @@ namespace service_nodes
 
             if (total_nodes >= CHECKPOINT_QUORUM_SIZE)
             {
-              pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
+              pub_keys_indexes = generate_shuffled_service_node_index_list(hf_version, total_nodes, state.block_hash, type);
               num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
             }
             result.checkpointing = quorum;
@@ -1385,7 +1401,7 @@ namespace service_nodes
 
             if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
             {
-              tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), quorum_rng_seed(state.block_hash, type));
+              tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), quorum_rng_seed(hf_version, state.block_hash, type));
               num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
             }
             // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
@@ -1452,7 +1468,7 @@ namespace service_nodes
           size_t const partition_index = pulse_candidates.size() / 2;
           for (crypto::hash const &entropy : pulse_entropy)
           {
-            std::mt19937_64 rng(quorum_rng_seed(entropy, type));
+            std::mt19937_64 rng(quorum_rng_seed(hf_version, entropy, type));
             size_t candidate_index = tools::uniform_distribution_portable(rng, partition_index - std::distance(pulse_candidates.begin(), running_it));
             std::swap(*running_it, *(pulse_candidates.begin() + candidate_index));
             running_it++;

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1327,7 +1327,7 @@ namespace service_nodes
     // are no decommissioned nodes, so this distinction is irrelevant for network concensus).
     std::vector<pubkey_and_sninfo> decomm_snode_list;
     if (hf_version >= cryptonote::network_version_12_checkpointing)
-        decomm_snode_list = state.decommissioned_service_nodes_infos();
+      decomm_snode_list = state.decommissioned_service_nodes_infos();
 
     quorum_type const max_quorum_type = max_quorum_type_for_hf(hf_version);
     for (int type_int = 0; type_int <= (int)max_quorum_type; type_int++)
@@ -1467,15 +1467,19 @@ namespace service_nodes
           }
 
           // NOTE: Sort ascending in height i.e. sort preferring the longest time since the validator was in a Pulse quorum.
-          std::sort(pulse_candidates.begin(), pulse_candidates.end(), [](pubkey_and_sninfo const *a, pubkey_and_sninfo const *b) {
-                      bool result = a->second->last_height_validating_for_pulse < b->second->last_height_validating_for_pulse;
+          std::stable_sort(pulse_candidates.begin(), pulse_candidates.end(), [](pubkey_and_sninfo const *a, pubkey_and_sninfo const *b) {
+                      auto a_key  = std::make_pair(a->second->pulse_sort_key.last_height_validating_in_quorum, a->second->pulse_sort_key.quorum_index);
+                      auto b_key  = std::make_pair(b->second->pulse_sort_key.last_height_validating_in_quorum, b->second->pulse_sort_key.quorum_index);
+                      bool result = a_key < b_key;
                       return result;
                     });
 
+          // NOTE: Divide the list in half, select validators from the first half of the list.
+          // Remove them from the list of candidates once chosen.
+          size_t const midpoint = pulse_candidates.size() / 2;
           for (size_t i = 0; i < pulse_entropy.size(); i++)
           {
-            size_t const partition_index = std::min(pulse_candidates.size() / 2, pulse_candidates.size());
-
+            size_t const partition_index = std::min(midpoint, pulse_candidates.size());
             std::mt19937_64 rng(quorum_rng_seed(pulse_entropy[i], type));
             size_t candidate_index             = tools::uniform_distribution_portable(rng, partition_index);
             pubkey_and_sninfo const *candidate = pulse_candidates[candidate_index];
@@ -1485,7 +1489,9 @@ namespace service_nodes
 
             // NOTE: Send candidate to the back of the list
             auto &info_ptr = state.service_nodes_infos.at(candidate->first);
-            duplicate_info(info_ptr).last_height_validating_for_pulse = state.height;
+            service_node_info &new_info = duplicate_info(info_ptr);
+            new_info.pulse_sort_key.last_height_validating_in_quorum = state.height;
+            new_info.pulse_sort_key.quorum_index = quorum->validators.size() - 1;
           }
         }
         break;
@@ -2444,6 +2450,11 @@ namespace service_nodes
       {
         // Nothing to do here (the missing data will be generated in the new proofs db via uptime proofs).
         info.version = version_t::v4_noproofs;
+      }
+      if (info.version < version_t::v5_pulse)
+      {
+        info.version = version_t::v5_pulse;
+        info.pulse_sort_key.last_height_validating_in_quorum = info.last_reward_block_height;
       }
       // Make sure we handled any future state version upgrades:
       assert(info.version == tools::enum_top<decltype(info.version)>);

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1185,6 +1185,15 @@ namespace service_nodes
     return true;
   }
 
+  static uint64_t service_node_index_list_shuffle_seed(crypto::hash const &hash, quorum_type type)
+  {
+    uint64_t result = 0;
+    std::memcpy(&result, hash.data, sizeof(result));
+    boost::endian::little_to_native_inplace(result);
+    result += static_cast<uint64_t>(type);
+    return result;
+  }
+
   static std::vector<size_t> generate_shuffled_service_node_index_list(
       size_t list_size,
       crypto::hash const &block_hash,
@@ -1195,12 +1204,7 @@ namespace service_nodes
     std::vector<size_t> result(list_size);
     std::iota(result.begin(), result.end(), 0);
 
-    uint64_t seed = 0;
-    std::memcpy(&seed, block_hash.data, std::min(sizeof(seed), sizeof(block_hash.data)));
-    boost::endian::little_to_native_inplace(seed);
-
-    seed += static_cast<uint64_t>(type);
-
+    uint64_t seed = service_node_index_list_shuffle_seed(block_hash, type);
     //       Shuffle 2
     //       |=================================|
     //       |                                 |
@@ -1236,10 +1240,10 @@ namespace service_nodes
     // state change *validators* want only active service nodes, but the state change *workers*
     // (i.e. the nodes to be tested) also include decommissioned service nodes.  (Prior to v12 there
     // are no decommissioned nodes, so this distinction is irrelevant for network concensus).
-    auto active_snode_list = state.active_service_nodes_infos();
-    decltype(active_snode_list) decomm_snode_list;
+    std::vector<pubkey_and_sninfo> const active_snode_list = state.active_service_nodes_infos();
+    std::vector<pubkey_and_sninfo> decomm_snode_list;
     if (hf_version >= cryptonote::network_version_12_checkpointing)
-      decomm_snode_list = state.decommissioned_service_nodes_infos();
+        decomm_snode_list = state.decommissioned_service_nodes_infos();
 
     quorum_type const max_quorum_type = max_quorum_type_for_hf(hf_version);
     for (int type_int = 0; type_int <= (int)max_quorum_type; type_int++)
@@ -1289,18 +1293,19 @@ namespace service_nodes
         // Further filter the active SN list for the blink quorum to only include SNs that are not
         // scheduled to finish unlocking between the quorum height and a few blocks after the
         // associated blink height.
-        active_snode_list.erase(std::remove_if(active_snode_list.begin(), active_snode_list.end(),
-            [active_until = state.height + BLINK_EXPIRY_BUFFER](auto &info) {
-              auto ruh = info.second->requested_unlock_height;
-              return ruh != KEY_IMAGE_AWAITING_UNLOCK_HEIGHT && ruh <= active_until;
-            }),
-            active_snode_list.end()
-        );
-        size_t total_nodes = active_snode_list.size();
-
-        if (total_nodes >= BLINK_MIN_VOTES)
+        pub_keys_indexes.reserve(active_snode_list.size());
+        uint64_t const active_until = state.height + BLINK_EXPIRY_BUFFER;
+        for (size_t index = 0; index < active_snode_list.size(); index++)
         {
-          pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
+          pubkey_and_sninfo const &entry = active_snode_list[index];
+          uint64_t requested_unlock_height = entry.second->requested_unlock_height;
+          if (requested_unlock_height == KEY_IMAGE_AWAITING_UNLOCK_HEIGHT || requested_unlock_height > active_until)
+            pub_keys_indexes.push_back(index);
+        }
+
+        if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
+        {
+          tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), service_node_index_list_shuffle_seed(state.block_hash, type));
           num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
         }
         // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1290,14 +1290,6 @@ namespace service_nodes
     for (cryptonote::block const &block : blocks)
     {
       crypto::hash hash = {};
-      uint64_t const xor64 = ((uint64_t)pulse_round & 0xFF) <<  0 |
-                             ((uint64_t)pulse_round & 0xFF) <<  8 |
-                             ((uint64_t)pulse_round & 0xFF) << 16 |
-                             ((uint64_t)pulse_round & 0xFF) << 24 |
-                             ((uint64_t)pulse_round & 0xFF) << 32 |
-                             ((uint64_t)pulse_round & 0xFF) << 40 |
-                             ((uint64_t)pulse_round & 0xFF) << 48 |
-                             ((uint64_t)pulse_round & 0xFF) << 56;
       if (block.major_version >= cryptonote::network_version_16)
       {
         std::array<uint8_t, 1 + sizeof(block.pulse.random_value)> src = {pulse_round};

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1493,6 +1493,8 @@ namespace service_nodes
             new_info.pulse_sort_key.last_height_validating_in_quorum = state.height;
             new_info.pulse_sort_key.quorum_index = quorum->validators.size() - 1;
           }
+
+          result.pulse = quorum;
         }
         break;
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -127,10 +127,6 @@ namespace service_nodes
     return result;
   }
 
-  std::vector<pubkey_and_sninfo> service_node_list::state_t::active_service_nodes_infos() const {
-    return sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_active(); });
-  }
-
   std::vector<pubkey_and_sninfo> service_node_list::state_t::decommissioned_service_nodes_infos() const {
     return sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_decommissioned() && info.is_fully_funded(); }, /*reserve=*/ false);
   }
@@ -1185,7 +1181,7 @@ namespace service_nodes
     return true;
   }
 
-  static uint64_t service_node_index_list_shuffle_seed(crypto::hash const &hash, quorum_type type)
+  static uint64_t quorum_rng_seed(crypto::hash const &hash, quorum_type type)
   {
     uint64_t result = 0;
     std::memcpy(&result, hash.data, sizeof(result));
@@ -1204,7 +1200,7 @@ namespace service_nodes
     std::vector<size_t> result(list_size);
     std::iota(result.begin(), result.end(), 0);
 
-    uint64_t seed = service_node_index_list_shuffle_seed(block_hash, type);
+    uint64_t seed = quorum_rng_seed(block_hash, type);
     //       Shuffle 2
     //       |=================================|
     //       |                                 |
@@ -1231,7 +1227,66 @@ namespace service_nodes
     return result;
   }
 
-  static quorum_manager generate_quorums(cryptonote::network_type nettype, uint8_t hf_version, service_node_list::state_t const &state)
+  static bool get_pulse_entropy_from_blockchain(cryptonote::BlockchainDB const &db, std::vector<crypto::hash> &entropy)
+  {
+    uint64_t current_height = db.height();
+    if (current_height < PULSE_QUORUM_ENTROPY_LAG)
+    {
+      const bool DEVELOPMENT = true; // TODO(doyle): Cleanup
+      if (DEVELOPMENT)
+      {
+          entropy.resize(PULSE_QUORUM_SIZE);
+          entropy[0]  = crypto::hash{"\x87\x28\x89\xe2\xe3\x63\xc7\x7d\xb6\x38\xbd\xa3\xa2\x00\x57\x2f\x3a\x01\x2d\x8a\xd1\x2c\xb6\xab\x00\x55\x6b\x60\xda\x25\xca"};
+          entropy[1]  = crypto::hash{"\x27\xca\xab\x1e\xcf\x33\xa7\x49\x88\xba\x17\xb0\x28\xa4\x19\x76\x84\x7f\x71\xa7\xeb\x38\xb1\x16\x10\xa0\xe3\x89\xa3\xd7\xa6"};
+          entropy[2]  = crypto::hash{"\x61\xc6\x37\x25\x58\x50\x7f\x11\x12\x8f\x79\xa7\x2c\xdb\x89\xdb\x43\x15\xe9\xd8\x28\x19\xe2\x68\xeb\x31\xb5\xad\x10\xf4\xb6"};
+          entropy[3]  = crypto::hash{"\x85\x7a\xb6\xf4\x4b\x87\xff\xa4\x2e\x7f\x38\xb1\x18\xa3\xfa\xef\xa6\xea\xad\x23\xcf\xbd\x29\xf4\x31\x51\xb5\xa4\xf7\x9d\x37"};
+          entropy[4]  = crypto::hash{"\x8a\x32\x67\xfc\xfe\xb5\xe7\x0c\x46\xea\x15\x2d\xd9\xf0\xc5\xbf\xd6\x34\x52\xeb\x2f\x57\xd3\x00\xef\x3d\x5f\xc1\x1e\x19\x4d"};
+          entropy[5]  = crypto::hash{"\xef\xd0\x45\xac\x06\x35\x3a\x36\xd4\xd5\xdb\xd9\x40\x31\xb7\x7b\x73\x87\x71\x43\x58\x13\x33\xa1\xa1\x59\xde\x13\x3f\x1b\xc1"};
+          entropy[6]  = crypto::hash{"\xa6\x83\x32\x9a\x70\x69\x55\x78\x1a\x25\x13\x9e\x60\x1e\x71\x31\x2a\x04\x89\xe0\xfe\x47\x5b\x14\x90\xc5\x58\x88\x2a\x90\x86"};
+          entropy[7]  = crypto::hash{"\x3b\x77\xff\x72\x0d\x22\x12\xb9\xb1\x64\x0d\xef\x2f\x80\x4a\x64\x5d\xdc\xba\xa0\x1f\xf7\x4d\xbc\xd4\x1d\xe8\xea\x6c\x3f\xbd"};
+          entropy[8]  = crypto::hash{"\x8c\x81\x6c\x77\xf0\x62\x55\xff\x38\xec\x57\x22\x62\x2e\x49\xd4\x44\x5a\xe3\x02\x27\xb6\xb3\xe4\x3c\xc7\x9f\xb8\xc5\x90\xa1"};
+          entropy[9]  = crypto::hash{"\x18\x8e\x4f\xb5\x99\x74\xec\x78\xf9\x7b\x36\x87\x14\x82\x05\x32\x07\xf3\x21\x21\x6d\x8e\xfd\x35\xe6\x70\xa3\x89\x17\x22\x4b"};
+          entropy[10] = crypto::hash{"\xb7\xbe\x54\xe3\x21\xe3\xeb\x88\xda\xab\xf1\xf7\x50\xb9\xef\x98\xa5\xcf\x9f\x75\x81\x74\x16\xbc\x85\x78\x6e\x0c\xaa\x14\x99"};
+          return true;
+      }
+
+      return false;
+    }
+
+    uint64_t start_height = current_height - PULSE_QUORUM_ENTROPY_LAG;
+    uint64_t end_height   = start_height + PULSE_QUORUM_SIZE;
+    std::vector<cryptonote::block> blocks;
+    try
+    {
+      blocks = db.get_blocks_range(start_height, end_height - 1 /*it is inclusive*/);
+    }
+    catch(std::exception const &e)
+    {
+      MERROR("Failed to get quorum entropy for Pulse, starting from block: " << start_height << ", reason: " << e.what());
+      return false;
+    }
+
+    entropy.reserve(blocks.size());
+    for (cryptonote::block const &block : blocks)
+    {
+      crypto::hash hash = {};
+      if (block.major_version >= HF_VERSION_PULSE)
+      {
+        crypto::cn_fast_hash(block.pulse.random_value.data, sizeof(block.pulse.random_value), hash.data);
+      }
+      else
+      {
+        hash = cryptonote::get_block_hash(block);
+      }
+
+      assert(hash != crypto::null_hash);
+      entropy.push_back(hash);
+    }
+
+    return true;
+  }
+
+  static quorum_manager generate_quorums(service_node_list::state_t &state, std::vector<pubkey_and_sninfo> const &active_snode_list, cryptonote::network_type nettype, uint8_t hf_version, std::vector<crypto::hash> &pulse_entropy)
   {
     quorum_manager result = {};
     assert(state.block_hash != crypto::null_hash);
@@ -1240,7 +1295,6 @@ namespace service_nodes
     // state change *validators* want only active service nodes, but the state change *workers*
     // (i.e. the nodes to be tested) also include decommissioned service nodes.  (Prior to v12 there
     // are no decommissioned nodes, so this distinction is irrelevant for network concensus).
-    std::vector<pubkey_and_sninfo> const active_snode_list = state.active_service_nodes_infos();
     std::vector<pubkey_and_sninfo> decomm_snode_list;
     if (hf_version >= cryptonote::network_version_12_checkpointing)
         decomm_snode_list = state.decommissioned_service_nodes_infos();
@@ -1248,102 +1302,171 @@ namespace service_nodes
     quorum_type const max_quorum_type = max_quorum_type_for_hf(hf_version);
     for (int type_int = 0; type_int <= (int)max_quorum_type; type_int++)
     {
-      auto type             = static_cast<quorum_type>(type_int);
-      size_t num_validators = 0, num_workers = 0;
-      auto quorum           = std::make_shared<service_nodes::quorum>();
+      auto type   = static_cast<quorum_type>(type_int);
+      auto quorum = std::make_shared<service_nodes::quorum>();
       std::vector<size_t> pub_keys_indexes;
 
       switch(type)
       {
         case quorum_type::obligations:
-        {
-          size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
-          num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
-          pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
-          result.obligations         = quorum;
-          size_t num_remaining_nodes = total_nodes - num_validators;
-          num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
-        }
-        break;
-
         case quorum_type::checkpointing:
-        {
-          // Checkpoint quorums only exist every CHECKPOINT_INTERVAL blocks, but the height that gets
-          // used to generate the quorum (i.e. the `height` variable here) is actually `H -
-          // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, where H is divisible by CHECKPOINT_INTERVAL, but
-          // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 is not (it equals 11).  Hence the addition here to
-          // "undo" the lag before checking to see if we're on an interval multiple:
-          if ((state.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL != 0)
-            continue; // Not on an interval multiple: no checkpointing quorum is defined.
-
-          size_t total_nodes = active_snode_list.size();
-
-          // TODO(loki): Soft fork, remove when testnet gets reset
-          if (nettype == cryptonote::TESTNET && state.height < 85357)
-            total_nodes = active_snode_list.size() + decomm_snode_list.size();
-
-          if (total_nodes >= CHECKPOINT_QUORUM_SIZE)
-          {
-            pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
-            num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
-          }
-          result.checkpointing = quorum;
-        }
-        break;
-
         case quorum_type::blink:
         {
-          if (state.height % BLINK_QUORUM_INTERVAL != 0)
-            continue;
+          size_t num_validators = 0;
+          size_t num_workers    = 0;
 
-          // Further filter the active SN list for the blink quorum to only include SNs that are not
-          // scheduled to finish unlocking between the quorum height and a few blocks after the
-          // associated blink height.
-          pub_keys_indexes.reserve(active_snode_list.size());
-          uint64_t const active_until = state.height + BLINK_EXPIRY_BUFFER;
-          for (size_t index = 0; index < active_snode_list.size(); index++)
+          if (type == quorum_type::obligations)
           {
-            pubkey_and_sninfo const &entry = active_snode_list[index];
-            uint64_t requested_unlock_height = entry.second->requested_unlock_height;
-            if (requested_unlock_height == KEY_IMAGE_AWAITING_UNLOCK_HEIGHT || requested_unlock_height > active_until)
-              pub_keys_indexes.push_back(index);
+            size_t total_nodes         = active_snode_list.size() + decomm_snode_list.size();
+            num_validators             = std::min(active_snode_list.size(), STATE_CHANGE_QUORUM_SIZE);
+            pub_keys_indexes           = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type, num_validators, active_snode_list.size());
+            result.obligations         = quorum;
+            size_t num_remaining_nodes = total_nodes - num_validators;
+            num_workers                = std::min(num_remaining_nodes, std::max(STATE_CHANGE_MIN_NODES_TO_TEST, num_remaining_nodes/STATE_CHANGE_NTH_OF_THE_NETWORK_TO_TEST));
+          }
+          else if (type == quorum_type::checkpointing)
+          {
+            // Checkpoint quorums only exist every CHECKPOINT_INTERVAL blocks, but the height that gets
+            // used to generate the quorum (i.e. the `height` variable here) is actually `H -
+            // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12`, where H is divisible by CHECKPOINT_INTERVAL, but
+            // REORG_SAFETY_BUFFER_BLOCKS_POST_HF12 is not (it equals 11).  Hence the addition here to
+            // "undo" the lag before checking to see if we're on an interval multiple:
+            if ((state.height + REORG_SAFETY_BUFFER_BLOCKS_POST_HF12) % CHECKPOINT_INTERVAL != 0)
+              continue; // Not on an interval multiple: no checkpointing quorum is defined.
+
+            size_t total_nodes = active_snode_list.size();
+
+            // TODO(loki): Soft fork, remove when testnet gets reset
+            if (nettype == cryptonote::TESTNET && state.height < 85357)
+              total_nodes = active_snode_list.size() + decomm_snode_list.size();
+
+            if (total_nodes >= CHECKPOINT_QUORUM_SIZE)
+            {
+              pub_keys_indexes = generate_shuffled_service_node_index_list(total_nodes, state.block_hash, type);
+              num_validators   = std::min(pub_keys_indexes.size(), CHECKPOINT_QUORUM_SIZE);
+            }
+            result.checkpointing = quorum;
+          }
+          else
+          {
+            assert(type == quorum_type::blink);
+            if (state.height % BLINK_QUORUM_INTERVAL != 0)
+              continue;
+
+            // Further filter the active SN list for the blink quorum to only include SNs that are not
+            // scheduled to finish unlocking between the quorum height and a few blocks after the
+            // associated blink height.
+            pub_keys_indexes.reserve(active_snode_list.size());
+            uint64_t const active_until = state.height + BLINK_EXPIRY_BUFFER;
+            for (size_t index = 0; index < active_snode_list.size(); index++)
+            {
+              pubkey_and_sninfo const &entry = active_snode_list[index];
+              uint64_t requested_unlock_height = entry.second->requested_unlock_height;
+              if (requested_unlock_height == KEY_IMAGE_AWAITING_UNLOCK_HEIGHT || requested_unlock_height > active_until)
+                pub_keys_indexes.push_back(index);
+            }
+
+            if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
+            {
+              tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), quorum_rng_seed(state.block_hash, type));
+              num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
+            }
+            // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
+            // distinguish it from an invalid height, which gets left as a nullptr)
+            result.blink = quorum;
           }
 
-          if (pub_keys_indexes.size() >= BLINK_MIN_VOTES)
+          quorum->validators.reserve(num_validators);
+          quorum->workers.reserve(num_workers);
+
+          size_t i = 0;
+          for (; i < num_validators; i++)
           {
-            tools::shuffle_portable(pub_keys_indexes.begin(), pub_keys_indexes.end(), service_node_index_list_shuffle_seed(state.block_hash, type));
-            num_validators = std::min<size_t>(pub_keys_indexes.size(), BLINK_SUBQUORUM_SIZE);
+            quorum->validators.push_back(active_snode_list[pub_keys_indexes[i]].first);
           }
-          // Otherwise leave empty to signal that there aren't enough SNs to form a usable quorum (to
-          // distinguish it from an invalid height, which gets left as a nullptr)
-          result.blink = quorum;
+
+          for (; i < num_validators + num_workers; i++)
+          {
+            size_t j = pub_keys_indexes[i];
+            if (j < active_snode_list.size())
+              quorum->workers.push_back(active_snode_list[j].first);
+            else
+              quorum->workers.push_back(decomm_snode_list[j - active_snode_list.size()].first);
+          }
         }
         break;
 
-        default:
+        case quorum_type::pulse:
         {
-          MERROR("Unhandled quorum type enum with value: " << type_int);
-          continue;
+          // NOTE: In Pulse, take the next Service Node Winner as the leader of
+          // the Pulse Quorum. We choose validators from the first half of the
+          // list and send them to the back of the list.  We need
+          // (PULSE_QUORUM_SIZE * 2) Service Nodes to avoid a chance of the
+          // just chosen Service Node re-entering the first half of the list and
+          // being selected again in the same quorum.
+
+          if (active_snode_list.size() < (PULSE_QUORUM_SIZE * 2) + 1 /*leader*/))
+          {
+            // TODO(doyle): We need fallback code
+            MERROR("Insufficient active Service Nodes for Pulse: " << active_snode_list.size());
+            continue;
+          }
+
+          if (pulse_entropy.size() < PULSE_QUORUM_SIZE)
+          {
+            MERROR("Blockchain has insufficient blocks to generate Pulse data");
+            continue;
+          }
+
+          std::vector<pubkey_and_sninfo const *> pulse_candidates;
+          pulse_candidates.reserve(active_snode_list.size());
+
+          // TODO(doyle): Support leaders failing and iterating the round for this block.
+          // NOTE: Find the leader for this block
+          {
+            auto best_leader_index = static_cast<size_t>(-1);
+            auto best_reward_time  = std::make_pair(static_cast<uint64_t>(-1), static_cast<uint32_t>(-1));
+            for (size_t node_index = 0; node_index < active_snode_list.size(); node_index++)
+            {
+              pubkey_and_sninfo const &node = active_snode_list[node_index];
+              auto reward_time = std::make_pair(node.second->last_reward_block_height, node.second->last_reward_transaction_index);
+              if (reward_time < best_reward_time)
+              {
+                best_reward_time  = reward_time;
+                best_leader_index = node_index;
+              }
+
+              pulse_candidates.push_back(&node);
+            }
+
+            quorum->workers.push_back(pulse_candidates[best_leader_index]->first);
+            pulse_candidates.erase(pulse_candidates.begin() + best_leader_index);
+          }
+
+          // NOTE: Sort ascending in height i.e. sort preferring the longest time since the validator was in a Pulse quorum.
+          std::sort(pulse_candidates.begin(), pulse_candidates.end(), [](pubkey_and_sninfo const *a, pubkey_and_sninfo const *b) {
+                      bool result = a->second->last_height_validating_for_pulse < b->second->last_height_validating_for_pulse;
+                      return result;
+                    });
+
+          for (size_t i = 0; i < pulse_entropy.size(); i++)
+          {
+            std::mt19937_64 rng(quorum_rng_seed(pulse_entropy[i], type));
+            size_t candidate_index             = tools::uniform_distribution_portable(rng, pulse_candidates.size() / 2);
+            pubkey_and_sninfo const *candidate = pulse_candidates[candidate_index];
+
+            quorum->validators.push_back(candidate->first);
+            pulse_candidates.erase(pulse_candidates.begin() + candidate_index);
+
+            // NOTE: Send candidate to the back of the list
+            pulse_candidates.push_back(candidate);
+            auto &info_ptr = state.service_nodes_infos.at(candidate->first);
+            duplicate_info(info_ptr).last_height_validating_for_pulse = state.height;
+          }
         }
         break;
-      }
 
-      quorum->validators.reserve(num_validators);
-      quorum->workers.reserve(num_workers);
-
-      size_t i = 0;
-      for (; i < num_validators; i++)
-      {
-        quorum->validators.push_back(active_snode_list[pub_keys_indexes[i]].first);
-      }
-
-      for (; i < num_validators + num_workers; i++)
-      {
-        size_t j = pub_keys_indexes[i];
-        if (j < active_snode_list.size())
-          quorum->workers.push_back(active_snode_list[j].first);
-        else
-          quorum->workers.push_back(decomm_snode_list[j - active_snode_list.size()].first);
+        default: MERROR("Unhandled quorum type enum with value: " << type_int); break;
       }
     }
 
@@ -1435,6 +1558,9 @@ namespace service_nodes
       }
     }
 
+    // Filtered pubkey-sorted vector of service nodes that are active (fully funded and *not* decommissioned).
+    std::vector<pubkey_and_sninfo> active_snode_list = sort_and_filter(service_nodes_infos, [](const service_node_info &info) { return info.is_active(); });
+
     if (need_swarm_update)
     {
       crypto::hash const block_hash = cryptonote::get_block_hash(block);
@@ -1443,7 +1569,7 @@ namespace service_nodes
 
       /// Gather existing swarms from infos
       swarm_snode_map_t existing_swarms;
-      for (const auto &key_info : active_service_nodes_infos())
+      for (const auto &key_info : active_snode_list)
         existing_swarms[key_info.second->swarm_id].push_back(key_info.first);
 
       calc_swarm_changes(existing_swarms, seed);
@@ -1463,7 +1589,10 @@ namespace service_nodes
       }
     }
 
-    quorums = generate_quorums(nettype, hf_version, *this);
+    // TODO(doyle): Error handling, we assume it works
+    std::vector<crypto::hash> entropy;
+    if (hf_version >= HF_VERSION_PULSE) get_pulse_entropy_from_blockchain(db, entropy);
+    quorums = generate_quorums(*this, active_snode_list, nettype, hf_version, entropy);
   }
 
   void service_node_list::process_block(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs)

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1227,14 +1227,20 @@ namespace service_nodes
     return result;
   }
 
-  static bool get_pulse_entropy_from_blockchain(cryptonote::BlockchainDB const &db, std::vector<crypto::hash> &entropy)
+  static bool get_pulse_entropy_from_blockchain(cryptonote::BlockchainDB const &db, std::vector<crypto::hash> &entropy, uint8_t pulse_round)
   {
     uint64_t current_height = db.height();
-    if (current_height < PULSE_QUORUM_ENTROPY_LAG)
+    uint64_t start_height   = current_height - PULSE_QUORUM_ENTROPY_LAG;
+    uint64_t end_height     = start_height + PULSE_QUORUM_SIZE;
+    std::vector<cryptonote::block> blocks;
+
+    try
     {
-      const bool DEVELOPMENT = true; // TODO(doyle): Cleanup
-      if (DEVELOPMENT)
+      const bool DEVELOPER_MODE = true;
+      if (current_height < PULSE_QUORUM_ENTROPY_LAG)
       {
+        if (DEVELOPER_MODE)
+        {
           entropy.resize(PULSE_QUORUM_SIZE);
           entropy[0]  = crypto::hash{"\x87\x28\x89\xe2\xe3\x63\xc7\x7d\xb6\x38\xbd\xa3\xa2\x00\x57\x2f\x3a\x01\x2d\x8a\xd1\x2c\xb6\xab\x00\x55\x6b\x60\xda\x25\xca"};
           entropy[1]  = crypto::hash{"\x27\xca\xab\x1e\xcf\x33\xa7\x49\x88\xba\x17\xb0\x28\xa4\x19\x76\x84\x7f\x71\xa7\xeb\x38\xb1\x16\x10\xa0\xe3\x89\xa3\xd7\xa6"};
@@ -1247,18 +1253,16 @@ namespace service_nodes
           entropy[8]  = crypto::hash{"\x8c\x81\x6c\x77\xf0\x62\x55\xff\x38\xec\x57\x22\x62\x2e\x49\xd4\x44\x5a\xe3\x02\x27\xb6\xb3\xe4\x3c\xc7\x9f\xb8\xc5\x90\xa1"};
           entropy[9]  = crypto::hash{"\x18\x8e\x4f\xb5\x99\x74\xec\x78\xf9\x7b\x36\x87\x14\x82\x05\x32\x07\xf3\x21\x21\x6d\x8e\xfd\x35\xe6\x70\xa3\x89\x17\x22\x4b"};
           entropy[10] = crypto::hash{"\xb7\xbe\x54\xe3\x21\xe3\xeb\x88\xda\xab\xf1\xf7\x50\xb9\xef\x98\xa5\xcf\x9f\x75\x81\x74\x16\xbc\x85\x78\x6e\x0c\xaa\x14\x99"};
-          return true;
+        }
+        else
+        {
+          return false;
+        }
       }
-
-      return false;
-    }
-
-    uint64_t start_height = current_height - PULSE_QUORUM_ENTROPY_LAG;
-    uint64_t end_height   = start_height + PULSE_QUORUM_SIZE;
-    std::vector<cryptonote::block> blocks;
-    try
-    {
-      blocks = db.get_blocks_range(start_height, end_height - 1 /*it is inclusive*/);
+      else
+      {
+        blocks = db.get_blocks_range(start_height, end_height - 1 /*it is inclusive*/);
+      }
     }
     catch(std::exception const &e)
     {
@@ -1270,13 +1274,39 @@ namespace service_nodes
     for (cryptonote::block const &block : blocks)
     {
       crypto::hash hash = {};
+      uint64_t const xor64 = ((uint64_t)pulse_round & 0xFF) <<  0 |
+                             ((uint64_t)pulse_round & 0xFF) <<  8 |
+                             ((uint64_t)pulse_round & 0xFF) << 16 |
+                             ((uint64_t)pulse_round & 0xFF) << 24 |
+                             ((uint64_t)pulse_round & 0xFF) << 32 |
+                             ((uint64_t)pulse_round & 0xFF) << 40 |
+                             ((uint64_t)pulse_round & 0xFF) << 48 |
+                             ((uint64_t)pulse_round & 0xFF) << 56;
       if (block.major_version >= HF_VERSION_PULSE)
       {
-        crypto::cn_fast_hash(block.pulse.random_value.data, sizeof(block.pulse.random_value), hash.data);
+        uint64_t random_value_xored[2];
+        static_assert(sizeof(block.pulse.random_value) == sizeof(random_value_xored), "Expected 16 byte size");
+
+        memcpy(&random_value_xored[0], block.pulse.random_value.data, sizeof(random_value_xored[0]));
+        memcpy(&random_value_xored[1], block.pulse.random_value.data + sizeof(random_value_xored[0]), sizeof(random_value_xored[1]));
+
+        random_value_xored[0] ^= xor64;
+        random_value_xored[1] ^= xor64;
+        crypto::cn_fast_hash(random_value_xored, sizeof(random_value_xored), hash.data);
       }
       else
       {
+        crypto::hash xor_hash;
+        static_assert(sizeof(xor_hash) % sizeof(xor64) == 0, "We want to construct a hash composed of the xor value");
+
+        for (size_t i = 0; i < sizeof(xor_hash) / sizeof(xor64); i++)
+        {
+          char *dest = xor_hash.data + (i * sizeof(xor64));
+          memcpy(dest, &xor64, sizeof(xor64));
+        }
+
         hash = cryptonote::get_block_hash(block);
+        crypto::hash_xor(hash, xor_hash);
       }
 
       assert(hash != crypto::null_hash);
@@ -1398,14 +1428,7 @@ namespace service_nodes
 
         case quorum_type::pulse:
         {
-          // NOTE: In Pulse, take the next Service Node Winner as the leader of
-          // the Pulse Quorum. We choose validators from the first half of the
-          // list and send them to the back of the list.  We need
-          // (PULSE_QUORUM_SIZE * 2) Service Nodes to avoid a chance of the
-          // just chosen Service Node re-entering the first half of the list and
-          // being selected again in the same quorum.
-
-          if (active_snode_list.size() < (PULSE_QUORUM_SIZE * 2) + 1 /*leader*/))
+          if (active_snode_list.size() < (PULSE_QUORUM_SIZE  + 1 /*leader*/))
           {
             // TODO(doyle): We need fallback code
             MERROR("Insufficient active Service Nodes for Pulse: " << active_snode_list.size());
@@ -1451,15 +1474,16 @@ namespace service_nodes
 
           for (size_t i = 0; i < pulse_entropy.size(); i++)
           {
+            size_t const partition_index = std::min(pulse_candidates.size() / 2, pulse_candidates.size());
+
             std::mt19937_64 rng(quorum_rng_seed(pulse_entropy[i], type));
-            size_t candidate_index             = tools::uniform_distribution_portable(rng, pulse_candidates.size() / 2);
+            size_t candidate_index             = tools::uniform_distribution_portable(rng, partition_index);
             pubkey_and_sninfo const *candidate = pulse_candidates[candidate_index];
 
             quorum->validators.push_back(candidate->first);
             pulse_candidates.erase(pulse_candidates.begin() + candidate_index);
 
             // NOTE: Send candidate to the back of the list
-            pulse_candidates.push_back(candidate);
             auto &info_ptr = state.service_nodes_infos.at(candidate->first);
             duplicate_info(info_ptr).last_height_validating_for_pulse = state.height;
           }
@@ -1591,7 +1615,7 @@ namespace service_nodes
 
     // TODO(doyle): Error handling, we assume it works
     std::vector<crypto::hash> entropy;
-    if (hf_version >= HF_VERSION_PULSE) get_pulse_entropy_from_blockchain(db, entropy);
+    if (hf_version >= HF_VERSION_PULSE) get_pulse_entropy_from_blockchain(db, entropy, 0 /*pulse_round*/);
     quorums = generate_quorums(*this, active_snode_list, nettype, hf_version, entropy);
   }
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -1282,31 +1282,18 @@ namespace service_nodes
                              ((uint64_t)pulse_round & 0xFF) << 40 |
                              ((uint64_t)pulse_round & 0xFF) << 48 |
                              ((uint64_t)pulse_round & 0xFF) << 56;
-      if (block.major_version >= HF_VERSION_PULSE)
+      if (block.major_version >= cryptonote::network_version_16)
       {
-        uint64_t random_value_xored[2];
-        static_assert(sizeof(block.pulse.random_value) == sizeof(random_value_xored), "Expected 16 byte size");
-
-        memcpy(&random_value_xored[0], block.pulse.random_value.data, sizeof(random_value_xored[0]));
-        memcpy(&random_value_xored[1], block.pulse.random_value.data + sizeof(random_value_xored[0]), sizeof(random_value_xored[1]));
-
-        random_value_xored[0] ^= xor64;
-        random_value_xored[1] ^= xor64;
-        crypto::cn_fast_hash(random_value_xored, sizeof(random_value_xored), hash.data);
+        std::array<uint8_t, 1 + sizeof(block.pulse.random_value)> src = {pulse_round};
+        std::copy(std::begin(block.pulse.random_value.data), std::end(block.pulse.random_value.data), src.begin() + 1);
+        crypto::cn_fast_hash(src.data(), src.size(), hash.data);
       }
       else
       {
-        crypto::hash xor_hash;
-        static_assert(sizeof(xor_hash) % sizeof(xor64) == 0, "We want to construct a hash composed of the xor value");
-
-        for (size_t i = 0; i < sizeof(xor_hash) / sizeof(xor64); i++)
-        {
-          char *dest = xor_hash.data + (i * sizeof(xor64));
-          memcpy(dest, &xor64, sizeof(xor64));
-        }
-
-        hash = cryptonote::get_block_hash(block);
-        crypto::hash_xor(hash, xor_hash);
+        crypto::hash block_hash = cryptonote::get_block_hash(block);
+        std::array<uint8_t, 1 + sizeof(hash)> src = {pulse_round};
+        std::copy(std::begin(block_hash.data), std::end(block_hash.data), src.begin() + 1);
+        crypto::cn_fast_hash(src.data(), src.size(), hash.data);
       }
 
       assert(hash != crypto::null_hash);
@@ -1441,57 +1428,46 @@ namespace service_nodes
             continue;
           }
 
+          // NOTE: Find the leader for this block
+          block_winner winner = state.get_block_winner();
+          quorum->workers.push_back(winner.key);
+
           std::vector<pubkey_and_sninfo const *> pulse_candidates;
           pulse_candidates.reserve(active_snode_list.size());
-
-          // TODO(doyle): Support leaders failing and iterating the round for this block.
-          // NOTE: Find the leader for this block
+          for (auto &node : active_snode_list)
           {
-            auto best_leader_index = static_cast<size_t>(-1);
-            auto best_reward_time  = std::make_pair(static_cast<uint64_t>(-1), static_cast<uint32_t>(-1));
-            for (size_t node_index = 0; node_index < active_snode_list.size(); node_index++)
-            {
-              pubkey_and_sninfo const &node = active_snode_list[node_index];
-              auto reward_time = std::make_pair(node.second->last_reward_block_height, node.second->last_reward_transaction_index);
-              if (reward_time < best_reward_time)
-              {
-                best_reward_time  = reward_time;
-                best_leader_index = node_index;
-              }
-
+            if (node.first != winner.key)
               pulse_candidates.push_back(&node);
-            }
-
-            quorum->workers.push_back(pulse_candidates[best_leader_index]->first);
-            pulse_candidates.erase(pulse_candidates.begin() + best_leader_index);
           }
 
           // NOTE: Sort ascending in height i.e. sort preferring the longest time since the validator was in a Pulse quorum.
           std::stable_sort(pulse_candidates.begin(), pulse_candidates.end(), [](pubkey_and_sninfo const *a, pubkey_and_sninfo const *b) {
-                      auto a_key  = std::make_pair(a->second->pulse_sort_key.last_height_validating_in_quorum, a->second->pulse_sort_key.quorum_index);
-                      auto b_key  = std::make_pair(b->second->pulse_sort_key.last_height_validating_in_quorum, b->second->pulse_sort_key.quorum_index);
-                      bool result = a_key < b_key;
+                      bool result = a->second->pulse_sorter < b->second->pulse_sorter;
                       return result;
                     });
 
           // NOTE: Divide the list in half, select validators from the first half of the list.
-          // Remove them from the list of candidates once chosen.
-          size_t const midpoint = pulse_candidates.size() / 2;
-          for (size_t i = 0; i < pulse_entropy.size(); i++)
+          // Swap the chosen validator into first half of the list.
+          auto running_it              = pulse_candidates.begin();
+          size_t const partition_index = pulse_candidates.size() / 2;
+          for (crypto::hash const &entropy : pulse_entropy)
           {
-            size_t const partition_index = std::min(midpoint, pulse_candidates.size());
-            std::mt19937_64 rng(quorum_rng_seed(pulse_entropy[i], type));
-            size_t candidate_index             = tools::uniform_distribution_portable(rng, partition_index);
-            pubkey_and_sninfo const *candidate = pulse_candidates[candidate_index];
+            std::mt19937_64 rng(quorum_rng_seed(entropy, type));
+            size_t candidate_index = tools::uniform_distribution_portable(rng, partition_index - std::distance(pulse_candidates.begin(), running_it));
+            std::swap(*running_it, *(pulse_candidates.begin() + candidate_index));
+            running_it++;
+          }
 
-            quorum->validators.push_back(candidate->first);
-            pulse_candidates.erase(pulse_candidates.begin() + candidate_index);
+          for (auto it = pulse_candidates.begin(); it != running_it; it++)
+          {
+            crypto::public_key const &validator_key = (*it)->first;
+            quorum->validators.push_back(validator_key);
 
             // NOTE: Send candidate to the back of the list
-            auto &info_ptr = state.service_nodes_infos.at(candidate->first);
+            auto &info_ptr = state.service_nodes_infos.at(validator_key);
             service_node_info &new_info = duplicate_info(info_ptr);
-            new_info.pulse_sort_key.last_height_validating_in_quorum = state.height;
-            new_info.pulse_sort_key.quorum_index = quorum->validators.size() - 1;
+            new_info.pulse_sorter.last_height_validating_in_quorum = state.height;
+            new_info.pulse_sorter.quorum_index = quorum->validators.size() - 1;
           }
 
           result.pulse = quorum;
@@ -1623,7 +1599,7 @@ namespace service_nodes
 
     // TODO(doyle): Error handling, we assume it works
     std::vector<crypto::hash> entropy;
-    if (hf_version >= HF_VERSION_PULSE) get_pulse_entropy_from_blockchain(db, entropy, 0 /*pulse_round*/);
+    if (hf_version >= cryptonote::network_version_16) get_pulse_entropy_from_blockchain(db, entropy, 0 /*pulse_round*/);
     quorums = generate_quorums(*this, active_snode_list, nettype, hf_version, entropy);
   }
 
@@ -2456,7 +2432,7 @@ namespace service_nodes
       if (info.version < version_t::v5_pulse)
       {
         info.version = version_t::v5_pulse;
-        info.pulse_sort_key.last_height_validating_in_quorum = info.last_reward_block_height;
+        info.pulse_sorter.last_height_validating_in_quorum = info.last_reward_block_height;
       }
       // Make sure we handled any future state version upgrades:
       assert(info.version == tools::enum_top<decltype(info.version)>);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -100,14 +100,20 @@ namespace service_nodes
     void store(const crypto::public_key &pubkey, cryptonote::Blockchain &blockchain);
   };
 
-  struct pulse_sort_key_t
+  struct pulse_sort_key
   {
     uint64_t last_height_validating_in_quorum = 0;
-    uint8_t  quorum_index = 0;
+    uint8_t quorum_index                      = 0;
+
+    bool operator<(pulse_sort_key const &other) const
+    {
+      bool result = std::make_pair(last_height_validating_in_quorum, quorum_index) < std::make_pair(other.last_height_validating_in_quorum, other.quorum_index);
+      return result;
+    }
 
     BEGIN_SERIALIZE_OBJECT()
       VARINT_FIELD(last_height_validating_in_quorum)
-      VARINT_FIELD(quorum_index)
+      FIELD(quorum_index)
     END_SERIALIZE()
   };
 
@@ -193,7 +199,7 @@ namespace service_nodes
     uint64_t                           last_ip_change_height = 0; // The height of the last quorum penalty for changing IPs
     version_t                          version = tools::enum_top<version_t>;
     uint8_t                            registration_hf_version = 0;
-    pulse_sort_key_t                   pulse_sort_key;
+    pulse_sort_key                     pulse_sorter;
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -238,7 +244,7 @@ namespace service_nodes
         }
       }
       if (version >= version_t::v5_pulse)
-        FIELD(pulse_sort_key);
+        FIELD(pulse_sorter)
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -100,6 +100,17 @@ namespace service_nodes
     void store(const crypto::public_key &pubkey, cryptonote::Blockchain &blockchain);
   };
 
+  struct pulse_sort_key_t
+  {
+    uint64_t last_height_validating_in_quorum = 0;
+    uint8_t  quorum_index = 0;
+
+    BEGIN_SERIALIZE_OBJECT()
+      VARINT_FIELD(last_height_validating_in_quorum)
+      VARINT_FIELD(quorum_index)
+    END_SERIALIZE()
+  };
+
   struct service_node_info // registration information
   {
     enum class version_t : uint8_t
@@ -182,7 +193,7 @@ namespace service_nodes
     uint64_t                           last_ip_change_height = 0; // The height of the last quorum penalty for changing IPs
     version_t                          version = tools::enum_top<version_t>;
     uint8_t                            registration_hf_version = 0;
-    uint64_t                           last_height_validating_for_pulse = 0;
+    pulse_sort_key_t                   pulse_sort_key;
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -227,7 +238,7 @@ namespace service_nodes
         }
       }
       if (version >= version_t::v5_pulse)
-        VARINT_FIELD(last_height_validating_for_pulse);
+        FIELD(pulse_sort_key);
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -109,6 +109,7 @@ namespace service_nodes
       v2_ed25519,
       v3_quorumnet,
       v4_noproofs,
+      v5_pulse,
 
       _count
     };
@@ -181,6 +182,7 @@ namespace service_nodes
     uint64_t                           last_ip_change_height = 0; // The height of the last quorum penalty for changing IPs
     version_t                          version = tools::enum_top<version_t>;
     uint8_t                            registration_hf_version = 0;
+    uint64_t                           last_height_validating_for_pulse = 0;
 
     service_node_info() = default;
     bool is_fully_funded() const { return total_contributed >= staking_requirement; }
@@ -224,6 +226,8 @@ namespace service_nodes
           VARINT_FIELD_N("quorumnet_port", fake_port)
         }
       }
+      if (version >= version_t::v5_pulse)
+        VARINT_FIELD(last_height_validating_for_pulse);
     END_SERIALIZE()
   };
 
@@ -489,7 +493,6 @@ namespace service_nodes
       friend bool operator<(const state_t &s, block_height h)   { return s.height < h; }
       friend bool operator<(block_height h, const state_t &s)   { return        h < s.height; }
 
-      std::vector<pubkey_and_sninfo>  active_service_nodes_infos() const; // return: Filtered pubkey-sorted vector of service nodes that are active (fully funded and *not* decommissioned).
       std::vector<pubkey_and_sninfo>  decommissioned_service_nodes_infos() const; // return: All nodes that are fully funded *and* decommissioned.
       std::vector<crypto::public_key> get_expired_nodes(cryptonote::BlockchainDB const &db, cryptonote::network_type nettype, uint8_t hf_version, uint64_t block_height) const;
       void update_from_block(

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -467,6 +467,7 @@ namespace service_nodes
         }
         break;
 
+        case quorum_type::pulse:
         case quorum_type::blink:
         break;
       }

--- a/src/cryptonote_core/service_node_quorum_cop.h
+++ b/src/cryptonote_core/service_node_quorum_cop.h
@@ -64,12 +64,14 @@ namespace service_nodes
     // to avoid drastic changes for now to a lot of the service node API
     std::shared_ptr<const quorum> checkpointing;
     std::shared_ptr<const quorum> blink;
+    std::shared_ptr<const quorum> pulse;
 
     std::shared_ptr<const quorum> get(quorum_type type) const
     {
       if (type == quorum_type::obligations) return obligations;
       else if (type == quorum_type::checkpointing) return checkpointing;
       else if (type == quorum_type::blink) return blink;
+      else if (type == quorum_type::pulse) return pulse;
       MERROR("Developer error: Unhandled quorum enum with value: " << (size_t)type);
       assert(!"Developer error: Unhandled quorum enum with value: ");
       return nullptr;

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -147,7 +147,7 @@ namespace service_nodes {
     return
         hf_version <= cryptonote::network_version_12_checkpointing ? quorum_type::obligations :
         hf_version <  cryptonote::network_version_14_blink         ? quorum_type::checkpointing :
-        hf_version <  HF_VERSION_PULSE                             ? quorum_type::blink :
+        hf_version <  cryptonote::network_version_16               ? quorum_type::blink :
         quorum_type::pulse;
   }
 

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -5,6 +5,10 @@
 #include "service_node_voting.h"
 
 namespace service_nodes {
+  constexpr size_t PULSE_QUORUM_ENTROPY_LAG = 21; // How many blocks back from the tip of the Blockchain to source entropy for the Pulse quorums.
+  constexpr size_t PULSE_QUORUM_SIZE        = 11;
+  static_assert(PULSE_QUORUM_ENTROPY_LAG >= PULSE_QUORUM_SIZE, "We need to pull atleast PULSE_QUORUM_SIZE number of blocks from the Blockchain, we can't if the amount of blocks to go back from the tip of the Blockchain is less than the blocks we need.");
+
   // Service node decommissioning: as service nodes stay up they earn "credits" (measured in blocks)
   // towards a future outage.  A new service node starts out with INITIAL_CREDIT, and then builds up
   // CREDIT_PER_DAY for each day the service node remains active up to a maximum of
@@ -143,7 +147,8 @@ namespace service_nodes {
     return
         hf_version <= cryptonote::network_version_12_checkpointing ? quorum_type::obligations :
         hf_version <  cryptonote::network_version_14_blink         ? quorum_type::checkpointing :
-        quorum_type::blink;
+        hf_version <  HF_VERSION_PULSE                             ? quorum_type::blink :
+        quorum_type::pulse;
   }
 
   constexpr uint64_t staking_num_lock_blocks(cryptonote::network_type nettype)

--- a/src/cryptonote_core/service_node_voting.h
+++ b/src/cryptonote_core/service_node_voting.h
@@ -62,6 +62,7 @@ namespace service_nodes
     obligations = 0,
     checkpointing,
     blink,
+    pulse,
     _count
   };
 
@@ -71,6 +72,7 @@ namespace service_nodes
       case quorum_type::obligations:   return os << "obligation";
       case quorum_type::checkpointing: return os << "checkpointing";
       case quorum_type::blink:         return os << "blink";
+      case quorum_type::pulse:         return os << "pulse";
       default: assert(false);          return os << "xx_unhandled_type";
     }
   }


### PR DESCRIPTION
Adds a way to generate pulse quorums into `service_node_info`. It's not implemented in the right spot, but is a starting point to isolate just the generating step.

The next part will be  
1. To validate the incoming block against quorum
2. We want a temporary quorum of some sort when creating a block template occurs (and if it fails, we regenerate the quorum, iterating by round). 