### PR TITLE
Pulse: Block TX Penalty from SN Reward

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1346,6 +1346,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   loki_block_reward_context block_reward_context = {};
   block_reward_context.fee                       = fee;
   block_reward_context.height                    = height;
+  block_reward_context.testnet_override          = nettype() == TESTNET && height < 386000;
   if (!calc_batched_governance_reward(height, block_reward_context.batched_governance))
   {
     MERROR_VER("Failed to calculate batched governance reward");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1324,10 +1324,7 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   //validate reward
-  uint64_t money_in_use = 0;
-  for (auto& o: b.miner_tx.vout)
-    money_in_use += o.amount;
-
+  uint64_t const money_in_use = get_outs_money_amount(b.miner_tx);
   if (b.miner_tx.vout.size() == 0) {
     MERROR_VER("miner tx has no outputs");
     return false;
@@ -4484,12 +4481,13 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   }
 
   abort_block.cancel();
+  uint64_t const fee_after_penalty = get_outs_money_amount(bl.miner_tx) - base_reward;
   if (bl.signatures.size() == service_nodes::PULSE_BLOCK_REQUIRED_SIGNATURES)
   {
     MINFO("+++++ PULSE BLOCK SUCCESSFULLY ADDED"
         "\n\tid: " << id <<
         "\n\tHEIGHT: " << new_height-1 << ", v" << +bl.major_version << '.' << +bl.minor_version <<
-        "\n\tblock reward: " << print_money(fee_summary + base_reward) << "(" << print_money(base_reward) << " + " << print_money(fee_summary) << ")"
+        "\n\tblock reward: " << print_money(fee_after_penalty + base_reward) << "(" << print_money(base_reward) << " + " << print_money(fee_after_penalty) << ")"
           ", coinbase_weight: " << coinbase_weight <<
           ", cumulative weight: " << cumulative_block_weight <<
           ", " << block_processing_time << "ms");
@@ -4501,7 +4499,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
         "\n\tid:  " << id <<
         "\n\tPoW: " << miner.blk_pow.proof_of_work <<
         "\n\tHEIGHT: " << new_height - 1 << ", v" << +bl.major_version << '.' << +bl.minor_version << ", difficulty: " << current_diffic <<
-        "\n\tblock reward: " << print_money(fee_summary + base_reward) << "(" << print_money(base_reward) << " + " << print_money(fee_summary) << ")"
+        "\n\tblock reward: " << print_money(fee_after_penalty + base_reward) << "(" << print_money(base_reward) << " + " << print_money(fee_after_penalty) << ")"
           ", coinbase_weight: " << coinbase_weight <<
           ", cumulative weight: " << cumulative_block_weight <<
           ", " << block_processing_time << "(" << miner.difficulty_calc_time << "/" << miner.verify_pow_time << ")ms");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1397,16 +1397,16 @@ bool Blockchain::validate_miner_transaction(const block& b, size_t cumulative_bl
   // +1 here to allow a 1 atomic unit error in the calculation (which can happen because of floating point errors or rounding)
   // TODO(loki): eliminate all floating point math in reward calculations.
   uint64_t max_base_reward = reward_parts.base_miner + reward_parts.governance_paid + reward_parts.service_node_paid + 1;
-  uint64_t max_money_in_use = max_base_reward + fee;
+  uint64_t max_money_in_use = max_base_reward + reward_parts.base_miner_fee;
   if (money_in_use > max_money_in_use)
   {
     MERROR_VER("coinbase transaction spends too much money (" << print_money(money_in_use) << "). Maximum block reward is "
-            << print_money(max_money_in_use) << " (= " << print_money(max_base_reward) << " base + " << print_money(fee) << " fees)");
+            << print_money(max_money_in_use) << " (= " << print_money(max_base_reward) << " base + " << print_money(reward_parts.base_miner_fee) << " fees)");
     return false;
   }
 
-  CHECK_AND_ASSERT_MES(money_in_use >= fee, false, "base reward calculation bug");
-  base_reward = money_in_use - fee;
+  CHECK_AND_ASSERT_MES(money_in_use >= reward_parts.base_miner_fee, false, "base reward calculation bug");
+  base_reward = money_in_use - reward_parts.base_miner_fee;
 
   return true;
 }

--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -489,6 +489,7 @@ namespace cryptonote
     // exceeding the block limit is already removed from base_reward).
     uint64_t non_miner_amounts = result.governance_due + result.service_node_paid;
     result.base_miner = base_reward > non_miner_amounts ? base_reward - non_miner_amounts : 0;
+    result.base_miner_fee = loki_context.fee;
 
     if (hard_fork_version >= cryptonote::network_version_16_pulse)
     {
@@ -505,20 +506,19 @@ namespace cryptonote
         return false;
       }
 
-      uint64_t const penalty = base_reward_unpenalized - base_reward;
-      if (penalty > loki_context.fee)
+      if (!loki_context.testnet_override)
       {
-        MERROR("Block reward penalty is greater than the fee that would be received, penalty "
-               << cryptonote::print_money(penalty) << ", fee "
-               << cryptonote::print_money(loki_context.fee));
-        return false;
-      }
+        uint64_t const penalty = base_reward_unpenalized - base_reward;
+        if (penalty > loki_context.fee)
+        {
+          MERROR("Block reward penalty is greater than the fee that would be received, penalty "
+                 << cryptonote::print_money(penalty) << ", fee "
+                 << cryptonote::print_money(loki_context.fee));
+          return false;
+        }
 
-      result.base_miner_fee = loki_context.fee - penalty;
-    }
-    else
-    {
-      result.base_miner_fee = loki_context.fee;
+        result.base_miner_fee = loki_context.fee - penalty;
+      }
     }
 
     return true;

--- a/src/cryptonote_core/cryptonote_tx_utils.h
+++ b/src/cryptonote_core/cryptonote_tx_utils.h
@@ -116,9 +116,10 @@ namespace cryptonote
   struct loki_block_reward_context
   {
     using portions = uint64_t;
-    uint64_t              height;
-    uint64_t              fee;
-    uint64_t              batched_governance;   // Optional: 0 hardfork v10, then must be calculated using blockchain::calc_batched_governance_reward
+    bool                     testnet_override;
+    uint64_t                 height;
+    uint64_t                 fee;
+    uint64_t                 batched_governance;   // Optional: 0 hardfork v10, then must be calculated using blockchain::calc_batched_governance_reward
     std::vector<service_nodes::payout_entry> block_leader_payouts = {service_nodes::null_payout_entry};
   };
 

--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -2334,9 +2334,7 @@ namespace service_nodes
     // original amount, i.e. 50% of the original base reward goes to service
     // nodes not 50% of the reward after removing the governance component (the
     // adjusted base reward post hardfork 10).
-    payout const block_leader                = m_state.get_block_leader();
-    uint64_t const base_reward               = reward_parts.original_base_reward;
-    uint64_t const total_service_node_reward = cryptonote::service_node_reward_formula(base_reward, hf_version);
+    payout const block_leader = m_state.get_block_leader();
     {
       auto const check_block_leader_pubkey = cryptonote::get_service_node_winner_from_tx_extra(miner_tx.extra);
       if (block_leader.key != check_block_leader_pubkey)
@@ -2452,7 +2450,7 @@ namespace service_nodes
         for (size_t i = 0; i < block_leader.payouts.size(); i++)
         {
           payout_entry const &payout = block_leader.payouts[i];
-          uint64_t const reward = cryptonote::get_portion_of_reward(payout.portions, total_service_node_reward);
+          uint64_t const reward = cryptonote::get_portion_of_reward(payout.portions, reward_parts.service_node_total);
           if (reward)
           {
             if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, reward))
@@ -2465,7 +2463,7 @@ namespace service_nodes
 
       case verify_mode::pulse_block_leader_is_producer:
       {
-        uint64_t total_reward = total_service_node_reward + reward_parts.base_miner_fee;
+        uint64_t total_reward = reward_parts.service_node_total + reward_parts.base_miner_fee;
         assert(total_reward > 0);
         for (size_t vout_index = 0; vout_index < block_leader.payouts.size(); vout_index++)
         {
@@ -2501,7 +2499,7 @@ namespace service_nodes
         for (size_t i = 0; i < block_leader.payouts.size(); i++)
         {
           payout_entry const &payout = block_leader.payouts[i];
-          uint64_t const reward = cryptonote::get_portion_of_reward(payout.portions, reward_parts.base_miner + total_service_node_reward);
+          uint64_t const reward = cryptonote::get_portion_of_reward(payout.portions, reward_parts.base_miner + reward_parts.service_node_total);
           if (reward)
           {
             if (!verify_coinbase_tx_output(miner_tx, height, vout_index, payout.address, reward))

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -386,7 +386,7 @@ namespace cryptonote
      * @param already_generated_coins the current total number of coins "minted"
      * @param total_weight return-by-reference the total weight of the new block
      * @param fee return-by-reference the total of fees from the included transactions
-     * @param expected_reward return-by-reference the total reward awarded to the miner finding this block, including transaction fees
+     * @param expected_reward return-by-reference the total reward awarded to the block producer finding this block, including transaction fees
      * @param version hard fork version to use for consensus rules
      *
      * @return true

--- a/src/loki_economy.h
+++ b/src/loki_economy.h
@@ -18,6 +18,7 @@ constexpr uint64_t FOUNDATION_REWARD_HF15 = BLOCK_REWARD_HF15 * 10 / 100;
 // LF to be used exclusively for Loki Blockswap liquidity seeding and incentives.  See
 // https://github.com/loki-project/loki-improvement-proposals/issues/24 for more details.  This ends
 // after 6 months.
+constexpr uint64_t BLOCK_REWARD_HF16        = BLOCK_REWARD_HF15;
 constexpr uint64_t BLOCKSWAP_LIQUIDITY_HF16 = BLOCK_REWARD_HF15 * 24 / 100;
 
 // HF17: at most 6 months after HF16.  This is tentative and will likely be replaced before the
@@ -28,7 +29,7 @@ constexpr uint64_t BLOCK_REWARD_HF17      = 18'333'333'333;
 constexpr uint64_t FOUNDATION_REWARD_HF17 =  1'833'333'333;
 
 static_assert(MINER_REWARD_HF15        + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF15);
-static_assert(BLOCKSWAP_LIQUIDITY_HF16 + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF15);
+static_assert(BLOCKSWAP_LIQUIDITY_HF16 + SN_REWARD_HF15 + FOUNDATION_REWARD_HF15 == BLOCK_REWARD_HF16);
 static_assert(                           SN_REWARD_HF15 + FOUNDATION_REWARD_HF17 == BLOCK_REWARD_HF17);
 
 // -------------------------------------------------------------------------------------------------

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -68,7 +68,7 @@ void loki_register_callback(std::vector<test_event_entry> &events,
 }
 
 std::vector<std::pair<uint8_t, uint64_t>>
-loki_generate_sequential_hard_fork_table(uint8_t max_hf_version)
+loki_generate_sequential_hard_fork_table(uint8_t max_hf_version, uint64_t pos_delay)
 {
   assert(max_hf_version < cryptonote::network_version_count);
   std::vector<std::pair<uint8_t, uint64_t>> result = {};
@@ -76,10 +76,8 @@ loki_generate_sequential_hard_fork_table(uint8_t max_hf_version)
 
   // HF15 reduces and HF16 eliminates miner block rewards, so we need to ensure we have enough
   // pre-HF15 blocks to generate enough LOKI for tests:
-  constexpr uint64_t pos_delay = 60;
-
   bool delayed = false;
-  for (uint8_t version = cryptonote::network_version_7; version <= max_hf_version; )
+  for (uint8_t version = cryptonote::network_version_7; version <= max_hf_version; version++)
   {
     if (version >= cryptonote::network_version_15_lns && !delayed)
     {
@@ -87,14 +85,6 @@ loki_generate_sequential_hard_fork_table(uint8_t max_hf_version)
       delayed = true;
     }
     result.emplace_back(version, version_height++);
-
-    // If we're going to HF16 or above, just skip over the RandomX version (HF12 through 15) so that
-    // we can avoid initializing the RandomX engine (which slows down the test suite quite
-    // substantially).
-    if (max_hf_version >= cryptonote::network_version_16_pulse && version == cryptonote::network_version_11_infinite_staking)
-      version = cryptonote::network_version_16_pulse;
-    else
-      version++;
   }
   return result;
 }

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -1359,7 +1359,7 @@ public:
 
 void                                      fill_nonce_with_loki_generator          (struct loki_chain_generator const *generator, cryptonote::block& blk, const cryptonote::difficulty_type& diffic, uint64_t height);
 void                                      loki_register_callback                  (std::vector<test_event_entry> &events, std::string const &callback_name, loki_callback callback);
-std::vector<std::pair<uint8_t, uint64_t>> loki_generate_sequential_hard_fork_table(uint8_t max_hf_version = cryptonote::network_version_count - 1);
+std::vector<std::pair<uint8_t, uint64_t>> loki_generate_sequential_hard_fork_table(uint8_t max_hf_version = cryptonote::network_version_count - 1, uint64_t pos_delay = 60);
 
 struct loki_blockchain_entry
 {

--- a/tests/core_tests/chaingen_main.cpp
+++ b/tests/core_tests/chaingen_main.cpp
@@ -119,7 +119,8 @@ int main(int argc, char* argv[])
     GENERATE_AND_PLAY(loki_checkpointing_alt_chain_with_increasing_service_node_checkpoints);
     GENERATE_AND_PLAY(loki_checkpointing_service_node_checkpoint_from_votes);
     GENERATE_AND_PLAY(loki_checkpointing_service_node_checkpoints_check_reorg_windows);
-    GENERATE_AND_PLAY(loki_core_block_reward_unpenalized);
+    GENERATE_AND_PLAY(loki_core_block_reward_unpenalized_pre_pulse);
+    GENERATE_AND_PLAY(loki_core_block_reward_unpenalized_post_pulse);
     GENERATE_AND_PLAY(loki_core_block_rewards_lrc6);
     GENERATE_AND_PLAY(loki_core_fee_burning);
     GENERATE_AND_PLAY(loki_core_governance_batched_reward);

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -2631,15 +2631,19 @@ bool loki_service_nodes_checkpoint_quorum_size::generate(std::vector<test_event_
 
   for (int i = 0; i < 16; i++)
   {
-    loki_register_callback(events, "check_checkpoint_quorum_should_be_empty", [check_height_1 = gen.height()](cryptonote::core &c, size_t ev_index)
-    {
-      DEFINE_TESTS_ERROR_CONTEXT("check_checkpoint_quorum_should_be_empty");
-      std::shared_ptr<const service_nodes::quorum> quorum = c.get_quorum(service_nodes::quorum_type::checkpointing, check_height_1);
-      CHECK_TEST_CONDITION(quorum != nullptr);
-      CHECK_TEST_CONDITION(quorum->validators.size() == 0);
-      return true;
-    });
+    gen.create_and_add_next_block();
+    std::shared_ptr<const service_nodes::quorum> quorum = gen.get_quorum(service_nodes::quorum_type::checkpointing, gen.height());
+    if (quorum) break;
   }
+
+  loki_register_callback(events, "check_checkpoint_quorum_should_be_empty", [check_height_1 = gen.height()](cryptonote::core &c, size_t ev_index)
+  {
+    DEFINE_TESTS_ERROR_CONTEXT("check_checkpoint_quorum_should_be_empty");
+    std::shared_ptr<const service_nodes::quorum> quorum = c.get_quorum(service_nodes::quorum_type::checkpointing, check_height_1);
+    CHECK_TEST_CONDITION(quorum != nullptr);
+    CHECK_TEST_CONDITION(quorum->validators.size() == 0);
+    return true;
+  });
 
   cryptonote::transaction new_registration_tx = gen.create_and_add_registration_tx(gen.first_miner());
   gen.create_and_add_next_block({new_registration_tx});

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -523,9 +523,14 @@ bool loki_core_block_reward_unpenalized_post_pulse::generate(std::vector<test_ev
 
     CHECK_TEST_CONDITION(orphan == false);
 
+    uint64_t rewards_from_fee = top_block.miner_tx.vout[0].amount;
     CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout.size() == 2, "1 for miner, 1 for service node");
-    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[0].amount == tx_fee, "Miner should have just received tx fee" << top_block.miner_tx.vout[0].amount);
-    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[1].amount < unpenalized_reward, "We should add enough transactions that the penalty is realised on the Service Node " << unpenalized_reward);
+    CHECK_TEST_CONDITION_MSG(rewards_from_fee > 0 && rewards_from_fee < tx_fee, "Block producer should receive a penalised tx fee less than " << cryptonote::print_money(tx_fee) << "received, " << cryptonote::print_money(rewards_from_fee) << "");
+    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[1].amount == unpenalized_reward, "Service Node should receive full reward " << unpenalized_reward);
+
+    MGINFO("rewards_from_fee: "   << cryptonote::print_money(rewards_from_fee));
+    MGINFO("tx_fee: "             << cryptonote::print_money(tx_fee));
+    MGINFO("unpenalized_amount: " << cryptonote::print_money(unpenalized_reward));
     return true;
   });
   return true;

--- a/tests/core_tests/loki_tests.cpp
+++ b/tests/core_tests/loki_tests.cpp
@@ -434,9 +434,9 @@ bool loki_checkpointing_service_node_checkpoints_check_reorg_windows::generate(s
   return true;
 }
 
-bool loki_core_block_reward_unpenalized::generate(std::vector<test_event_entry>& events)
+bool loki_core_block_reward_unpenalized_pre_pulse::generate(std::vector<test_event_entry>& events)
 {
-  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table();
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table(cryptonote::network_version_16_pulse - 1);
   loki_chain_generator gen(events, hard_forks);
   gen.add_blocks_until_version(hard_forks.back().first);
 
@@ -468,6 +468,64 @@ bool loki_core_block_reward_unpenalized::generate(std::vector<test_event_entry>&
     CHECK_TEST_CONDITION(orphan == false);
     CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[0].amount < unpenalized_block_reward, "We should add enough transactions that the penalty is realised on the base block reward");
     CHECK_EQ(top_block.miner_tx.vout[1].amount, expected_service_node_reward);
+    return true;
+  });
+  return true;
+}
+
+bool loki_core_block_reward_unpenalized_post_pulse::generate(std::vector<test_event_entry>& events)
+{
+  std::vector<std::pair<uint8_t, uint64_t>> hard_forks = loki_generate_sequential_hard_fork_table(cryptonote::network_version_count -1, 150 /*Proof Of Stake Delay*/);
+  loki_chain_generator gen(events, hard_forks);
+
+  uint8_t const newest_hf = hard_forks.back().first;
+  assert(newest_hf >= cryptonote::network_version_13_enforce_checkpoints);
+
+  gen.add_blocks_until_version(hard_forks.back().first);
+  gen.add_mined_money_unlock_blocks();
+
+  // Make big chunky TX's to trigger the block size penalty
+  cryptonote::account_base dummy = gen.add_account();
+  uint64_t tx_fee = 0;
+  std::vector<cryptonote::transaction> txs(150);
+  for (size_t i = 0; i < txs.size(); i++)
+  {
+    std::array<loki_service_node_contribution, 3> contributions = {};
+    for (size_t i = 0; i < contributions.size(); i++)
+    {
+      loki_service_node_contribution &entry = contributions[i];
+      entry.contributor                     = gen.add_account().get_keys().m_account_address;
+      entry.portions                        = STAKING_PORTIONS / 4;
+    }
+
+    txs[i] = gen.create_registration_tx(gen.first_miner(),
+                                        cryptonote::keypair::generate(hw::get_device("default")),
+                                        STAKING_PORTIONS / 4, /*operator portions*/
+                                        0,                    /*operator cut*/
+                                        contributions,
+                                        3);
+    gen.add_tx(txs[i], true /*can_be_added_to_blockchain*/, ""/*fail_msg*/, true /*kept_by_block*/);
+    tx_fee += txs[i].rct_signatures.txnFee;
+  }
+  gen.create_and_add_next_block(txs);
+
+  uint64_t unpenalized_reward = cryptonote::service_node_reward_formula(BLOCK_REWARD_HF17, newest_hf);
+  loki_register_callback(events, "check_block_rewards", [unpenalized_reward, tx_fee](cryptonote::core &c, size_t ev_index)
+  {
+    DEFINE_TESTS_ERROR_CONTEXT("check_block_rewards");
+    uint64_t top_height;
+    crypto::hash top_hash;
+    c.get_blockchain_top(top_height, top_hash);
+
+    bool orphan;
+    cryptonote::block top_block;
+    CHECK_TEST_CONDITION(c.get_block_by_hash(top_hash, top_block, &orphan));
+
+    CHECK_TEST_CONDITION(orphan == false);
+
+    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout.size() == 2, "1 for miner, 1 for service node");
+    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[0].amount == tx_fee, "Miner should have just received tx fee" << top_block.miner_tx.vout[0].amount);
+    CHECK_TEST_CONDITION_MSG(top_block.miner_tx.vout[1].amount < unpenalized_reward, "We should add enough transactions that the penalty is realised on the Service Node " << unpenalized_reward);
     return true;
   });
   return true;

--- a/tests/core_tests/loki_tests.h
+++ b/tests/core_tests/loki_tests.h
@@ -42,7 +42,8 @@ struct loki_checkpointing_alt_chain_too_old_should_be_dropped                   
 struct loki_checkpointing_alt_chain_with_increasing_service_node_checkpoints         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_service_node_checkpoint_from_votes                         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_checkpointing_service_node_checkpoints_check_reorg_windows               : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
-struct loki_core_block_reward_unpenalized                                            : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct loki_core_block_reward_unpenalized_pre_pulse                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
+struct loki_core_block_reward_unpenalized_post_pulse                                 : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_fee_burning                                                         : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_governance_batched_reward                                           : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };
 struct loki_core_block_rewards_lrc6                                                  : public test_chain_unit_base { bool generate(std::vector<test_event_entry>& events); };


### PR DESCRIPTION
The reward pre-hf16 is removed from the miner as they are the block
producer. After Pulse, the block producer changes to the Service Node.
Here we subtract the penalty from the Service Node Leader (the node at
the top of the Service Node List irrespective of round or even after PoW
the fallback).

#1267

- Also remove the hardfork skip in core_tests, we actually already have a
change that makes all the core_tests to run under turtle_lite_v2 (pico) in
get_block_longhash.

- Removes extraneous service node reward check in validate_miner_tx,
we pass in the reward_parts that's calculated from the state of our 
blockchain (i.e. it's already representative of the reward we expect to see
in the incoming miner_tx, so no need to double check it).