### PR TITLE
Add support for N=11 and N=12 quorum comms

### DIFF
--- a/src/cryptonote_protocol/quorumnet_conn_matrix.h
+++ b/src/cryptonote_protocol/quorumnet_conn_matrix.h
@@ -133,6 +133,35 @@ template<> constexpr std::array<bool, 10*10> quorum_conn_matrix<10>{{
     0,0,0,1,1,1,0,0,0,0,
 }};
 
+template<> constexpr std::array<bool, 11*11> quorum_conn_matrix<11>{{
+    0,1,0,0,0,0,1,0,0,0,1,
+    0,0,1,0,0,0,0,1,1,0,0,
+    0,0,0,1,1,0,0,1,0,0,0,
+    0,0,0,0,1,1,0,0,1,0,0,
+    1,1,0,0,0,0,1,0,0,0,0,
+    1,0,1,0,0,0,1,0,0,0,0,
+    0,0,0,0,0,0,0,1,0,1,0,
+    1,0,0,0,0,0,0,0,1,0,0,
+    0,0,0,0,0,0,0,0,0,1,1,
+    0,1,0,0,0,1,0,0,0,0,0,
+    0,0,0,1,0,1,0,0,0,0,0,
+}};
+
+template<> constexpr std::array<bool, 12*12> quorum_conn_matrix<12>{{
+    0,1,0,0,0,0,0,0,0,0,1,0,
+    0,0,1,1,0,0,0,0,1,0,0,0,
+    0,0,0,1,0,1,0,0,0,0,1,0,
+    1,0,0,0,1,0,0,1,0,0,0,0,
+    1,0,0,0,0,0,1,0,0,1,0,0,
+    0,1,0,0,0,0,1,1,0,0,0,0,
+    1,0,0,0,0,0,0,1,0,1,0,0,
+    0,0,0,0,0,0,0,0,1,0,1,0,
+    0,0,0,1,0,0,0,0,0,1,0,1,
+    0,0,0,0,0,1,0,0,0,0,0,1,
+    0,0,0,0,0,0,1,0,0,0,0,1,
+    0,0,1,0,1,0,0,0,0,0,0,0,
+}};
+
 template<> constexpr std::array<bool, 13*13> quorum_conn_matrix<13>{{
     0,1,1,1,0,1,0,0,0,0,0,0,0,
     0,0,1,0,0,0,0,1,0,0,0,0,1,
@@ -298,6 +327,8 @@ constexpr const bool *get_matrix(int N) {
         case 8: return &quorum_conn_matrix<8>[0];
         case 9: return &quorum_conn_matrix<9>[0];
         case 10: return &quorum_conn_matrix<10>[0];
+        case 11: return &quorum_conn_matrix<11>[0];
+        case 12: return &quorum_conn_matrix<12>[0];
         case 13: return &quorum_conn_matrix<13>[0];
         case 14: return &quorum_conn_matrix<14>[0];
         case 15: return &quorum_conn_matrix<15>[0];

--- a/utils/generate-quorum-matrix.py
+++ b/utils/generate-quorum-matrix.py
@@ -22,7 +22,7 @@ TRACE = True
 # N sizes to calculate for.  The default calculates for all possible quorums that are capable of
 # achieving supermajority for blink and obligations quorums (10, 7 required) and checkpoint quorums
 # (20, 13 required)
-N = (7, 8, 9, 10, *range(13, 21))
+N = range(7, 21)
 
 # This defines how much 2-path connectivity we require for different values of N
 def min_connections(n):


### PR DESCRIPTION
Previously we supported N=7 through N=10 and N=13 through N=20; with
pulse we need N=11 and N=12*, so fill in the gaps so we now have a matrix
for everything from N=7 to N=20.

(* - I think I'm remembering correctly we need 12, i.e. leader + 11 validators, but even if not it would feel a bit weird to leave just one N=? hole here).

Connections are generated from utils/generate-quorum-matrix.py using
that same criteria as the existing connection matrices (that is, finding
a set of connections to ensure that every node is connected to every
other node twice with direct or two-hop connections).  The missing added
connection details are as follows:
```
┌────┬───────────────────────────────┬─────────────┬────────────────────┐
│ i  │ Connections (1 = out, x = in) │ ≤2 paths    │ Connectivity:      │
├────┼───────────────────────────────┼─────────────┼────────────────────┤
│ 0  │ -100xx1x001                   │ -3433343332 │ 6 (= 3 out + 3 in) │
│ 1  │ x-10x0011x0                   │ 3-333344322 │ 6 (= 3 out + 3 in) │
│ 2  │ 0x-11x01000                   │ 43-33232322 │ 5 (= 3 out + 2 in) │
│ 3  │ 00x-110010x                   │ 333-2322223 │ 5 (= 3 out + 2 in) │
│ 4  │ 11xx-010000                   │ 3332-424222 │ 5 (= 3 out + 2 in) │
│ 5  │ 101x0-100xx                   │ 33234-33323 │ 6 (= 3 out + 3 in) │
│ 6  │ x000xx-1010                   │ 443223-2222 │ 5 (= 2 out + 3 in) │
│ 7  │ 1xx000x-100                   │ 3422432-232 │ 5 (= 2 out + 3 in) │
│ 8  │ 0x0x000x-11                   │ 33322322-22 │ 5 (= 2 out + 3 in) │
│ 9  │ 010001x0x-0                   │ 322222232-2 │ 4 (= 2 out + 2 in) │
│ 10 │ x0010100x0-                   │ 2223232222- │ 4 (= 2 out + 2 in) │
└────┴───────────────────────────────┴─────────────┴────────────────────┘

┌────┬───────────────────────────────┬──────────────┬────────────────────┐
│ i  │ Connections (1 = out, x = in) │ ≤2 paths     │ Connectivity:      │
├────┼───────────────────────────────┼──────────────┼────────────────────┤
│ 0  │ -10xx0x00010                  │ -23332332222 │ 5 (= 2 out + 3 in) │
│ 1  │ x-110x001000                  │ 2-3422232222 │ 5 (= 3 out + 2 in) │
│ 2  │ 0x-10100001x                  │ 33-222233222 │ 5 (= 3 out + 2 in) │
│ 3  │ 1xx-1001x000                  │ 342-23323233 │ 6 (= 3 out + 3 in) │
│ 4  │ 100x-010010x                  │ 3222-2323332 │ 5 (= 3 out + 2 in) │
│ 5  │ 01x00-110x00                  │ 22232-323232 │ 5 (= 3 out + 2 in) │
│ 6  │ 1000xx-101x0                  │ 322333-32333 │ 6 (= 3 out + 3 in) │
│ 7  │ 000x0xx-1010                  │ 3332223-2322 │ 5 (= 2 out + 3 in) │
│ 8  │ 0x01000x-101                  │ 22333322-222 │ 5 (= 3 out + 2 in) │
│ 9  │ 0000x1x0x-01                  │ 222232332-23 │ 5 (= 2 out + 3 in) │
│ 10 │ x0x0001x00-1                  │ 2223333222-2 │ 5 (= 2 out + 3 in) │
│ 11 │ 00101000xxx-                  │ 22232232232- │ 5 (= 2 out + 3 in) │
└────┴───────────────────────────────┴──────────────┴────────────────────┘
```