### PR TITLE
LNS resolve - fix empty reply

### DIFF
--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -2166,12 +2166,14 @@ std::optional<mapping_value> name_system_db::resolve(mapping_type type, std::str
   bind_all(resolve_sql, db_mapping_type(type), name_hash_b64, blockchain_height);
   if (step(resolve_sql) == SQLITE_ROW)
   {
-    auto& r = result.emplace();
-    auto data = get_blob(resolve_sql, 0);
-    assert(data.size() <= r.buffer.size());
-    r.len = data.size();
-    r.encrypted = true;
-    std::copy(data.begin(), data.end(), r.buffer.begin());
+    if (auto blob = get<std::optional<blob_view>>(resolve_sql, 0))
+    {
+      auto& r = result.emplace();
+      assert(blob->data.size() <= r.buffer.size());
+      r.len = blob->data.size();
+      r.encrypted = true;
+      std::copy(blob->data.begin(), blob->data.end(), r.buffer.begin());
+    }
   }
   reset(resolve_sql);
   clear_bindings(resolve_sql);

--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -405,12 +405,12 @@ mapping_record sql_get_mapping_from_statement(sql_compiled_statement& statement)
     return result;
 
   int owner_column = tools::enum_count<mapping_record_column>;
-  if (!sql_copy_blob(statement, owner_column, reinterpret_cast<void *>(&result.owner), sizeof(result.owner)))
+  if (!sql_copy_blob(statement, owner_column, &result.owner, sizeof(result.owner)))
     return result;
 
   if (result.backup_owner_id > 0)
   {
-    if (!sql_copy_blob(statement, owner_column + 1, reinterpret_cast<void *>(&result.backup_owner), sizeof(result.backup_owner)))
+    if (!sql_copy_blob(statement, owner_column + 1, &result.backup_owner, sizeof(result.backup_owner)))
       return result;
   }
 
@@ -440,7 +440,7 @@ bool sql_run_statement(lns_sql_type type, sql_compiled_statement& statement, voi
           {
             auto *entry = reinterpret_cast<owner_record *>(context);
             get(statement, owner_record_column::id, entry->id);
-            if (!sql_copy_blob(statement, owner_record_column::address, reinterpret_cast<void *>(&entry->address), sizeof(entry->address)))
+            if (!sql_copy_blob(statement, owner_record_column::address, &entry->address, sizeof(entry->address)))
               return false;
             data_loaded = true;
           }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3438,9 +3438,6 @@ namespace cryptonote { namespace rpc {
     {
       auto [val, nonce] = mapping->value_nonce(type);
       res.encrypted_value = lokimq::to_hex(val);
-      MFATAL("val: " << lokimq::to_hex(val));
-      MFATAL("nonce: " << lokimq::to_hex(nonce));
-      MFATAL("all: " << lokimq::to_hex(mapping->to_view()));
       if (val.size() < mapping->to_view().size())
         res.nonce = lokimq::to_hex(nonce);
     }


### PR DESCRIPTION
LNS resolve requests for a not-found entry were returning `"encrypted_value": ""` erroneously because the resolve query returns a row of NULLs when not found (instead of no rows).  This fixes it to properly detect such a result (and cleans up the way we handle fetching blobs to allow fetching a nullable blob).