### PR TITLE
get_service_nodes RPC tweaks

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -116,10 +116,14 @@ public: \
   template<typename T> inline void serialize_default(const T &t, T v) { }
   template<typename T, typename S> inline void serialize_default(T &t, S &&v) { t = std::forward<S>(v); }
 
+  template <typename T1, typename T2, typename = void> constexpr bool is_comparable = false;
+  template <typename T1, typename T2> constexpr bool is_comparable<T1, T2, std::void_t<decltype(std::declval<T1>() == std::declval<T2>())>> = true;
+
 #define KV_SERIALIZE_OPT_N(variable, val_name, default_value) \
   do { \
-    if (is_store && this_ref.variable == default_value) \
-      break; \
+    if constexpr (epee::is_comparable<decltype(this_ref.variable), decltype(default_value)>) \
+      if (is_store && this_ref.variable == default_value) \
+          break; \
     if (!epee::serialization::perform_serialize<is_store>(this_ref.variable, stg, parent_section, val_name)) \
       epee::serialize_default(this_ref.variable, default_value); \
   } while (0);

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1537,7 +1537,7 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
   // Print Funding Status
   {
     stream << indent1 << "[" << entry_index << "] " << "Service Node: " << entry.service_node_pubkey << " ";
-    stream << "v" << entry.version_major << "." << entry.version_minor << "." << entry.version_patch << "\n";
+    stream << "v" << tools::join(".", entry.service_node_version) << "\n";
 
     if (detailed_view)
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2275,9 +2275,6 @@ namespace cryptonote { namespace rpc {
     if (get_service_nodes_res.service_node_states.empty()) // Started in service node but not staked, no information on the blockchain yet
     {
       res.service_node_state.service_node_pubkey  = std::move(get_service_node_key_res.service_node_pubkey);
-      res.service_node_state.version_major        = LOKI_VERSION[0];
-      res.service_node_state.version_minor        = LOKI_VERSION[1];
-      res.service_node_state.version_patch        = LOKI_VERSION[2];
       res.service_node_state.public_ip            = epee::string_tools::get_ip_string_from_int32(m_core.sn_public_ip());
       res.service_node_state.storage_port         = m_core.storage_port();
       res.service_node_state.storage_lmq_port     = m_core.m_storage_lmq_port;
@@ -2845,9 +2842,6 @@ namespace cryptonote { namespace rpc {
         entry.last_uptime_proof                  = proof.timestamp;
         entry.storage_server_reachable           = proof.storage_server_reachable;
         entry.storage_server_reachable_timestamp = proof.storage_server_reachable_timestamp;
-        entry.version_major                      = proof.version[0];
-        entry.version_minor                      = proof.version[1];
-        entry.version_patch                      = proof.version[2];
         entry.votes = std::vector<service_nodes::checkpoint_vote_record>(proof.votes.begin(), proof.votes.end());
     });
 

--- a/src/rpc/core_rpc_server_commands_defs.cpp
+++ b/src/rpc/core_rpc_server_commands_defs.cpp
@@ -1111,9 +1111,6 @@ KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::requested_fields_t)
     KV_SERIALIZE(last_uptime_proof)
     KV_SERIALIZE(storage_server_reachable)
     KV_SERIALIZE(storage_server_reachable_timestamp)
-    KV_SERIALIZE(version_major)
-    KV_SERIALIZE(version_minor)
-    KV_SERIALIZE(version_patch)
     KV_SERIALIZE(votes)
   }
 KV_SERIALIZE_MAP_CODE_END()
@@ -1163,9 +1160,6 @@ KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::response::entry)
   KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(last_uptime_proof);
   KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(storage_server_reachable);
   KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(storage_server_reachable_timestamp);
-  KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(version_major);
-  KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(version_minor);
-  KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(version_patch);
   KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(votes);
 KV_SERIALIZE_MAP_CODE_END()
 

--- a/src/rpc/core_rpc_server_commands_defs.cpp
+++ b/src/rpc/core_rpc_server_commands_defs.cpp
@@ -1116,12 +1116,13 @@ KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::requested_fields_t)
 KV_SERIALIZE_MAP_CODE_END()
 
 
+static constexpr GET_SERVICE_NODES::requested_fields_t all_fields{true};
 KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::request)
   KV_SERIALIZE(service_node_pubkeys);
   KV_SERIALIZE(include_json);
   KV_SERIALIZE(limit)
   KV_SERIALIZE(active_only)
-  KV_SERIALIZE(fields)
+  KV_SERIALIZE_OPT(fields, all_fields)
   KV_SERIALIZE(poll_block_hash)
 KV_SERIALIZE_MAP_CODE_END()
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2007,7 +2007,7 @@ namespace rpc {
 
     // Boolean values indicate whether corresponding fields should be included in the response
     struct requested_fields_t {
-      bool all = true; // If set, overrides any individual requested fields
+      bool all = false; // If set, overrides any individual requested fields.  Defaults to *true* if "fields" is entirely omitted
       bool service_node_pubkey;
       bool registration_height;
       bool registration_hf_version;
@@ -2053,7 +2053,7 @@ namespace rpc {
       bool include_json;                             // When set, the response's as_json member is filled out.
       uint32_t limit;                                // If non-zero, select a random sample (in random order) of the given number of service nodes to return from the full list.
       bool active_only;                              // If true, only include results for active (fully staked, not decommissioned) service nodes.
-      requested_fields_t fields;
+      requested_fields_t fields;                     // If omitted return all fields; otherwise return only the specified fields
 
       std::string poll_block_hash;                   // If specified this changes the behaviour to only return service node records if the block hash is *not* equal to the given hash; otherwise it omits the records and instead sets `"unchanged": true` in the response. This is primarily used to poll for new results where the requested results only change with new blocks.
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2038,9 +2038,6 @@ namespace rpc {
       bool last_uptime_proof;
       bool storage_server_reachable;
       bool storage_server_reachable_timestamp;
-      bool version_major;
-      bool version_minor;
-      bool version_patch;
       bool votes;
 
       bool block_hash;
@@ -2097,9 +2094,6 @@ namespace rpc {
         uint64_t                                           last_uptime_proof;                   // The last time this Service Node's uptime proof was relayed by at least 1 Service Node other than itself in unix epoch time.
         bool                                               storage_server_reachable;            // Whether the node's storage server has been reported as unreachable for a long time
         uint64_t                                           storage_server_reachable_timestamp;  // The last time this Service Node's storage server was contacted
-        uint16_t                                           version_major;                       // Major version the node is currently running
-        uint16_t                                           version_minor;                       // Minor version the node is currently running
-        uint16_t                                           version_patch;                       // Patch version the node is currently running
         std::vector<service_nodes::checkpoint_vote_record> votes;                               // Of the last N checkpoints the Service Node is in a checkpointing quorum, record whether or not the Service Node voted to checkpoint a block
 
         KV_MAP_SERIALIZABLE


### PR DESCRIPTION
- Changes the behaviour of `fields.all` to default to false when `fields` is specified
- Removes redundant version_{major,minor,patch} fields (we already provide a 3-element-array version in `service_node_version`).