### PR TITLE
LMQ: get config directory from core instead of arg parsing

### DIFF
--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -1016,6 +1016,12 @@ namespace cryptonote
       * @return true
       */
      bool relay_txpool_transactions();
+
+     /**
+      * @brief returns the lokid config directory
+      */
+     const std::string& get_config_directory() const { return m_config_folder; }
+
  private:
 
      /**

--- a/src/rpc/lmq_server.cpp
+++ b/src/rpc/lmq_server.cpp
@@ -128,7 +128,7 @@ lmq_rpc::lmq_rpc(cryptonote::core& core, core_rpc_server& rpc, const boost::prog
     // windows.  In theory we could do some runtime detection to see if the Windows version is new
     // enough to support unix domain sockets, but for now the Windows default is just "don't listen"
 #ifndef _WIN32
-    locals.push_back("ipc://" + command_line::get_arg(vm, cryptonote::arg_data_dir) + "/lokid.sock");
+    locals.push_back("ipc://" + core.get_config_directory() + "/lokid.sock");
 #endif
   } else if (locals.size() == 1 && locals[0] == "none") {
     locals.clear();


### PR DESCRIPTION
There are some cases where core modified the config folder that the
default lmq control socket would miss; this cleans it up to get the
config folder from core rather than trying to use core's command-line
argument.