### PR TITLE
Fix json serialization of pulse sigs

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -61,7 +61,7 @@ namespace service_nodes
       std::memset(padding, 0, sizeof(padding));
     }
 
-    BEGIN_SERIALIZE()
+    BEGIN_SERIALIZE_OBJECT()
       FIELD(voter_index)
       FIELD(signature)
     END_SERIALIZE()


### PR DESCRIPTION
This was producing invalid json:

    "signatures":[,"voter_index":0,"signature":"...",,"voter_index":1,"signature":"...",,

This change corrects it to:

    "signatures":[{"voter_index":0,"signature":"..."},{"voter_index":1,"signature":"..."},{