### PR TITLE
Revert shared_mutex to recursive_mutex

### DIFF
--- a/src/p2p/net_node.h
+++ b/src/p2p/net_node.h
@@ -39,6 +39,7 @@
 #include <functional>
 #include <utility>
 #include <vector>
+#include <shared_mutex>
 
 #include "cryptonote_config.h"
 #include "cryptonote_protocol/levin_notify.h"

--- a/src/p2p/net_peerlist.cpp
+++ b/src/p2p/net_peerlist.cpp
@@ -272,14 +272,14 @@ namespace nodetool
 
   void peerlist_manager::get_peerlist(std::vector<peerlist_entry>& pl_gray, std::vector<peerlist_entry>& pl_white)
   {
-    std::shared_lock lock{m_peerlist_lock};
+    std::lock_guard lock{m_peerlist_lock};
     copy_peers(pl_gray, m_peers_gray.get<by_addr>());
     copy_peers(pl_white, m_peers_white.get<by_addr>());
   }
 
   void peerlist_manager::get_peerlist(peerlist_types& peers)
   { 
-    std::shared_lock lock{m_peerlist_lock};
+    std::lock_guard lock{m_peerlist_lock};
     peers.white.reserve(peers.white.size() + m_peers_white.size());
     peers.gray.reserve(peers.gray.size() + m_peers_gray.size());
     peers.anchor.reserve(peers.anchor.size() + m_peers_anchor.size());

--- a/src/p2p/net_peerlist.h
+++ b/src/p2p/net_peerlist.h
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 #include <optional>
-#include <shared_mutex>
+#include <mutex>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -100,8 +100,8 @@ namespace nodetool
   {
   public: 
     bool init(peerlist_types&& peers, bool allow_local_ip);
-    size_t get_white_peers_count(){std::shared_lock lock{m_peerlist_lock}; return m_peers_white.size();}
-    size_t get_gray_peers_count(){std::shared_lock lock{m_peerlist_lock}; return m_peers_gray.size();}
+    size_t get_white_peers_count(){std::lock_guard lock{m_peerlist_lock}; return m_peers_white.size();}
+    size_t get_gray_peers_count(){std::lock_guard lock{m_peerlist_lock}; return m_peers_gray.size();}
     bool merge_peerlist(const std::vector<peerlist_entry>& outer_bs, const std::function<bool(const peerlist_entry&)> &f = NULL);
     bool get_peerlist_head(std::vector<peerlist_entry>& bs_head, bool anonymize, uint32_t depth = P2P_DEFAULT_PEERS_IN_HANDSHAKE);
     void get_peerlist(std::vector<peerlist_entry>& pl_gray, std::vector<peerlist_entry>& pl_white);
@@ -184,7 +184,7 @@ namespace nodetool
     void trim_gray_peerlist();
 
     friend class boost::serialization::access;
-    std::shared_mutex m_peerlist_lock;
+    std::recursive_mutex m_peerlist_lock;
     std::string m_config_folder;
     bool m_allow_local_ip;
 


### PR DESCRIPTION
This code doesn't work at all with a shared_mutex because it follows the
usual Monero misdesign of not properly structuring locks.  For now just
revert it to a recursive_mutex so that it doesn't fail or throw "would
deadlock" exceptions.

(I believe upstream uses a boost::shared_recursive_mutex here, but there's not a huge gain with a shared mutex at all: the shared locks here are in not-often-called, fast methods).