### PR TITLE
epee optional kv serialization - don't emplace

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization_overloads.h
@@ -329,7 +329,8 @@ namespace epee
     {
       if constexpr (is_std_optional<T>) {
         // Emplace a new value and try to deserialize into it
-        bool ret = kv_unserialize(d.emplace(), stg, parent_section, pname);
+        d = T{};
+        bool ret = kv_unserialize(*d, stg, parent_section, pname);
         if (!ret) d.reset(); // Deserialization failed so clear the value
         return ret;
       }


### PR DESCRIPTION
clang doesn't like opt.emplace() when the optional's contained type
doesn't have an explicit default constructor (such as the recent
std::optional<requested_fields_t>), so construct and assign explicitly
rather than using emplace.