### PR TITLE
Fix internal RPC requests for service nodes

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2916,6 +2916,8 @@ namespace cryptonote { namespace rpc {
     entry.registration_hf_version       = info.registration_hf_version;
 
   }
+
+  static constexpr GET_SERVICE_NODES::requested_fields_t all_fields{true};
   //------------------------------------------------------------------------------------------------------------------------------
   GET_SERVICE_NODES::response core_rpc_server::invoke(GET_SERVICE_NODES::request&& req, rpc_context context)
   {
@@ -2931,7 +2933,7 @@ namespace cryptonote { namespace rpc {
       res.polling_mode = true;
       if (req.poll_block_hash == res.block_hash) {
         res.unchanged = true;
-        res.fields = req.fields;
+        res.fields = req.fields.value_or(all_fields);
         return res;
       }
     }
@@ -2980,7 +2982,7 @@ namespace cryptonote { namespace rpc {
     }
 
     res.service_node_states.reserve(sn_infos.size());
-    res.fields = req.fields;
+    res.fields = req.fields.value_or(all_fields);
 
     if (req.include_json)
     {

--- a/src/rpc/core_rpc_server_commands_defs.cpp
+++ b/src/rpc/core_rpc_server_commands_defs.cpp
@@ -1129,20 +1129,19 @@ KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::requested_fields_t)
 KV_SERIALIZE_MAP_CODE_END()
 
 
-static constexpr GET_SERVICE_NODES::requested_fields_t all_fields{true};
 KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::request)
   KV_SERIALIZE(service_node_pubkeys);
   KV_SERIALIZE(include_json);
   KV_SERIALIZE(limit)
   KV_SERIALIZE(active_only)
-  KV_SERIALIZE_OPT(fields, all_fields)
+  KV_SERIALIZE(fields)
   KV_SERIALIZE(poll_block_hash)
 KV_SERIALIZE_MAP_CODE_END()
 
 
 KV_SERIALIZE_MAP_CODE_BEGIN(GET_SERVICE_NODES::response::entry)
   const auto* res = stg.template get_context<response>();
-  const bool all = !res || res->fields.all;
+  const bool all = !is_store || !res || res->fields.all;
 
   #define KV_SERIALIZE_ENTRY_FIELD_IF_REQUESTED(var) if (all || res->fields.var) KV_SERIALIZE(var)
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2066,7 +2066,7 @@ namespace rpc {
       bool include_json;                             // When set, the response's as_json member is filled out.
       uint32_t limit;                                // If non-zero, select a random sample (in random order) of the given number of service nodes to return from the full list.
       bool active_only;                              // If true, only include results for active (fully staked, not decommissioned) service nodes.
-      requested_fields_t fields;                     // If omitted return all fields; otherwise return only the specified fields
+      std::optional<requested_fields_t> fields;      // If omitted return all fields; otherwise return only the specified fields
 
       std::string poll_block_hash;                   // If specified this changes the behaviour to only return service node records if the block hash is *not* equal to the given hash; otherwise it omits the records and instead sets `"unchanged": true` in the response. This is primarily used to poll for new results where the requested results only change with new blocks.
 


### PR DESCRIPTION
Fixes a couple of issues that caused problems when making requests to
GET_SERVICE_NODES:

- Internal requests making an rpc request for `GET_SERVICE_NODES::req{}`
  weren't ending up specifying `"all":true` in requested_fields *or* any
  other fields, so they requested no fields and got no fields in
  response.

That, however, exposed another problem:

- the serialized value *loading* of service node entries shouldn't be
  looking at requested fields at all: it should just deserialize
  whatever is incoming.  This was resulting in a parsed incoming service
  node RPC request ending up with all-empty data even when the data
  *was* there, which consequently broke the get-all-service-nodes call
  in the wallet, making the wallet think it had no locked service nodes.

The fix for issue 1 is to ignore requested_fields when `!is_store`.

The fix for issue 2 is to make requested_fields a std::optional and
handle the null-mean-all logic in the RPC call itself rather than in the
serialization layer.