### PR TITLE
Fix typo in static sqlite external target

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -315,7 +315,7 @@ set(Boost_VERSION ${BOOST_VERSION})
 
 
 build_external(sqlite3)
-add_static_target(sqlite3 sqlite_external libsqlite3.a)
+add_static_target(sqlite3 sqlite3_external libsqlite3.a)
 
 
 


### PR DESCRIPTION
This could cause sqlite3 to not get built in time (found via lokinet,
which copied this, where this issue showed up).