### PR TITLE
Miscellaneous daemon and rpc fixes

### DIFF
--- a/contrib/epee/include/console_handler.h
+++ b/contrib/epee/include/console_handler.h
@@ -423,7 +423,7 @@ eof:
   public:
     using callback = std::function<bool(const std::vector<std::string> &)>;
     using empty_callback = std::function<bool()>;
-    using lookup = std::unordered_map<std::string, std::pair<callback, std::pair<std::string, std::string>>>;
+    using lookup = std::map<std::string, std::pair<callback, std::pair<std::string, std::string>>>;
 
     /// Go through registered commands in sorted order, call the function with three string
     /// arguments: command name, usage, and description.

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -77,13 +77,14 @@ namespace cryptonote { namespace rpc {
   /// For HTTP JSON these become a 500 Internal Server Error response with the message as the body.
   /// For LokiMQ the code becomes the first part of the response and the message becomes the
   /// second part of the response.
-  struct rpc_error {
+  struct rpc_error : std::runtime_error {
     /// \param code - a signed, 16-bit numeric code.  0 must not be used (as it is used for a
     /// success code in LokiMQ), and values in the -32xxx range are reserved by JSON-RPC.
     ///
     /// \param message - a message to send along with the error code (see general description above).
     rpc_error(int16_t code, std::string message)
-      : code{code}, message{std::move(message)} {}
+      : std::runtime_error{"RPC error " + std::to_string(code) + ": " + message},
+        code{code}, message{std::move(message)} {}
 
     int16_t code;
     std::string message;

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -188,6 +188,9 @@ namespace cryptonote { namespace rpc {
       // This isn't really WARNable as it's the client fault; log at info level instead.
       MINFO("RPC request for '/" << uri << "' called with invalid/unparseable data: " << e.what());
       return HTTP_BAD_REQUEST;
+    } catch (const rpc_error& e) {
+      MWARNING("RPC request for '/" << uri << "' failed with: " << e.what() << "; returning 500 error");
+      return HTTP_ERROR;
     } catch (const std::exception& e) {
       MWARNING("RPC request '/" << uri << "' request raised an exception: " << e.what());
       return HTTP_ERROR;
@@ -244,6 +247,9 @@ namespace cryptonote { namespace rpc {
       // This isn't really WARNable as it's the client fault; log at info level instead.
       MINFO("JSON RPC request for '" << method << "' called with invalid data: " << e.what());
       return json_rpc_error(-32602, "Invalid params", body);
+    } catch (const rpc_error& e) {
+      MWARNING("JSON RPC request for '" << method << "' failed with: " << e.what());
+      return json_rpc_error(e.code, e.message, body);
     } catch (const std::exception& e) {
       MWARNING("json_rpc '" << method << "' request raised an exception: " << e.what());
       return json_rpc_error(-32603, "Internal error", body);

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -164,6 +164,10 @@ lmq_rpc::lmq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
         MINFO("LMQ RPC request '" << (call.is_public ? "rpc." : "admin.") << name << "' called with invalid/unparseable data: " << e.what());
         m.send_reply(LMQ_BAD_REQUEST, "Unable to parse request: "s + e.what());
         return;
+      } catch (const rpc_error& e) {
+        MWARNING("LMQ RPC request '" << (call.is_public ? "rpc." : "admin.") << name << "' failed with: " << e.what());
+        m.send_reply(LMQ_ERROR, e.what());
+        return;
       } catch (const std::exception& e) {
         MWARNING("LMQ RPC request '" << (call.is_public ? "rpc." : "admin.") << name << "' "
             "raised an exception: " << e.what());

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -154,6 +154,7 @@ lmq_rpc::lmq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
 
       try {
         m.send_reply(LMQ_OK, call.invoke(std::move(request), rpc_));
+        return;
       } catch (const parse_error& e) {
         // This isn't really WARNable as it's the client fault; log at info level instead.
         //


### PR DESCRIPTION
- Fixes daemon interactive commands listed in `help` being unordered
- Fixes JSON RPC error codes not being returned properly for json_rpc requests.
- Avoids a potential double-reply (success+error, with error being ignored) in LokiMQ RPC.