### PR TITLE
Tweaks to default inactivity timeout behaviour

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2543,7 +2543,7 @@ bool simple_wallet::set_inactivity_lock_timeout(const std::vector<std::string> &
     uint32_t r;
     if (tools::parse_int(args[1], r))
     {
-      m_wallet->inactivity_lock_timeout(r);
+      m_wallet->inactivity_lock_timeout(std::chrono::seconds{r});
       m_wallet->rewrite(m_wallet_file, pwd_container->password());
     }
     else
@@ -3245,7 +3245,7 @@ bool simple_wallet::set_variable(const std::vector<std::string> &args)
     success_msg_writer() << "track-uses = " << m_wallet->track_uses();
     success_msg_writer() << "device_name = " << m_wallet->device_name();
     success_msg_writer() << "export-format = " << (m_wallet->export_format() == tools::wallet2::ExportFormat::Ascii ? "ascii" : "binary");
-    success_msg_writer() << "inactivity-lock-timeout = " << m_wallet->inactivity_lock_timeout()
+    success_msg_writer() << "inactivity-lock-timeout = " << m_wallet->inactivity_lock_timeout().count()
 #ifdef _WIN32
         << " (disabled on Windows)"
 #endif
@@ -8620,8 +8620,8 @@ bool simple_wallet::check_inactivity()
     // inactivity lock
     if (!m_locked && !m_in_command)
     {
-      const uint32_t seconds = m_wallet->inactivity_lock_timeout();
-      if (seconds > 0 && time(NULL) - m_last_activity_time > seconds)
+      const auto timeout = m_wallet->inactivity_lock_timeout();
+      if (timeout > 0s && std::chrono::seconds{time(NULL) - m_last_activity_time} > timeout)
       {
         m_locked = true;
         m_cmd_binder.cancel_input();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1246,8 +1246,8 @@ private:
     void ignore_outputs_below(uint64_t value) { m_ignore_outputs_below = value; }
     bool track_uses() const { return m_track_uses; }
     void track_uses(bool value) { m_track_uses = value; }
-    uint32_t inactivity_lock_timeout() const { return m_inactivity_lock_timeout; }
-    void inactivity_lock_timeout(uint32_t seconds) { m_inactivity_lock_timeout = seconds; }
+    std::chrono::seconds inactivity_lock_timeout() const { return m_inactivity_lock_timeout; }
+    void inactivity_lock_timeout(std::chrono::seconds seconds) { m_inactivity_lock_timeout = seconds; }
     const std::string & device_name() const { return m_device_name; }
     void device_name(const std::string & device_name) { m_device_name = device_name; }
     const std::string & device_derivation_path() const { return m_device_derivation_path; }
@@ -1836,7 +1836,7 @@ private:
     uint64_t m_ignore_outputs_above;
     uint64_t m_ignore_outputs_below;
     bool m_track_uses;
-    uint32_t m_inactivity_lock_timeout;
+    std::chrono::seconds m_inactivity_lock_timeout;
     bool m_is_initialized;
     NodeRPCProxy m_node_rpc_proxy;
     std::unordered_set<crypto::hash> m_scanned_pool_txs[2];


### PR DESCRIPTION
The new (from Monero) cli wallet timeout has been annoying me constantly when testing things.  This tweaks the timeouts to be far less annoying:

- increase default inactivity timeout to 10 minutes for new and upgrading mainnet wallets.  90 seconds is annoyingly short.
- Disable (by default) inactivity timeout for non-mainnet wallets.
- switch wallet2 timeout variables to use chrono types