### PR TITLE
Pulse: Record participation uniquely

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4359,7 +4359,7 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   uint64_t already_generated_coins = chain_height ? m_db->get_block_already_generated_coins(chain_height - 1) : 0;
   if(!validate_miner_transaction(bl, cumulative_block_weight, fee_summary, base_reward, already_generated_coins, m_hardfork->get_current_version()))
   {
-    MGINFO_RED("Block with id: " << id << " has incorrect miner transaction");
+    MGINFO_RED("Block " << (chain_height - 1) << " with id: " << id << " has incorrect miner transaction");
     bvc.m_verifivation_failed = true;
     return_tx_to_pool(txs);
     return false;

--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -139,7 +139,7 @@ namespace service_nodes
     {
       if (check_checkpoint_obligation)
       {
-        if (checkpoint_participation.write_index >= CHECKPOINT_MAX_MISSABLE_VOTES)
+        if (checkpoint_participation.write_index >= QUORUM_VOTE_CHECK_COUNT)
         {
           int missed_participation = 0;
           for (participation_entry const &entry : checkpoint_participation)
@@ -157,7 +157,7 @@ namespace service_nodes
         }
       }
 
-      if (pulse_participation.write_index >= PULSE_MAX_MISSABLE_VOTES)
+      if (pulse_participation.write_index >= QUORUM_VOTE_CHECK_COUNT)
       {
         int missed_participation = 0;
         for (participation_entry const &entry : pulse_participation)


### PR DESCRIPTION
- Avoid situations where rescanning/syncing the chain pre records the
node participation when it may not be relevant anymore (i.e. someone
restarting their node would re-record historical non-participation in
blocks and prime them for re-voting off a particular node).