### PR TITLE
AES redux for cn-pico & cn-heavy

### DIFF
--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -45,7 +45,7 @@
 #endif
 
 #if defined(HAS_INTEL_HW) || defined(HAS_ARM_HW)
-inline bool check_override()
+inline bool force_software_aes()
 {
 	const char *env = getenv("LOKI_USE_SOFTWARE_AES");
 	return env && strcmp(env, "0") && strcmp(env, "no");

--- a/src/crypto/cn_heavy_hash_hard_arm.cpp
+++ b/src/crypto/cn_heavy_hash_hard_arm.cpp
@@ -51,7 +51,7 @@ static bool hw_check_aes()
 	return (getauxval(AT_HWCAP) & HWCAP_AES) != 0;
 }
 
-extern "C" const bool cpu_aes_enabled = hw_check_aes() && check_override();
+extern "C" const bool cpu_aes_enabled = hw_check_aes() && !force_software_aes();
 
 extern const uint8_t saes_sbox[256];
 

--- a/src/crypto/cn_heavy_hash_hard_arm.cpp
+++ b/src/crypto/cn_heavy_hash_hard_arm.cpp
@@ -29,6 +29,12 @@
 // Parts of this file are originally copyright (c) 2014-2017, The Monero Project
 // Parts of this file are originally copyright (c) 2012-2013, The Cryptonote developers
 
+#if defined(__aarch64__)
+
+#ifndef __clang__
+#  pragma GCC target ("+crypto")
+#endif
+
 #include "cn_heavy_hash.hpp"
 extern "C" {
 #include "keccak.h"
@@ -36,7 +42,16 @@ extern "C" {
 #include "skein.h"
 }
 
-#ifdef HAS_ARM_HW
+#include <sys/auxv.h>
+#include <asm/hwcap.h>
+#include <arm_neon.h>
+
+static bool hw_check_aes()
+{
+	return (getauxval(AT_HWCAP) & HWCAP_AES) != 0;
+}
+
+extern "C" const bool cpu_aes_enabled = hw_check_aes() && check_override();
 
 extern const uint8_t saes_sbox[256];
 

--- a/src/crypto/cn_heavy_hash_hard_intel.cpp
+++ b/src/crypto/cn_heavy_hash_hard_intel.cpp
@@ -29,14 +29,45 @@
 // Parts of this file are originally copyright (c) 2014-2017, The Monero Project
 // Parts of this file are originally copyright (c) 2012-2013, The Cryptonote developers
 
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X86) || defined(_M_X64)
+
+#ifdef __GNUC__
+#  ifndef __clang__
+     // Force on aes support; we do a cpuid check at runtime before it actually gets invoked.
+#    pragma GCC target ("aes,sse2")
+#  endif
+#  include <x86intrin.h>
+#endif
+
 #include "cn_heavy_hash.hpp"
+
 extern "C" {
 #include "keccak.h"
 #include "jh.h"
 #include "skein.h"
 }
 
-#ifdef HAS_INTEL_HW
+#if defined(_WIN32) || defined(_WIN64)
+#  include <malloc.h>
+#  include <intrin.h>
+#  define HAS_WIN_INTRIN_API
+#else
+#  include <cpuid.h>
+#endif
+
+static bool hw_check_aes()
+{
+	int32_t cpu_info[4] = {0};
+
+#if defined(HAS_WIN_INTRIN_API)
+	__cpuidex(cpu_info, 1, 0);
+#else
+	__cpuid_count(1, 0, cpu_info[0], cpu_info[1], cpu_info[2], cpu_info[3]);
+#endif
+	return (cpu_info[2] & (1 << 25)) != 0;
+}
+
+extern "C" const bool cpu_aes_enabled = hw_check_aes() && check_override();
 
 #if !defined(_LP64) && !defined(_WIN64)
 #define BUILD32
@@ -120,33 +151,36 @@ inline void xor_shift(__m128i& x0, __m128i& x1, __m128i& x2, __m128i& x3, __m128
     x7 = _mm_xor_si128(x7, tmp0);
 }
 
+static inline __m128i* as_xmm(cn_sptr& x) { return reinterpret_cast<__m128i*>(x.as_void()); }
+static inline __m128i* as_xmm(cn_sptr&& x) { return reinterpret_cast<__m128i*>(x.as_void()); }
+
 template<size_t MEMORY, size_t ITER, size_t VERSION>
 void cn_heavy_hash<MEMORY,ITER,VERSION>::implode_scratchpad_hard()
 {
 	__m128i x0, x1, x2, x3, x4, x5, x6, x7;
 	__m128i k0, k1, k2, k3, k4, k5, k6, k7, k8, k9;
 	
-	aes_genkey(spad.as_xmm() + 2, k0, k1, k2, k3, k4, k5, k6, k7, k8, k9);
+	aes_genkey(as_xmm(spad) + 2, k0, k1, k2, k3, k4, k5, k6, k7, k8, k9);
 
-	x0 = _mm_load_si128(spad.as_xmm() + 4);
-	x1 = _mm_load_si128(spad.as_xmm() + 5);
-	x2 = _mm_load_si128(spad.as_xmm() + 6);
-	x3 = _mm_load_si128(spad.as_xmm() + 7);
-	x4 = _mm_load_si128(spad.as_xmm() + 8);
-	x5 = _mm_load_si128(spad.as_xmm() + 9);
-	x6 = _mm_load_si128(spad.as_xmm() + 10);
-	x7 = _mm_load_si128(spad.as_xmm() + 11);
+	x0 = _mm_load_si128(as_xmm(spad) + 4);
+	x1 = _mm_load_si128(as_xmm(spad) + 5);
+	x2 = _mm_load_si128(as_xmm(spad) + 6);
+	x3 = _mm_load_si128(as_xmm(spad) + 7);
+	x4 = _mm_load_si128(as_xmm(spad) + 8);
+	x5 = _mm_load_si128(as_xmm(spad) + 9);
+	x6 = _mm_load_si128(as_xmm(spad) + 10);
+	x7 = _mm_load_si128(as_xmm(spad) + 11);
 
 	for (size_t i = 0; i < MEMORY / sizeof(__m128i); i +=8)
 	{
-		x0 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 0), x0);
-		x1 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 1), x1);
-		x2 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 2), x2);
-		x3 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 3), x3);
-		x4 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 4), x4);
-		x5 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 5), x5);
-		x6 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 6), x6);
-		x7 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 7), x7);
+		x0 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 0), x0);
+		x1 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 1), x1);
+		x2 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 2), x2);
+		x3 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 3), x3);
+		x4 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 4), x4);
+		x5 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 5), x5);
+		x6 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 6), x6);
+		x7 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 7), x7);
 
 		aes_round8(k0, x0, x1, x2, x3, x4, x5, x6, x7);
 		aes_round8(k1, x0, x1, x2, x3, x4, x5, x6, x7);
@@ -165,14 +199,14 @@ void cn_heavy_hash<MEMORY,ITER,VERSION>::implode_scratchpad_hard()
 
 	for (size_t i = 0; VERSION > 0 && i < MEMORY / sizeof(__m128i); i +=8)
 	{
-		x0 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 0), x0);
-		x1 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 1), x1);
-		x2 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 2), x2);
-		x3 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 3), x3);
-		x4 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 4), x4);
-		x5 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 5), x5);
-		x6 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 6), x6);
-		x7 = _mm_xor_si128(_mm_load_si128(lpad.as_xmm() + i + 7), x7);
+		x0 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 0), x0);
+		x1 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 1), x1);
+		x2 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 2), x2);
+		x3 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 3), x3);
+		x4 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 4), x4);
+		x5 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 5), x5);
+		x6 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 6), x6);
+		x7 = _mm_xor_si128(_mm_load_si128(as_xmm(lpad) + i + 7), x7);
 
 		aes_round8(k0, x0, x1, x2, x3, x4, x5, x6, x7);
 		aes_round8(k1, x0, x1, x2, x3, x4, x5, x6, x7);
@@ -204,14 +238,14 @@ void cn_heavy_hash<MEMORY,ITER,VERSION>::implode_scratchpad_hard()
 		xor_shift(x0, x1, x2, x3, x4, x5, x6, x7);
 	}
 
-	_mm_store_si128(spad.as_xmm() + 4, x0);
-	_mm_store_si128(spad.as_xmm() + 5, x1);
-	_mm_store_si128(spad.as_xmm() + 6, x2);
-	_mm_store_si128(spad.as_xmm() + 7, x3);
-	_mm_store_si128(spad.as_xmm() + 8, x4);
-	_mm_store_si128(spad.as_xmm() + 9, x5);
-	_mm_store_si128(spad.as_xmm() + 10, x6);
-	_mm_store_si128(spad.as_xmm() + 11, x7);
+	_mm_store_si128(as_xmm(spad) + 4, x0);
+	_mm_store_si128(as_xmm(spad) + 5, x1);
+	_mm_store_si128(as_xmm(spad) + 6, x2);
+	_mm_store_si128(as_xmm(spad) + 7, x3);
+	_mm_store_si128(as_xmm(spad) + 8, x4);
+	_mm_store_si128(as_xmm(spad) + 9, x5);
+	_mm_store_si128(as_xmm(spad) + 10, x6);
+	_mm_store_si128(as_xmm(spad) + 11, x7);
 }
 
 template<size_t MEMORY, size_t ITER, size_t VERSION>
@@ -220,16 +254,16 @@ void cn_heavy_hash<MEMORY,ITER,VERSION>::explode_scratchpad_hard()
 	__m128i x0, x1, x2, x3, x4, x5, x6, x7;
 	__m128i k0, k1, k2, k3, k4, k5, k6, k7, k8, k9;
 
-	aes_genkey(spad.as_xmm(), k0, k1, k2, k3, k4, k5, k6, k7, k8, k9);
+	aes_genkey(as_xmm(spad), k0, k1, k2, k3, k4, k5, k6, k7, k8, k9);
 
-	x0 = _mm_load_si128(spad.as_xmm() + 4);
-	x1 = _mm_load_si128(spad.as_xmm() + 5);
-	x2 = _mm_load_si128(spad.as_xmm() + 6);
-	x3 = _mm_load_si128(spad.as_xmm() + 7);
-	x4 = _mm_load_si128(spad.as_xmm() + 8);
-	x5 = _mm_load_si128(spad.as_xmm() + 9);
-	x6 = _mm_load_si128(spad.as_xmm() + 10);
-	x7 = _mm_load_si128(spad.as_xmm() + 11);
+	x0 = _mm_load_si128(as_xmm(spad) + 4);
+	x1 = _mm_load_si128(as_xmm(spad) + 5);
+	x2 = _mm_load_si128(as_xmm(spad) + 6);
+	x3 = _mm_load_si128(as_xmm(spad) + 7);
+	x4 = _mm_load_si128(as_xmm(spad) + 8);
+	x5 = _mm_load_si128(as_xmm(spad) + 9);
+	x6 = _mm_load_si128(as_xmm(spad) + 10);
+	x7 = _mm_load_si128(as_xmm(spad) + 11);
 
 	for (size_t i = 0; VERSION > 0 && i < 16; i++)
 	{
@@ -260,14 +294,14 @@ void cn_heavy_hash<MEMORY,ITER,VERSION>::explode_scratchpad_hard()
 		aes_round8(k8, x0, x1, x2, x3, x4, x5, x6, x7);
 		aes_round8(k9, x0, x1, x2, x3, x4, x5, x6, x7);
 
-		_mm_store_si128(lpad.as_xmm() + i + 0, x0);
-		_mm_store_si128(lpad.as_xmm() + i + 1, x1);
-		_mm_store_si128(lpad.as_xmm() + i + 2, x2);
-		_mm_store_si128(lpad.as_xmm() + i + 3, x3);
-		_mm_store_si128(lpad.as_xmm() + i + 4, x4);
-		_mm_store_si128(lpad.as_xmm() + i + 5, x5);
-		_mm_store_si128(lpad.as_xmm() + i + 6, x6);
-		_mm_store_si128(lpad.as_xmm() + i + 7, x7);
+		_mm_store_si128(as_xmm(lpad) + i + 0, x0);
+		_mm_store_si128(as_xmm(lpad) + i + 1, x1);
+		_mm_store_si128(as_xmm(lpad) + i + 2, x2);
+		_mm_store_si128(as_xmm(lpad) + i + 3, x3);
+		_mm_store_si128(as_xmm(lpad) + i + 4, x4);
+		_mm_store_si128(as_xmm(lpad) + i + 5, x5);
+		_mm_store_si128(as_xmm(lpad) + i + 6, x6);
+		_mm_store_si128(as_xmm(lpad) + i + 7, x7);
 	}
 }
 
@@ -343,11 +377,11 @@ void cn_heavy_hash<MEMORY,ITER,VERSION>::hardware_hash(const void* in, size_t le
 	for(size_t i = 0; i < ITER; i++)
 	{
 		__m128i cx;
-		cx = _mm_load_si128(scratchpad_ptr(idx0).as_xmm());
+		cx = _mm_load_si128(as_xmm(scratchpad_ptr(idx0)));
 
 		cx = _mm_aesenc_si128(cx, _mm_set_epi64x(ah0, al0));
 
-		_mm_store_si128(scratchpad_ptr(idx0).as_xmm(), _mm_xor_si128(bx0, cx));
+		_mm_store_si128(as_xmm(scratchpad_ptr(idx0)), _mm_xor_si128(bx0, cx));
 		idx0 = xmm_extract_64(cx);
 		bx0 = cx;
 

--- a/src/crypto/cn_heavy_hash_hard_intel.cpp
+++ b/src/crypto/cn_heavy_hash_hard_intel.cpp
@@ -67,7 +67,7 @@ static bool hw_check_aes()
 	return (cpu_info[2] & (1 << 25)) != 0;
 }
 
-extern "C" const bool cpu_aes_enabled = hw_check_aes() && check_override();
+extern "C" const bool cpu_aes_enabled = hw_check_aes() && !force_software_aes();
 
 #if !defined(_LP64) && !defined(_WIN64)
 #define BUILD32

--- a/src/crypto/cn_heavy_hash_soft.cpp
+++ b/src/crypto/cn_heavy_hash_soft.cpp
@@ -33,7 +33,16 @@ extern "C" {
 #include "keccak.h"
 #include "jh.h"
 #include "skein.h"
+#include "stdlib.h"
+#if !defined(__clang__) && defined(HAS_INTEL_HW)
+#  include <x86intrin.h>
+#endif
 }
+
+
+#if !defined(HAS_INTEL_HW) && !defined(HAS_ARM_HW)
+extern "C" const bool cpu_aes_enabled = false;
+#endif
 
 /*
 AES Tables Implementation is
@@ -169,7 +178,7 @@ inline uint32_t sub_word(uint32_t key)
 		(saes_sbox[(key >> 8)  & 0xff] << 8  ) | saes_sbox[key & 0xff];
 }
 
-#if defined(__clang__) || !(defined(__x86_64__) || defined(__i386__))
+#if defined(__clang__) || !defined(HAS_INTEL_HW)
 inline uint32_t rotr(uint32_t value, uint32_t amount)
 {
 	return (value >> amount) | (value << ((32 - amount) & 31));


### PR DESCRIPTION
Force aes instruction availability in the pico & heavy implementations;
they each have runtime checks that will ensure they are supported before
called, and so this allows creating a binary that supports both non-AES
and AES CPUs.

This also unifies some of the common cpuid checking code, and moves it
to a single global variable (previously pico used a somewhat inefficient
static local variable, and cn-heavy used a hugely inefficiently cpuid
call on every hash call).

Also removes the x86-specific `__m128i` code from cn_heavy_hash.hpp and
adds a simple wrapper for it in the intel-specific code instead.