### PR TITLE
GCC-10 fix

### DIFF
--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -95,34 +95,19 @@ public:
 		spad.set(boost::alignment::aligned_alloc(4096, 4096));
 	}
 
-	cn_heavy_hash (cn_heavy_hash&& other) noexcept : lpad(other.lpad.as_byte()), spad(other.spad.as_byte()), borrowed_pad(other.borrowed_pad)
-	{
-		other.lpad.set(nullptr);
-		other.spad.set(nullptr);
-	}
-
 	// Factory function enabling to temporaliy turn v2 object into v1
 	// It is caller's responsibility to ensure that v2 object is not hashing at the same time!!
 	static cn_heavy_hash_v1 make_borrowed(cn_heavy_hash_v2& t)
 	{
-		return cn_heavy_hash_v1(t.lpad.as_void(), t.spad.as_void());
+		return {t.lpad.as_void(), t.spad.as_void()};
 	}
 
-	cn_heavy_hash& operator= (cn_heavy_hash&& other) noexcept
-    {
-		if(this == &other)
-			return *this;
-
-		free_mem();
-		lpad.set(other.lpad.as_void());
-		spad.set(other.spad.as_void());
-		borrowed_pad = other.borrowed_pad;
-		return *this;
-	}
-
-	// Copying is going to be really inefficient
+	// Disable copy/move ctors; copying, in particular, is going to be really inefficient and we
+	// don't need to move it anywhere in LOKI code anyway.
 	cn_heavy_hash(const cn_heavy_hash& other) = delete;
+	cn_heavy_hash(cn_heavy_hash&& other) = delete;
 	cn_heavy_hash& operator= (const cn_heavy_hash& other) = delete;
+	cn_heavy_hash& operator= (cn_heavy_hash&& other) = delete;
 
 	~cn_heavy_hash()
 	{

--- a/src/crypto/jh.c
+++ b/src/crypto/jh.c
@@ -216,13 +216,13 @@ static void F8(hashState *state)
       uint64  i;
 
       /*xor the 512-bit message with the fist half of the 1024-bit hash state*/
-      for (i = 0; i < 8; i++)  state->x[i >> 1][i & 1] ^= ((uint64*)state->buffer)[i];
+      for (i = 0; i < 8; i++)  ((uint64*)state->x)[i] ^= ((uint64*)state->buffer)[i];
 
       /*the bijective function E8 */
       E8(state);
 
       /*xor the 512-bit message with the second half of the 1024-bit hash state*/
-      for (i = 0; i < 8; i++)  state->x[(8+i) >> 1][(8+i) & 1] ^= ((uint64*)state->buffer)[i];
+      for (i = 0; i < 8; i++)  ((uint64*)state->x)[8+i] ^= ((uint64*)state->buffer)[i];
 }
 
 /*before hashing a message, initialize the hash state as H0 */


### PR DESCRIPTION
With this code as written, GCC-10 can't hash beyond block 12 on mainnet.  Although this is GCC's fault technically, the code here is stupidly obscure for no good reason.

(The CN-heavy move constructor removal was just me eliminating potential issues while tracking this down, but since removing it didn't affect anything, I just left them deleted).