### PR TITLE
Fix max uint64_t errors when contributing to a reserved spot

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8113,7 +8113,8 @@ wallet2::stake_result wallet2::check_stake_allowed(const crypto::public_key& sn_
       max_contrib_total  += reserved_amount_not_contributed_yet;
       is_preexisting_contributor = true;
 
-      min_contrib_total = std::max(min_contrib_total, reserved_amount_not_contributed_yet);
+      if (min_contrib_total == UINT64_MAX || reserved_amount_not_contributed_yet > min_contrib_total)
+        min_contrib_total = reserved_amount_not_contributed_yet;
       break;
     }
   }


### PR DESCRIPTION
When trying to fill a reserved spot of a service node that is fully reserved the wallet is getting back the UINT64_MAX error code value for min_contrib_total, but not properly ignoring it resulting in:

Error: You must contribute at least 18446744073.709551615 loki to become a contributor for this service node.

even when you are trying to fill your own reserved, unfilled spot.

Fix it to recognize (and ignore) the error value when filling a reserved spot.