### PR TITLE
Regtest fixes

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -477,8 +477,9 @@ namespace cryptonote
 
       if (height >= m_stop_height)
       {
-        m_stop = true;
-        call_stop = true;
+        // Whoever actually first sets m_stop has the responsibility of calling stop():
+        bool already_stopping = m_stop.exchange(true);
+        call_stop = !already_stopping;
         break;
       }
 

--- a/src/cryptonote_basic/miner.h
+++ b/src/cryptonote_basic/miner.h
@@ -121,7 +121,6 @@ namespace cryptonote
     uint64_t m_height;
     std::atomic<uint32_t> m_thread_index; 
     std::atomic<uint32_t> m_threads_total;
-    std::atomic<uint32_t> m_threads_active;
     std::atomic<int32_t> m_pausers_count;
     std::mutex m_miners_count_lock;
 

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1965,6 +1965,7 @@ bool rpc_command_executor::prepare_registration()
     res.mainnet  ? cryptonote::MAINNET :
     res.stagenet ? cryptonote::STAGENET :
     res.testnet  ? cryptonote::TESTNET :
+    res.nettype == "fakechain" ? cryptonote::FAKECHAIN :
     cryptonote::UNDEFINED;
 #endif
 


### PR DESCRIPTION
Fixes a couple issues in `--regtest` mode:
- Fix stop_mining terminating the program.  (This isn't specific to --regtest, but seems much easier to trigger under --regtest --fixed-difficulty)
- Fix `prepare_registration` staking values in interactive mode under --regtest