### PR TITLE
Recommission credit

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -726,7 +726,7 @@ namespace service_nodes
         }
         return true;
 
-      case new_state::recommission:
+      case new_state::recommission: {
         if (hf_version < cryptonote::network_version_12_checkpointing) {
           MERROR("Invalid recommission transaction seen before network v12");
           return false;
@@ -742,8 +742,13 @@ namespace service_nodes
         else
           LOG_PRINT_L1("Recommission for service node: " << key);
 
+        // To figure out how much credit the node gets at recommissioned we need to know how much it
+        // had when it got decommissioned, and how long it's been decommisioned.
+        int64_t credit_at_decomm = quorum_cop::calculate_decommission_credit(info, info.last_decommission_height);
+        int64_t decomm_blocks = block_height - info.last_decommission_height;
 
         info.active_since_height = block_height;
+        info.recommission_credit = RECOMMISSION_CREDIT(credit_at_decomm, decomm_blocks);
         // Move the SN at the back of the list as if it had just registered (or just won)
         info.last_reward_block_height = block_height;
         info.last_reward_transaction_index = std::numeric_limits<uint32_t>::max();
@@ -762,7 +767,7 @@ namespace service_nodes
           proof.votes.fill({});
         }
         return true;
-
+      }
       case new_state::ip_change_penalty:
         if (hf_version < cryptonote::network_version_12_checkpointing) {
           MERROR("Invalid ip_change_penalty transaction seen before network v12");
@@ -2275,6 +2280,18 @@ namespace service_nodes
       {
         // Nothing to do here (the missing data will be generated in the new proofs db via uptime proofs).
         info.version = version_t::v4_noproofs;
+      }
+      if (info.version < version_t::v5_recomm_credit)
+      {
+        // If it's an old record then assume it's from before loki 8, in which case there were only
+        // two valid values here: initial for a node that has never been recommissioned, or 0 for a recommission.
+
+        auto was = info.recommission_credit;
+        if (info.decommission_count <= info.is_decommissioned()) // Has never been decommissioned (or is currently in the first decommission), so add initial starting credit
+          info.recommission_credit = DECOMMISSION_INITIAL_CREDIT;
+        else
+          info.recommission_credit = 0;
+        info.version = version_t::v5_recomm_credit;
       }
       // Make sure we handled any future state version upgrades:
       assert(info.version == tools::enum_top<decltype(info.version)>);

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -107,6 +107,7 @@ namespace service_nodes
       v2_ed25519,
       v3_quorumnet,
       v4_noproofs,
+      v5_recomm_credit,
 
       _count
     };
@@ -169,6 +170,7 @@ namespace service_nodes
     uint32_t                           decommission_count = 0; // How many times this service node has been decommissioned
     int64_t                            active_since_height = 0; // if decommissioned: equal to the *negative* height at which you became active before the decommission
     uint64_t                           last_decommission_height = 0; // The height at which the last (or current!) decommissioning started, or 0 if never decommissioned
+    int64_t                            recommission_credit = DECOMMISSION_INITIAL_CREDIT; // The number of blocks of credit you started with or kept when you were last activated (i.e. as of `active_since_height`)
     std::vector<contributor_t>         contributors;
     uint64_t                           total_contributed = 0;
     uint64_t                           total_reserved = 0;
@@ -197,6 +199,9 @@ namespace service_nodes
       VARINT_FIELD(last_reward_transaction_index)
       VARINT_FIELD(decommission_count)
       VARINT_FIELD(active_since_height)
+      if (version >= version_t::v5_recomm_credit)
+        VARINT_FIELD(recommission_credit)
+
       VARINT_FIELD(last_decommission_height)
       FIELD(contributors)
       VARINT_FIELD(total_contributed)


### PR DESCRIPTION
This PR changes the credit rules for recommission: instead of being
restored with no credit at all, with this you get restored with 2 blocks
of credit lost (up to all of your credit) for each block of decommission
time you had.

For example, if you had 1000 blocks of credit and are decommissioned for
150 blocks, you'll get recommissioned with 700 blocks of credit.  If you
were decommissioned for 500 or more blocks then you'll get
decommissioned with 0 blocks of credit.

This applies the effects immediately rather than waiting for the hard
fork.  Because this isn't a consensus-breaking change it seems easier to
not worry about the HF rules.  The consequences are that the rules that
get applied to determining how much credit you have will depend on the
nodes involved in testing up until the hard fork: you *may* be subject
to the harsher v7 rules, or you may fall under v8 rules if enough of the
testing quorum has upgraded, but you'll never end up worse than the v7
rules.

This also fixes the long-standing issue in the RPC (and thus block explorer) that shows 1440 blocks (i.e. 48 hours) for a not-fully-staked node; such a node now shows the proper 60 blocks/2h value.