### PR TITLE
Add Docker-Compose configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ local.properties
 .idea/
 
 /testnet
+
+docker-compose.override.yml

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  loki:
+    build:
+      context: ./
+    volumes:
+        - testWallet:/wallet
+        - testBlockchain:/home/loki/.loki/lmdb
+    entrypoint: ["lokid", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=22022", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=22023", "--non-interactive", "--confirm-external-bind", "--testnet"]
+
+volumes:
+  testWallet:
+  testBlockchain:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,3 @@ services:
   loki:
     build:
       context: ./
-    entrypoint: ["lokid", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=22022", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=22023", "--non-interactive", "--confirm-external-bind"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  loki:
+    build:
+      context: ./
+    entrypoint: ["lokid", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=22022", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=22023", "--non-interactive", "--confirm-external-bind"]


### PR DESCRIPTION
adds docker-compose configuration with an optional override file for persistent wallet/volume storage on testnet.

copy the `docker-compose.override.yml.dist` to `docker-compose.override.yml`.

the override file can be changed per user as it is gitignored.