### PR TITLE
Pulse Devnet Hardfork

### DIFF
--- a/src/cryptonote_basic/hardfork.cpp
+++ b/src/cryptonote_basic/hardfork.cpp
@@ -92,6 +92,7 @@ static constexpr HardFork::Params devnet_hard_forks[] =
 {
   { network_version_7,                      1,      0, 1597170000 },
   { network_version_15_lns,                 2,      0, 1597170000 }, // 2020-08-11 18:20 UTC
+  { network_version_16,                  4559,      0, 1597720928 }, // 2020-08-18 03:20 UT
 };
 
 uint64_t HardFork::get_hardcoded_hard_fork_height(network_type nettype, cryptonote::network_version version)

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -96,7 +96,7 @@ constexpr auto TARGET_BLOCK_TIME           = 2min;
 constexpr auto DIFFICULTY_WINDOW           = 60;
 constexpr uint64_t DIFFICULTY_BLOCKS_COUNT = (DIFFICULTY_WINDOW + 1); // added +1 to make N=N
 
-constexpr uint64_t BLOCKS_EXPECTED_IN_HOURS(int hours) { return (1h / TARGET_BLOCK_TIME); }
+constexpr uint64_t BLOCKS_EXPECTED_IN_HOURS(int hours) { return (1h / TARGET_BLOCK_TIME) * hours; }
 constexpr uint64_t BLOCKS_EXPECTED_IN_DAYS(int days)   { return BLOCKS_EXPECTED_IN_HOURS(24) * days; }
 constexpr uint64_t BLOCKS_EXPECTED_IN_YEARS(int years) { return BLOCKS_EXPECTED_IN_DAYS(365) * years; }
 


### PR DESCRIPTION
- Add hardfork for devnet in ~1hr, block 4559 (as of posting we are on 4479)
- Fix BLOCKS_EXPECTED_IN_HOURS not applying hours to the value