### PR TITLE
Multisig tranfer generation fix

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10123,7 +10123,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
       {
         std::unordered_set<rct::key> new_used_L;
         size_t src_idx = 0;
-        THROW_WALLET_EXCEPTION_IF(selected_transfers.size() != sources.size(), error::wallet_internal_error, "mismatched selected_transfers and sources sixes");
+        THROW_WALLET_EXCEPTION_IF(selected_transfers.size() != sources.size(), error::wallet_internal_error, "mismatched selected_transfers and sources sizes");
         for(size_t idx: selected_transfers)
         {
           cryptonote::tx_source_entry& src = sources_copy[src_idx];
@@ -10147,7 +10147,7 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
                                                       additional_tx_keys,
                                                       rct_config,
                                                       &msout,
-                                                      /*shuffle_outs*/ true,
+                                                      /*shuffle_outs*/ false,
                                                       tx_params);
         LOG_PRINT_L2("constructed tx, r="<<r);
         THROW_WALLET_EXCEPTION_IF(!r, error::tx_not_constructed, sources, splitted_dsts, unlock_time, m_nettype);


### PR DESCRIPTION
`shuffle_outs` should not be true when generating multisig transfer permutations in an M-of-N wallet; if outputs get shuffled then the tx prefix hashes across the different transactions don't match, which isn't allowed, and fails with:

    Multisig txes do not share prefix

I'm not sure where we deviated from Monero on this value—upstream has had "false" here for quite a while.

(Also fixes a random log message typo)