### PR TITLE
Use integer math for difficulty calculation

### DIFF
--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -152,14 +152,14 @@ namespace cryptonote {
 
     const int64_t T = static_cast<int64_t>(target_seconds);
 
-    size_t N = DIFFICULTY_WINDOW_V2 - 1;
+    int64_t N = DIFFICULTY_WINDOW_V2 - 1;
 
     // Return a difficulty of 1 for first 4 blocks if it's the start of the chain.
     if (timestamps.size() < 4) {
       return 1;
     }
     // Otherwise, use a smaller N if the start of the chain is less than N+1.
-    else if ( timestamps.size()-1 < N ) {
+    else if ( timestamps.size()-1 < (size_t) N ) {
       N = timestamps.size() - 1;
     }
     // Otherwise make sure timestamps and cumulative_difficulties are correct size.
@@ -171,46 +171,122 @@ namespace cryptonote {
     }
     // To get an average solvetime to within +/- ~0.1%, use an adjustment factor.
     // adjust=0.999 for 80 < N < 120(?)
-    const double adjust = 0.998;
+    //const double adjust = 0.998;
     // The divisor k normalizes the LWMA sum to a standard LWMA.
-    const double k = N * (N + 1) / 2;
+    const int64_t k = (int64_t)N * (int64_t)(N + 1) / 2;
 
-    double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
-    int64_t solveTime(0);
-    uint64_t difficulty(0), next_difficulty(0);
+    // Mathematically we're aiming to find:
+    //
+    //          N * T(=120) * adjust(=0.998)
+    //  diff = --------------------------------
+    //         LWMA * (1/diff1 + 1/diff2 + ...)
+    //
+    // where LWMA = sum{(solvetime * i)} / k  i from 1 to N, where k = N(N+1)/2 normalizes the LWMA value
+    // such that if all solve times were "x" we'd get LWMA="x" after summing them.  (More precisely:
+    // k is the number that solves the equality LWMA=solvetime).
+    //
+    // This used to be done with floating point math, which caused endless difficult errors, and
+    // should never have been done.  The equation does not *immediately* lend itself to a straight
+    // calculation using integer math: the denominator is almost much smaller than 1.  So we need to
+    // scale things, and we do this by trying to make the x/y terms in the denominator have as big
+    // of an `x` as possible (relative to `y`), because the bigger `x` is relative to `y` the less
+    // precision we lose from the x/y calculation.
+    //
+    // So as a first step we scale top and bottom by the average difficulty to get:
+    //
+    //          N * T(=120) * adjust(=499/500) * meandiff
+    //  diff = ------------------------------------------
+    //         LWMA * (1/diff1 + 1/diff2 + ...) * meandiff
+    //
+    // which lets us calculate (using integer math) as:
+    //
+    //                N * T(=120) * adjust(=499/500) * meandiff
+    //  diff = -------------------------------------------------------
+    //          (LWMA * meandiff)/diff1 + (LWMA*meandiff)/diff2 + ...
+    // 
+    // We can go one step further by factoring out the implicit `/k` term from LWMA_i and pushing it
+    // into the denominator; let λ = LWMA*k (i.e. λ is the sum of LWMA calculations *not* divided by
+    // k).
+    //
+    //                N * T(=120) * meandiff * k * 499 / 500
+    //  diff = ----------------------------------------------------
+    //          (λ * meandiff)/diff1 + (λ * meandiff)/diff2 + ...
+    //
+    // and to guard against possible (albeit unlikely) overflow in the numerator we bring the
+    // *499/500 outside the main fraction:
+    //
+    //                    N * T(=120) * meandiff * k
+    //  diff = ---------------------------------------------------- * 499 / 500
+    //          (λ * meandiff)/diff1 + (λ * meandiff)/diff2 + ...
+    //
+    // There are two numbers here which could overflow:
+    // - The numerator
+    // - The λ*meandiff value
+    //
+    // Some historical context implies why these aren't something we need to worry about:
+    // - LOKI peak difficulty (under CN-pico in July 2019) was somewhere around 40 billion (i.e. a
+    //   little over 300MH/s).
+    // - Using a ludicrously extreme final block time of one week without a block, and putting this
+    //   in the last term (since it has the largest λ), we get a λ = 59*86400 = 5097600, and so λ *
+    //   meandiff = 203'904'000'000'000'000, which is only about 1/45 the max value of an int64_t,
+    //   so we'd need a massive difficulty increase *and* so-slow-that-they're-broken blocks to
+    //   overflow the numerators of the sub-terms in the denominator.
+    // - The numerator would overflow at a mean difficulty (over the last 59 blocks) of 21.9
+    //   trillion = 182GH/s, or more than 500 times the peak difficulty we ever saw.  (This is why
+    //   we don't add the * 499 term into the numerator: it would get us close to int64_t limits).
+    //
+    // Thus we ignore overflow concerns because even if someone managed to overflow something here
+    // with an incredibly high difficulty on a private chain, checkpointing will prevent anyone from
+    // caring about it.
+    //
+    // We can *slightly* improve the calculation accuracy from this point by pushing the 499 and 500
+    // into the numerator and denominator, respectively, but *only* if it will not result in
+    // overflow.  If it would, we keep them for the end.
+    //
+    int64_t mean_diff = (cumulative_difficulties[N] - cumulative_difficulties[0]) / N;
 
+    int64_t lambda = 0;
     // Loop through N most recent blocks. N is most recently solved block.
-    for (int64_t i = 1; i <= (int64_t)N; i++) {
-      solveTime = static_cast<int64_t>(timestamps[i]) - static_cast<int64_t>(timestamps[i - 1]);
+    for (int64_t i = 1; i <= N; i++) {
+      int64_t solveTime = static_cast<int64_t>(timestamps[i]) - static_cast<int64_t>(timestamps[i - 1]);
 
       if (use_old_lwma) solveTime = std::max<int64_t>(solveTime, (-7 * T));
       solveTime = std::min<int64_t>(solveTime, (T * 7));
 
-      difficulty = cumulative_difficulties[i] - cumulative_difficulties[i - 1];
-      LWMA += (solveTime * i) / k;
-      sum_inverse_D += 1 / static_cast<double>(difficulty);
+      lambda += solveTime * i;
     }
 
-    harmonic_mean_D = N / sum_inverse_D;
-
     // Keep LWMA sane in case something unforeseen occurs.
-    if (static_cast<int64_t>(loki::round(LWMA)) < T / 20)
-      LWMA = static_cast<double>(T / 20);
+    lambda = std::max(lambda, k * T / 20);
 
-    nextDifficulty = harmonic_mean_D * T / LWMA * adjust;
+    int64_t numerator = N * T * mean_diff * k;
+    int64_t final_mult = 1;
+    if (numerator < std::numeric_limits<int64_t>::max() / 499)
+        numerator *= 499;
+    else
+        final_mult = 499;
 
-    // No limits should be employed, but this is correct way to employ a 20% symmetrical limit:
-    // nextDifficulty=max(previous_Difficulty*0.8,min(previous_Difficulty/0.8, next_Difficulty));
-    next_difficulty = static_cast<uint64_t>(nextDifficulty);
+    int64_t denominator_base = lambda * mean_diff;
+    int64_t final_div = 1;
+    if (denominator_base < std::numeric_limits<int64_t>::max() / 500)
+        denominator_base *= 500;
+    else
+        final_div = 500;
 
-    if (next_difficulty == 0)
+    int64_t denominator = 0;
+    for (int64_t i = 1; i <= N; i++)
+        denominator += denominator_base / (cumulative_difficulties[i] - cumulative_difficulties[i - 1]);
+
+    int64_t next_difficulty = numerator / denominator * final_mult / final_div;
+
+    if (next_difficulty <= 0)
         next_difficulty = 1;
 
     // Rough estimate based on comparable coins, pre-merge-mining hashrate, and hashrate changes is
     // that 30MH/s seems more or less right, so we cap it there for the first WINDOW blocks to
     // prevent too-long blocks right after the fork.
     if (v12_initial_override)
-      return std::min(next_difficulty, 30000000 * uint64_t(target_seconds));
+      return std::min(next_difficulty, 30000000 * T);
 
     return next_difficulty;
   }


### PR DESCRIPTION
This replaces the floating point math difficulty calculation with integer math.

See the lengthy comment I left in the DA code for the mathematical details.

It is still a work in progress: this calculation appears to be produce individual block difficulty values that are *slightly* too small by somewhere around 0.05% - 0.1%.  over the entire chain on mainnet, currently, I get a final *cumulative* difficulty of:

    Height: 560788 prev difficulty: 4218954063635982, new difficulty: 4215801479958170

which is 99.925% of the proper value, suggesting that this small deviation in the integer calculation is fairly consistent over the entire chain (and is likely caused by the fact that the intermediate integer division calculations truncate).

Draft PR for now: I'll do some more measurements on the deviations and see if I can tweak it slightly to get closer to the FP values.

(Although we won't need this for pulse, it seems a worthwhile replacement for syncing the past chain, which currently still seems to result in slight difficulty variations -- *probably* caused by #1180, but I'll be happy to get rid of the FP math regardless).