### PR TITLE
get_output_distribution fixes (plus related changes)

### DIFF
--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -44,7 +44,7 @@ namespace epee {
           case 0x18: case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
             s << "\\u00" << (c >= 0x10 ? '1' : '0');
             c &= 0xf;
-            s << (c < 0xa ? '0' + c : ('a' - 10) + c);
+            s << char(c < 0xa ? '0' + c : ('a' - 10) + c);
             break;
           default:
             s << c;

--- a/contrib/epee/src/portable_storage.cpp
+++ b/contrib/epee/src/portable_storage.cpp
@@ -26,7 +26,7 @@ namespace epee {
 
     void dump_as_json(std::ostream& s, const std::string& v, size_t, bool)
     {
-      s << '"';
+      s.put('"');
       // JSON strings may only contain 0x20 and above, except for " and \\ which must be escaped.
       // For values below 0x20 we can use \u00XX escapes, except for the really common \n and \t (we
       // could also use \b, \f, \r, but it really isn't worth the bother.
@@ -34,23 +34,24 @@ namespace epee {
         switch(c) {
           case '"':
           case '\\':
-            s << '\\' << c;
+            s.put('\\'); s.put(c);
             break;
-          case '\n': s << "\\n"; break;
-          case '\t': s << "\\t"; break;
+          case '\n': s.write("\\n", 2); break;
+          case '\t': s.write("\\t", 2); break;
           case 0x00: case 0x01: case 0x02: case 0x03: case 0x04: case 0x05: case 0x06: case 0x07:
           case 0x08: /*\t=0x09: \n=0x0a*/  case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
           case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
           case 0x18: case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
-            s << "\\u00" << (c >= 0x10 ? '1' : '0');
+            s.write("\\u00", 4);
+            s.put(c >= 0x10 ? '1' : '0');
             c &= 0xf;
-            s << char(c < 0xa ? '0' + c : ('a' - 10) + c);
+            s.put(c < 0xa ? '0' + c : ('a' - 10) + c);
             break;
           default:
-            s << c;
+            s.put(c);
         }
       }
-      s << '"';
+      s.put('"');
     }
 
 

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -212,7 +212,7 @@ namespace cryptonote { namespace rpc {
     OUT_PEERS::response                                 invoke(OUT_PEERS::request&& req, rpc_context context);
     IN_PEERS::response                                  invoke(IN_PEERS::request&& req, rpc_context context);
     UPDATE::response                                    invoke(UPDATE::request&& req, rpc_context context);
-    GET_OUTPUT_DISTRIBUTION::response                   invoke(GET_OUTPUT_DISTRIBUTION::request&& req, rpc_context context);
+    GET_OUTPUT_DISTRIBUTION::response                   invoke(GET_OUTPUT_DISTRIBUTION::request&& req, rpc_context context, bool binary = false);
     GET_OUTPUT_DISTRIBUTION_BIN::response               invoke(GET_OUTPUT_DISTRIBUTION_BIN::request&& req, rpc_context context);
     POP_BLOCKS::response                                invoke(POP_BLOCKS::request&& req, rpc_context context);
     GETBLOCKCOUNT::response                             invoke(GETBLOCKCOUNT::request&& req, rpc_context context);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3692,14 +3692,14 @@ bool wallet2::get_rct_distribution(uint64_t &start_height, std::vector<uint64_t>
     }
   }
 
-  cryptonote::rpc::GET_OUTPUT_DISTRIBUTION::request req{};
-  cryptonote::rpc::GET_OUTPUT_DISTRIBUTION::response res{};
+  cryptonote::rpc::GET_OUTPUT_DISTRIBUTION_BIN::request req{};
+  cryptonote::rpc::GET_OUTPUT_DISTRIBUTION_BIN::response res{};
   req.amounts.push_back(0);
   req.from_height = 0;
   req.cumulative = false;
   req.binary = true;
   req.compress = true;
-  bool r = invoke_http<rpc::GET_OUTPUT_DISTRIBUTION>(req, res);
+  bool r = invoke_http<rpc::GET_OUTPUT_DISTRIBUTION_BIN>(req, res);
   if (!r)
   {
     MWARNING("Failed to request output distribution: no connection to daemon");
@@ -9349,8 +9349,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> segregation_limit;
     if (is_after_segregation_fork && (m_segregate_pre_fork_outputs || m_key_reuse_mitigation2))
     {
-      cryptonote::rpc::GET_OUTPUT_DISTRIBUTION::request req_t{};
-      cryptonote::rpc::GET_OUTPUT_DISTRIBUTION::response resp_t{};
+      cryptonote::rpc::GET_OUTPUT_DISTRIBUTION_BIN::request req_t{};
+      cryptonote::rpc::GET_OUTPUT_DISTRIBUTION_BIN::response resp_t{};
       for(size_t idx: selected_transfers)
         req_t.amounts.push_back(m_transfers[idx].is_rct() ? 0 : m_transfers[idx].amount());
       std::sort(req_t.amounts.begin(), req_t.amounts.end());
@@ -9360,7 +9360,8 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
       req_t.to_height = segregation_fork_height + 1;
       req_t.cumulative = true;
       req_t.binary = true;
-      bool r = invoke_http<rpc::GET_OUTPUT_DISTRIBUTION>(req_t, resp_t);
+      req_t.compress = true;
+      bool r = invoke_http<rpc::GET_OUTPUT_DISTRIBUTION_BIN>(req_t, resp_t);
       THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "transfer_selected");
       THROW_WALLET_EXCEPTION_IF(resp_t.status == rpc::STATUS_BUSY, error::daemon_busy, "get_output_distribution");
       THROW_WALLET_EXCEPTION_IF(resp_t.status != rpc::STATUS_OK, error::get_output_distribution, get_rpc_status(resp_t.status));

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -9322,7 +9322,7 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
 
     std::vector<uint64_t> output_blacklist;
     if (!get_output_blacklist(output_blacklist))
-      THROW_WALLET_EXCEPTION_IF(true, error::get_output_blacklist, "Couldn't retrive list of outputs that are to be exlcuded from selection");
+      THROW_WALLET_EXCEPTION_IF(true, error::get_output_blacklist, "Couldn't retrive list of outputs that are to be excluded from selection");
 
     std::sort(output_blacklist.begin(), output_blacklist.end());
     if (output_blacklist.size() * 0.05 > (double)rct_offsets.size())


### PR DESCRIPTION
- Fixes a problem in JSON serialization of bytes < 0x20; this is what was causing the issue reported in #1200 (which affects current `dev` as well, depending on number of inputs on the chain -- but is easily reproducible on testnet).
- Removes support for binary/compress get_output_distribution with JSON requests.  Using them actually *increases* data size quite substantially because it produces lots of <0x20 values, most which of which require 6 bytes to encode in JSON: "\u0012". `*`
- Switches wallet2 to use the much more efficient GET_OUTPUT_DISTRIBUTION_BIN (which can use binary and varint compession).

`*` - this size expansion is (somewhat) new in `dev`.  In `master` (and Monero) using `binary` and `compress` produces flat out illegal JSON.