### PR TITLE
Pulse: Vote validators off based on missing block signatures

### DIFF
--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -729,6 +729,9 @@ bool pulse::get_round_timings(cryptonote::Blockchain const &blockchain, uint64_t
   if (hf16_height == std::numeric_limits<uint64_t>::max())
     return false;
 
+  if (blockchain.get_current_blockchain_height() < hf16_height)
+    return false;
+
   cryptonote::block genesis_block;
   if (!blockchain.get_block_by_height(hf16_height - 1, genesis_block))
     return false;

--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -457,19 +457,6 @@ bool enforce_validator_participation_and_timeouts(round_context const &context,
 
   if (timed_out && !all_received)
   {
-    for (uint16_t quorum_index = 0; quorum_index < service_nodes::PULSE_QUORUM_SIZE; quorum_index++)
-    {
-      uint16_t validator_bit        = 1 << quorum_index;
-      bool locked_in_to_participate = (validator_bitset & validator_bit);
-      bool participated_in_stage    = (stage.bitset & validator_bit);
-
-      if (locked_in_to_participate && !participated_in_stage)
-      {
-        crypto::public_key const &pkey = context.prepare_for_round.quorum.validators[quorum_index];
-        node_list.record_pulse_participation(pkey, context.wait_for_next_block.height, context.prepare_for_round.round, false /*participated*/, false /*block_producer*/);
-      }
-    }
-
     MDEBUG(log_prefix(context) << "Stage timed out: insufficient responses. Expected "
                                << "(" << bitset_view16(validator_bitset).count() << ") " << bitset_view16(validator_bitset) << " received "
                                << "(" << bitset_view16(stage.bitset).count()     << ") " << bitset_view16(stage.bitset));
@@ -1388,17 +1375,6 @@ round_state wait_for_handshake_bitsets(round_context &context, service_nodes::se
       return goto_preparing_for_next_round(context);
     }
 
-    // Record all the nodes that are not participating in the round
-    for (size_t quorum_index = 0; quorum_index < quorum.size(); quorum_index++)
-    {
-      uint16_t quorum_bit = 1 << quorum_index;
-      if ((quorum_bit & best_bitset) == 0)
-      {
-        crypto::public_key const &pkey = context.prepare_for_round.quorum.validators[quorum_index];
-        node_list.record_pulse_participation(pkey, context.wait_for_next_block.height, context.prepare_for_round.round, false /*participated*/, false /*block_producer*/);
-      }
-    }
-
     context.transient.wait_for_handshake_bitsets.best_bitset = best_bitset;
     context.transient.wait_for_handshake_bitsets.best_count  = count;
     MINFO(log_prefix(context) << count << "/" << quorum.size()
@@ -1475,10 +1451,6 @@ round_state wait_for_block_template(round_context &context, service_nodes::servi
   bool received = context.transient.wait_for_block_template.stage.msgs_received == 1;
   if (timed_out || received)
   {
-    // Record if the block producer sent a block template or not
-    crypto::public_key const &block_producer = context.prepare_for_round.quorum.workers[0];
-    node_list.record_pulse_participation(block_producer, context.wait_for_next_block.height, context.prepare_for_round.round, received /*participated*/, true /*block_producer*/);
-
     if (received)
     {
       cryptonote::block const &block = context.transient.wait_for_block_template.block;
@@ -1675,18 +1647,6 @@ round_state send_and_wait_for_signed_blocks(round_context &context, service_node
       assert(signature);
       MDEBUG(log_prefix(context) << "Signature added: " << validator_index << ":" << context.prepare_for_round.quorum.validators[validator_index] << ", " << *signature);
       final_block.signatures.emplace_back(validator_index, *signature);
-    }
-
-    // Record all the validators that participated in the round to help produce
-    // the block.
-    for (uint16_t quorum_index = 0; quorum_index < quorum.size(); quorum_index++)
-    {
-      uint16_t bit = 1 << quorum_index;
-      if (bit & stage.bitset)
-      {
-        crypto::public_key const &pkey = context.prepare_for_round.quorum.validators[quorum_index];
-        node_list.record_pulse_participation(pkey, context.wait_for_next_block.height, context.prepare_for_round.round, true /*participated*/, false /*block_producer*/);
-      }
     }
 
     // Propagate Final Block

--- a/src/cryptonote_core/service_node_list.h
+++ b/src/cryptonote_core/service_node_list.h
@@ -58,8 +58,7 @@ namespace service_nodes
 
     struct
     {
-      uint8_t round          = 0;
-      bool    block_producer = false;
+      uint8_t round = 0;
     } pulse;
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -68,8 +67,7 @@ namespace service_nodes
       KV_SERIALIZE(is_pulse);
       if (this_ref.is_pulse)
       {
-        KV_SERIALIZE_N(pulse.round,          "pulse_round");
-        KV_SERIALIZE_N(pulse.block_producer, "pulse_block_producer");
+        KV_SERIALIZE_N(pulse.round, "pulse_round");
       }
     END_KV_SERIALIZE_MAP()
   };
@@ -473,7 +471,6 @@ namespace service_nodes
     bool handle_uptime_proof(cryptonote::NOTIFY_UPTIME_PROOF::request const &proof, bool &my_uptime_proof_confirmation, crypto::x25519_public_key &x25519_pkey);
 
     void record_checkpoint_participation(crypto::public_key const &pubkey, uint64_t height, bool participated);
-    void record_pulse_participation     (crypto::public_key const &pubkey, uint64_t height, uint8_t round, bool participated, bool block_producer);
 
     // Called every hour to remove proofs for expired SNs from memory and the database.
     void cleanup_proofs();
@@ -595,6 +592,7 @@ namespace service_nodes
     // Note(maxim): private methods don't have to be protected the mutex
     bool m_rescanning = false; /* set to true when doing a rescan so we know not to reset proofs */
     void process_block(const cryptonote::block& block, const std::vector<cryptonote::transaction>& txs);
+    void record_pulse_participation(crypto::public_key const &pubkey, uint64_t height, uint8_t round, bool participated);
 
     // Verify block against Service Node state that has just been called with 'state.update_from_block(block)'.
     bool verify_block(const cryptonote::block& block, bool alt_block, cryptonote::checkpoint_t const *checkpoint);

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -1546,7 +1546,6 @@ static void print_vote_history(std::ostringstream &stream, std::vector<service_n
     {
       stream << "[" << entry.height << ", ";
       stream << +entry.pulse.round << ", ";
-      stream << (entry.pulse.block_producer ? "Block Producer" : "Validator") << ", ";
       stream << (entry.voted ? "Yes" : "No") << "]";
     }
     else
@@ -1684,7 +1683,7 @@ static void append_printable_service_node_list_entry(cryptonote::network_type ne
     stream << indent2 <<  "Checkpoint Participation [Height, Voted]\n" << indent3;
     print_vote_history(stream, entry.checkpoint_participation);
 
-    stream << "\n\n" << indent2 << "Pulse Participation [Height, Round, (Block Producer|Validator), Voted]\n" << indent3;
+    stream << "\n\n" << indent2 << "Pulse Participation [Height, Round, Voted]\n" << indent3;
     print_vote_history(stream, entry.pulse_participation);
   }
 


### PR DESCRIPTION
- Instead of the Pulse quorums validators recording participation
between each other- so failures may not manifest in a decommission until
the several common nodes align and agree to vote off the node.

Voting now occurs when blocks arrives, validators participating in the
generation of the block are marked. This is shared information between
all nodes syncing the chain so decommissions are more readily agreeable
and acted upon in the Obligation quorums immediately.