### PR TITLE
Fix bl.* commands not being registered

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -272,6 +272,7 @@ namespace cryptonote
 
   void (*long_poll_trigger)(tx_memory_pool& pool) = [](tx_memory_pool&) { need_core_init(); };
   quorumnet_new_proc *quorumnet_new = [](core&) -> void* { need_core_init(); };
+  quorumnet_init_proc *quorumnet_init = [](core&, void*) { need_core_init(); };
   quorumnet_delete_proc *quorumnet_delete = [](void*&) { need_core_init(); };
   quorumnet_relay_obligation_votes_proc *quorumnet_relay_obligation_votes = [](void*, const std::vector<service_nodes::quorum_vote_t>&) { need_core_init(); };
   quorumnet_send_blink_proc *quorumnet_send_blink = [](core&, const std::string&) -> std::future<std::pair<blink_result, std::string>> { need_core_init(); };
@@ -1073,6 +1074,7 @@ namespace cryptonote
       m_quorumnet_state = quorumnet_new(*this);
     }
 
+    quorumnet_init(*this, m_quorumnet_state);
   }
 
   void core::start_lokimq() {

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -83,6 +83,10 @@ namespace cryptonote
   // passed into all the other callbacks below so that the callbacks can recast it into whatever it
   // should be.
   using quorumnet_new_proc = void *(core &core);
+  // Initializes quorumnet; unlike `quorumnet_new_proc` this needs to be called for all nodes, not
+  // just service nodes.  The second argument should be the `quorumnet_new` return value if a
+  // service node, nullptr if not.
+  using quorumnet_init_proc = void (core &core, void *self);
   // Destroys the quorumnet state; called on shutdown *after* the LokiMQ object has been destroyed.
   // Should destroy the state object and set the pointer reference to nullptr.
   using quorumnet_delete_proc = void (void *&self);
@@ -100,6 +104,7 @@ namespace cryptonote
   extern void (*long_poll_trigger)(tx_memory_pool& pool);
 
   extern quorumnet_new_proc *quorumnet_new;
+  extern quorumnet_init_proc *quorumnet_init;
   extern quorumnet_delete_proc *quorumnet_delete;
   extern quorumnet_relay_obligation_votes_proc *quorumnet_relay_obligation_votes;
   extern quorumnet_send_blink_proc *quorumnet_send_blink;


### PR DESCRIPTION
bl.* weren't being registered for non-service nodes.  This fixes it by
moving endpoint setup from quorumnet_new (SN-only) to a new
quorumnet_init that does endpoint setup (for both SNs and non-SNs).