### PR TITLE
Fix broken sync timer

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -475,6 +475,10 @@ namespace cryptonote
       << " [Your node is " << abs_diff << " blocks (" << (abs_diff / (24 * 60 * 60 / DIFFICULTY_TARGET_V2)) << " days) "
       << (0 <= diff ? std::string("behind") : std::string("ahead"))
       << "]\nSYNCHRONIZATION started");
+
+      m_period_start_time = m_sync_start_time = std::chrono::steady_clock::now();
+      m_sync_start_height = curr_height;
+
       if (hshd.current_height >= curr_height + 5) // don't switch to unsafe mode just for a few blocks
       {
         m_core.safesyncmode(false);
@@ -1366,10 +1370,6 @@ namespace cryptonote
           m_core.resume_mine();
           if (!starting) m_last_add_end_time = epee::misc_utils::get_ns_count();
         };
-
-        m_sync_start_time = std::chrono::steady_clock::now();
-        m_sync_start_height = m_core.get_current_blockchain_height();
-        m_period_start_time = m_sync_start_time;
 
         while (1)
         {

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1330,7 +1330,7 @@ namespace cryptonote
     std::string text;
     const auto now = std::chrono::steady_clock::now();
     auto period_sync_time = now - m_period_start_time;
-    if (period_sync_time > 2min)
+    if (period_sync_time > 30s)
     {
       // Period is over, time to report another estimate
       uint64_t remaining_seconds = get_estimated_remaining_sync_seconds(current_blockchain_height, target_blockchain_height);


### PR DESCRIPTION
Currently the prediction seems broken and erratic:
```
... 7 minutes with no estimate
2020-08-01 19:15:33.251	I Synced 148887/347643 (42%, 198756 left, 5% of total synced, estimated 36 minutes left)
...
2020-08-01 19:17:33.623	I Synced 177784/347643 (51%, 169859 left, 19% of total synced, estimated 17 minutes left)
...
2020-08-01 19:20:24.599	I Synced 209483/347643 (60%, 138160 left, 12% of total synced, estimated 13 minutes left)
...
5 minutes with no estimate
```
Fixed it by setting the sync variables when synchronization actually begins instead of at some random point in the thread-contentious adding blocks function.

with this applied (showing just the relevant lines):
```
2020-08-01 19:38:57.556	I Synced 273976/347646 (78%, 73670 left, 10% of total synced, estimated 4 minutes left)
2020-08-01 19:39:41.935	I Synced 281575/347647 (80%, 66072 left, 19% of total synced, estimated 5 minutes left)
2020-08-01 19:40:12.554	I Synced 288874/347648 (83%, 58774 left, 28% of total synced, estimated 4 minutes left)
2020-08-01 19:40:42.579	I Synced 296073/347648 (85%, 51575 left, 37% of total synced, estimated 3 minutes left)
2020-08-01 19:41:12.690	I Synced 303173/347648 (87%, 44475 left, 45% of total synced, estimated 3 minutes left)
2020-08-01 19:41:43.433	I Synced 309372/347650 (88%, 38278 left, 53% of total synced, estimated 2 minutes left)
2020-08-01 19:42:13.446	I Synced 316472/347650 (91%, 31178 left, 62% of total synced, estimated 2 minutes left)
2020-08-01 19:42:43.686	I Synced 323571/347650 (93%, 24079 left, 70% of total synced, estimated 1 minutes left)
2020-08-01 19:43:13.968	I Synced 330470/347650 (95%, 17180 left, 79% of total synced, estimated 1 minutes left)
2020-08-01 19:43:44.119	I Synced 337470/347650 (97%, 10180 left, 87% of total synced, estimated 44 seconds left)
2020-08-01 19:44:14.438	I Synced 344570/347650 (99%, 3080 left, 96% of total synced, estimated 13 seconds left)
2020-08-01 19:44:27.857	I Synced 82074 blocks in 6 minutes (227.983 blocks per second)
```

I also lowered the timer for printing this to be every ~30s instead of every 2 minutes because 2 minutes seemed quite sporadic.