### PR TITLE
Wallet rpc --wallet-dir segfault fix

### DIFF
--- a/src/common/base58.cpp
+++ b/src/common/base58.cpp
@@ -33,6 +33,7 @@
 #include <cassert>
 #include <cstring>
 #include <vector>
+#include <string_view>
 
 #include "crypto/hash.h"
 #include "int-util.h"
@@ -40,68 +41,34 @@
 
 namespace tools
 {
+  using namespace std::literals;
   namespace base58
   {
     namespace
     {
-      const char alphabet[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-      const size_t alphabet_size = sizeof(alphabet) - 1;
-      const size_t encoded_block_sizes[] = {0, 2, 3, 5, 6, 7, 9, 10, 11};
-      const size_t full_block_size = sizeof(encoded_block_sizes) / sizeof(encoded_block_sizes[0]) - 1;
-      const size_t full_encoded_block_size = encoded_block_sizes[full_block_size];
-      const size_t addr_checksum_size = 4;
+      constexpr std::string_view alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"sv;
+      constexpr size_t full_block_size = 8;
+      constexpr std::array<uint8_t, full_block_size + 1> encoded_block_sizes = {0, 2, 3, 5, 6, 7, 9, 10, 11};
+      constexpr size_t full_encoded_block_size = encoded_block_sizes.back();
+      constexpr std::array<int8_t, full_encoded_block_size + 1> decoded_block_sizes = {0, -1, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8};
+      constexpr size_t addr_checksum_size = 4;
 
-      struct reverse_alphabet
+      struct reverse_alphabet_table
       {
-        reverse_alphabet()
+        std::array<int8_t, 256> from_b58_lut;
+        constexpr reverse_alphabet_table() noexcept : from_b58_lut{}
         {
-          m_data.resize(alphabet[alphabet_size - 1] - alphabet[0] + 1, -1);
-
-          for (size_t i = 0; i < alphabet_size; ++i)
-          {
-            size_t idx = static_cast<size_t>(alphabet[i] - alphabet[0]);
-            m_data[idx] = static_cast<int8_t>(i);
-          }
+          for (size_t i = 0; i < from_b58_lut.size(); ++i)
+            from_b58_lut[i] = -1;
+          for (size_t i = 0; i < alphabet.size(); i++)
+            from_b58_lut[alphabet[i]] = i;
         }
 
-        int operator()(char letter) const
+        constexpr int8_t operator[](char letter) const
         {
-          size_t idx = static_cast<size_t>(letter - alphabet[0]);
-          return idx < m_data.size() ? m_data[idx] : -1;
+          return from_b58_lut[static_cast<unsigned char>(letter)];
         }
-
-        static reverse_alphabet instance;
-
-      private:
-        std::vector<int8_t> m_data;
-      };
-
-      reverse_alphabet reverse_alphabet::instance;
-
-      struct decoded_block_sizes
-      {
-        decoded_block_sizes()
-        {
-          m_data.resize(encoded_block_sizes[full_block_size] + 1, -1);
-          for (size_t i = 0; i <= full_block_size; ++i)
-          {
-            m_data[encoded_block_sizes[i]] = static_cast<int>(i);
-          }
-        }
-
-        int operator()(size_t encoded_block_size) const
-        {
-          assert(encoded_block_size <= full_encoded_block_size);
-          return m_data[encoded_block_size];
-        }
-
-        static decoded_block_sizes instance;
-
-      private:
-        std::vector<int> m_data;
-      };
-
-      decoded_block_sizes decoded_block_sizes::instance;
+      } constexpr reverse_alphabet;
 
       uint64_t uint_8be_to_64(const uint8_t* data, size_t size)
       {
@@ -128,8 +95,8 @@ namespace tools
         int i = static_cast<int>(encoded_block_sizes[size]) - 1;
         while (0 < num)
         {
-          uint64_t remainder = num % alphabet_size;
-          num /= alphabet_size;
+          uint64_t remainder = num % alphabet.size();
+          num /= alphabet.size();
           res[i] = alphabet[remainder];
           --i;
         }
@@ -139,7 +106,7 @@ namespace tools
       {
         assert(1 <= size && size <= full_encoded_block_size);
 
-        int res_size = decoded_block_sizes::instance(size);
+        int res_size = decoded_block_sizes[size];
         if (res_size <= 0)
           return false; // Invalid block size
 
@@ -147,7 +114,7 @@ namespace tools
         uint64_t order = 1;
         for (size_t i = size - 1; i < size; --i)
         {
-          int digit = reverse_alphabet::instance(block[i]);
+          auto digit = reverse_alphabet[block[i]];
           if (digit < 0)
             return false; // Invalid symbol
 
@@ -157,7 +124,7 @@ namespace tools
             return false; // Overflow
 
           res_num = tmp;
-          order *= alphabet_size; // Never overflows, 58^10 < 2^64
+          order *= alphabet.size(); // Never overflows, 58^10 < 2^64
         }
 
         if (static_cast<size_t>(res_size) < full_block_size && (UINT64_C(1) << (8 * res_size)) <= res_num)
@@ -202,7 +169,7 @@ namespace tools
 
       size_t full_block_count = enc.size() / full_encoded_block_size;
       size_t last_block_size = enc.size() % full_encoded_block_size;
-      int last_block_decoded_size = decoded_block_sizes::instance(last_block_size);
+      int8_t last_block_decoded_size = decoded_block_sizes[last_block_size];
       if (last_block_decoded_size < 0)
         return false; // Invalid enc length
       size_t data_size = full_block_count * full_block_size + last_block_decoded_size;

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -191,6 +191,15 @@ namespace tools
       // remote STOP command).
       void run_loop();
 
+      // Starts the long poll thread, if not already active and m_long_poll_disabled is not set.
+      // m_wallet must already be set.
+      void start_long_poll_thread();
+
+      // Stops the long poll thread and joins it.  This must be done before resetting m_wallet.
+      // After the call `m_long_poll_disabled` will be false (and must be set back to true if you
+      // want to re-start the thread).
+      void stop_long_poll_thread();
+
       std::unique_ptr<wallet2> m_wallet;
       std::string m_wallet_dir;
       std::vector<std::tuple<std::string /*ip*/, uint16_t /*port*/, bool /*required*/>> m_bind;
@@ -202,5 +211,6 @@ namespace tools
       std::chrono::steady_clock::time_point m_last_auto_refresh_time;
       std::atomic<bool> m_long_poll_new_changes;
       std::atomic<bool> m_long_poll_disabled;
+      std::thread m_long_poll_thread;
   };
 }

--- a/tests/unit_tests/base58.cpp
+++ b/tests/unit_tests/base58.cpp
@@ -69,7 +69,7 @@ namespace
 
   void do_test_decode_block_pos(const std::string& enc, const std::string& expected)
   {
-    std::string data(base58::decoded_block_sizes::instance(enc.size()), '\0');
+    std::string data(base58::decoded_block_sizes[enc.size()], '\0');
     ASSERT_TRUE(base58::decode_block(enc.data(), enc.size(), &data[0]));
     ASSERT_EQ(data, expected);
   }
@@ -150,18 +150,18 @@ TEST_uint_64_to_8be(0x0102030405060708, "\x1\x2\x3\x4\x5\x6\x7\x8");
 
 TEST(reverse_alphabet, is_correct)
 {
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance(0));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance(std::numeric_limits<char>::min()));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance(std::numeric_limits<char>::max()));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('1' - 1));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('z' + 1));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('0'));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('I'));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('O'));
-  ASSERT_EQ(-1, base58::reverse_alphabet::instance('l'));
-  ASSERT_EQ(0,  base58::reverse_alphabet::instance('1'));
-  ASSERT_EQ(8,  base58::reverse_alphabet::instance('9'));
-  ASSERT_EQ(base58::alphabet_size - 1, base58::reverse_alphabet::instance('z'));
+  ASSERT_EQ(-1, base58::reverse_alphabet[0]);
+  ASSERT_EQ(-1, base58::reverse_alphabet[std::numeric_limits<char>::min()]);
+  ASSERT_EQ(-1, base58::reverse_alphabet[std::numeric_limits<char>::max()]);
+  ASSERT_EQ(-1, base58::reverse_alphabet['1' - 1]);
+  ASSERT_EQ(-1, base58::reverse_alphabet['z' + 1]);
+  ASSERT_EQ(-1, base58::reverse_alphabet['0']);
+  ASSERT_EQ(-1, base58::reverse_alphabet['I']);
+  ASSERT_EQ(-1, base58::reverse_alphabet['O']);
+  ASSERT_EQ(-1, base58::reverse_alphabet['l']);
+  ASSERT_EQ(0,  base58::reverse_alphabet['1']);
+  ASSERT_EQ(8,  base58::reverse_alphabet['9']);
+  ASSERT_EQ(base58::alphabet.size() - 1, base58::reverse_alphabet['z']);
 }
 
 


### PR DESCRIPTION
The long polling through was living beyond the wallet destruction and reconstruction when the rpc wallet opened a new wallet.

Fixed it by synchronously shutting down and restarting the thread when we close/open a wallet.

Also includes some base58 encoding cleanup because the segfault in gdb led me into there and I found some ancient code that could be significantly cleaned up using constexpr's (though it turned out that wasn't the problem at all).