### PR TITLE
Make debug_utilities available to build even without -DBUILD_DEBUG_UTILS

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -178,7 +178,7 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
     debian_pipeline("Debian sid/clang-10 (amd64)", "debian:sid", deps='clang-10 '+default_deps_base,
                     cmake_extra='-DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 ', lto=true),
     debian_pipeline("Debian sid/gcc-10 (amd64)", "debian:sid", deps='g++-10 '+default_deps_base,
-                    cmake_extra='-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10'),
+                    cmake_extra='-DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DBUILD_DEBUG_UTILS=ON'),
     debian_pipeline("Debian buster (i386)", "i386/debian:buster", cmake_extra='-DDOWNLOAD_SODIUM=ON -DARCH_ID=i386'),
     debian_pipeline("Ubuntu focal (amd64)", "ubuntu:focal"),
 
@@ -206,7 +206,7 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
 */
     // Macos builds:
     mac_builder('macOS (Release)', run_tests=true),
-    mac_builder('macOS (Debug)', build_type='Debug'),
+    mac_builder('macOS (Debug)', build_type='Debug', cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
     mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13',
                 build_tests=false, extra_cmds=static_check_and_upload),
 ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,12 +89,15 @@ if(NOT IOS)
   add_subdirectory(simplewallet)
 endif()
 
-option(BUILD_DEBUG_UTILS "Build debug utils" OFF)
+# We'll always add, but with EXCLUDE_FROM_ALL if you didn't ask for them (but this lets you do a
+# `make cn_deserialize` or whatever from a build dir without needing to reconfigure).
+option(BUILD_DEBUG_UTILS "Build debug utils as part of the default build" OFF)
 if(BUILD_DEBUG_UTILS)
   message(STATUS "Building debug utilities")
   add_subdirectory(debug_utilities)
 else()
-  message(STATUS "Not building debug utilities")
+  message(STATUS "Not building debug utilities by default")
+  add_subdirectory(debug_utilities EXCLUDE_FROM_ALL)
 endif()
 
 if(PER_BLOCK_CHECKPOINT)


### PR DESCRIPTION
This uses EXCLUDE_FROM_ALL when BUILD_DEBUG_UTILS is not on so that they
don't get built but they *can* be built with a `make cn_deserialize` (or
whatever target you want) from a build dir.

Also adds them to a couple drone builds to make sure they build.