### PR TITLE
Service node contribution fixes

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8191,13 +8191,17 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
   const auto& snode_info  = response.front();
   if (amount == 0) amount = snode_info.staking_requirement * fraction;
 
-  size_t total_num_locked_contributions = 0;
+  size_t total_existing_contributions = 0; // Count both contributions and reserved spots
   for (auto const &contributor : snode_info.contributors)
-    total_num_locked_contributions += contributor.locked_contributions.size();
+  {
+    total_existing_contributions += contributor.locked_contributions.size(); // contribution
+    if (contributor.reserved > contributor.amount)
+        total_existing_contributions++; // reserved contributor spot
+  }
 
   uint8_t const hf_version   = *res;
   uint64_t max_contrib_total = snode_info.staking_requirement - snode_info.total_reserved;
-  uint64_t min_contrib_total = service_nodes::get_min_node_contribution(hf_version, snode_info.staking_requirement, snode_info.total_reserved, total_num_locked_contributions);
+  uint64_t min_contrib_total = service_nodes::get_min_node_contribution(hf_version, snode_info.staking_requirement, snode_info.total_reserved, total_existing_contributions);
 
   bool is_preexisting_contributor = false;
   for (const auto& contributor : snode_info.contributors)


### PR DESCRIPTION
This fixes a few issues surrounding required contributions:

- #1210 broke reserved registrations (including the operator stake)
  because it wasn't properly recognizing a contribution into a reserved
  slot.

- As part of the above, the overstaking protection now applies to the
  reserved amount + any free contribution room.  (So, if you have a
  reserved spot of 8000 and there is 2000 free, but someone else fills
  1000 of it before your stake gets mined, any stake above 9090 (9000 +
  1%) will fall through without being locked up.

- The required contribution calculation was only taking into account
  contributions but not unfilled, reserved contributions (issue #1137).
  This fixes it to count unfilled, reserved spots as contributions for
  the purposes of calculating the minimum contribution.  This is applied
  in the wallet immediately, but for the chain it is not enforced until
  HF16.

- Eliminates some potential edge cases if a stake contains multiple
  stake outputs.  The wallet won't generate these, but they are
  allowed on chain and could result in an incompletely staked service
  node with no contributor slots remaining.  The minimum contribution
  math effectively assumes a single output for calculating the minimum
  contribution (but if we have multiple outputs we would chew up two
  slots).  Disallow such stakes entirely beginning in HF16.

- Operator stake included in the registration tx had some weird edge
  cases.  The wallet wouldn't produce these, but they should be
  disallowed at the blockchain level:
  - multi-output stakes were allowed (as above).
  - the registration stake only had to be >= 25%, even if the operator
    reserved a larger amount.
  - the registration stake could be for someone *other* than the
    operator.

  Beginning in HF16 the stake included in the registration must be >=
  the operator-reserved amount, and must be staked by the operator
  wallet, and must be a single output.