### PR TITLE
Make Monero happier with the libsodium-provided privkey

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -989,7 +989,8 @@ namespace cryptonote
         constexpr unsigned char zero[crypto_core_ed25519_SCALARBYTES] = {0};
         crypto_core_ed25519_scalar_add(reinterpret_cast<unsigned char*>(keys.key.data), pk_sh_data, zero);
         if (!crypto::secret_key_to_public_key(keys.key, keys.pub))
-            throw std::runtime_error{"Failed to derive primary key from ed25519 key"};
+          throw std::runtime_error{"Failed to derive primary key from ed25519 key"};
+        assert(0 == std::memcmp(keys.pub.data, keys.pub_x25519.data, 32));
       } else if (!init_key(m_config_folder + "/key", keys.key, keys.pub,
           crypto::secret_key_to_public_key,
           [](crypto::secret_key &key, crypto::public_key &pubkey) {


### PR DESCRIPTION
Passing the libsodium-derived private key into Monero was fine *except*
when you try to generate a pubkey from it via secret_key_to_public_key:
Monero for some reason has an extra check during pubkey generation that
requires the privkey is less than the basepoint.  (This check is
pointless because a value above the basepoint is perfectly acceptable:
all operations are always mod basepoint).

This is easy to work around by explicitly doing a mod L on the private
key value before setting it in the Monero privkey.  (This results in
exactly the same pubkey, and an exactly equivalent privkey).

This also updates the code to actually do the pubkey generation via
`secret_key_to_public_key` to make sure it is fine with it.