### PR TITLE
Fix JSON serialization of pulse block data

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -436,6 +436,8 @@ namespace cryptonote
   {
     unsigned char data[16];
     bool operator==(pulse_random_value const &other) const { return std::memcmp(data, other.data, sizeof(data)) == 0; }
+
+    static constexpr bool binary_serializable = true;
   };
 
   struct pulse_header
@@ -443,12 +445,16 @@ namespace cryptonote
     pulse_random_value random_value;
     uint8_t            round;
     uint16_t           validator_bitset;
-    BEGIN_SERIALIZE()
-      FIELD(random_value);
-      FIELD(round);
-      FIELD(validator_bitset);
-    END_SERIALIZE();
   };
+
+  template <typename Archive>
+  void serialize_value(Archive& ar, pulse_header& p)
+  {
+    auto obj = ar.begin_object();
+    serialization::field(ar, "random_value", p.random_value);
+    serialization::field(ar, "round", p.round);
+    serialization::field(ar, "validator_bitset", p.validator_bitset);
+  }
 
   struct block_header
   {
@@ -635,7 +641,6 @@ namespace std {
 
 BLOB_SERIALIZER(cryptonote::txout_to_key);
 BLOB_SERIALIZER(cryptonote::txout_to_scripthash);
-BLOB_SERIALIZER(cryptonote::pulse_random_value);
 
 VARIANT_TAG(cryptonote::txin_gen, "gen", 0xff);
 VARIANT_TAG(cryptonote::txin_to_script, "script", 0x0);


### PR DESCRIPTION
There was a missing call to nested the values in an object, so the
resulting json ended up as:

    "pulse":,"random_value":"b01b8d1290cbac40917a23a08b343bec","round":0,"validator_bitset":2047,

instead of:

    "pulse":{"random_value":"b01b8d1290cbac40917a23a08b343bec","round":0,"validator_bitset":2047},

Modernize it to avoid macros, and fix it by beginning an object.

(This won't affect binary serialization; object serialization only has
an effect on json serialization and is a no-op for binary
serialization).