### PR TITLE
Rescan Difficulty Fix

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -349,9 +349,8 @@ void BlockchainDB::show_stats()
   );
 }
 
-void BlockchainDB::fixup(fixup_context const context)
+void BlockchainDB::fixup(cryptonote::network_type)
 {
-  (void)context;
   if (is_read_only()) {
     LOG_PRINT_L1("Database is opened read only - skipping fixup check");
     return;
@@ -435,8 +434,8 @@ void BlockchainDB::fill_timestamps_and_difficulties_for_pow(cryptonote::network_
                                                             uint64_t chain_height,
                                                             uint64_t timestamps_difficulty_height) const
 {
-  constexpr uint64_t MIN_HEIGHT = 1;
-  if (chain_height <= MIN_HEIGHT)
+  constexpr uint64_t MIN_CHAIN_HEIGHT = 2;
+  if (chain_height < MIN_CHAIN_HEIGHT)
     return;
 
   uint64_t const top_block_height   = chain_height - 1;
@@ -460,7 +459,7 @@ void BlockchainDB::fill_timestamps_and_difficulties_for_pow(cryptonote::network_
     uint64_t start_height = chain_height - std::min<size_t>(chain_height, block_count);
     start_height          = std::max<uint64_t>(start_height, 1);
 
-    for (uint64_t block_height = start_height; block_height < (chain_height - MIN_HEIGHT); block_height++)
+    for (uint64_t block_height = start_height; block_height < (chain_height - 1) /*skip latest block*/; block_height++)
     {
       timestamps.push_back(get_block_timestamp(block_height));
       difficulties.push_back(get_block_cumulative_difficulty(block_height));

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1841,15 +1841,7 @@ public:
   /**
    * @brief fix up anything that may be wrong due to past bugs
    */
-  struct fixup_context
-  {
-    cryptonote::network_type nettype;
-    struct
-    {
-      uint64_t start_height;
-    } recalc_diff;
-  };
-  virtual void fixup(fixup_context const context);
+  virtual void fixup(cryptonote::network_type nettype);
 
   virtual void get_output_blacklist(std::vector<uint64_t> &blacklist) const   = 0;
   virtual void add_output_blacklist(std::vector<uint64_t> const &blacklist)   = 0;

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -4782,10 +4782,9 @@ void BlockchainLMDB::fixup(cryptonote::network_type nettype)
       mdb_txn_cursors *m_cursors = &m_wcursors; // Necessary for macro
       CURSOR(block_info);
 
-      uint64_t blocks_in_batch = std::min(BLOCKS_PER_BATCH, num_blocks);
       for (uint64_t block_index = 0;
-           block_index < blocks_in_batch;
-           block_index++, num_blocks -= BLOCKS_PER_BATCH)
+           block_index < std::min(BLOCKS_PER_BATCH, num_blocks);
+           block_index++, num_blocks -= std::min(BLOCKS_PER_BATCH, num_blocks))
       {
         uint64_t const curr_height       = (batch_index * BLOCKS_PER_BATCH) + block_index;
         uint64_t const curr_chain_height = curr_height + 1;

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -422,7 +422,7 @@ private:
   void add_max_block_size(uint64_t sz) override;
 
   // fix up anything that may be wrong due to past bugs
-  void fixup(fixup_context const context) override;
+  void fixup(cryptonote::network_type nettype) override;
 
   // migrate from older DB version to current
   void migrate(const uint32_t oldversion, cryptonote::network_type nettype);

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -72,18 +72,13 @@ uint64_t db_batch_size_verify = 5000;
 
 std::string refresh_string = "\r                                    \r";
 
-const command_line::arg_descriptor<uint64_t> arg_recalculate_difficulty = {
+const command_line::arg_descriptor<bool> arg_recalculate_difficulty = {
   "recalculate-difficulty",
   "Recalculate per-block difficulty starting from the height specified",
   // This is now enabled by default because the network broke at 526483 because of divergent
   // difficulty values (and the chain that kept going violated the correct difficulty, and got
   // checkpointed multiple times because enough of the network followed it).
-  //
-  // TODO: We can disable this post-pulse (since diff won't matter anymore), but until then there
-  // is a subtle bug somewhere in difficulty calculations that can cause divergence; this seems
-  // important enough to just rescan at every startup (and only takes a few seconds).
-  1};
-
+  false};
 }
 
 
@@ -740,6 +735,9 @@ int main(int argc, char* argv[])
     core.deinit();
     return 0;
   }
+
+  if (command_line::get_arg(vm, arg_recalculate_difficulty))
+    core.get_blockchain_storage().get_db().fixup(core.get_nettype());
 
   import_from_file(core, import_file_path, block_stop);
 

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -174,7 +174,7 @@ namespace cryptonote {
     }
     // HF12 switches to RandomX with a likely drastically reduced hashrate versus Turtle, so override
     // difficulty for the first difficulty window blocks:
-    else if (hf_version >= cryptonote::network_version_12_checkpointing &&
+    else if (height >= hf12_height &&
              height < hf12_height + (DIFFICULTY_WINDOW + 1))
     {
       result = difficulty_calc_mode::hf12_override;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -490,11 +490,7 @@ bool Blockchain::init(BlockchainDB* db, sqlite3 *lns_db, const network_type nett
   }
 
   if (m_nettype != FAKECHAIN)
-  {
-    cryptonote::BlockchainDB::fixup_context context = {};
-    context.nettype = m_nettype;
-    m_db->fixup(context);
-  }
+    m_db->fixup(m_nettype);
 
   db_rtxn_guard rtxn_guard(m_db);
 
@@ -4468,19 +4464,6 @@ bool Blockchain::handle_block_to_main_chain(const block& bl, const crypto::hash&
   }
 
   TIME_MEASURE_FINISH(addblock);
-
-  // TODO(loki): Temporary forking code.
-  {
-    // Rescan difficulty every N block we have a reocurring difficulty bug that causes daemons to miscalculate difficulty
-    uint64_t block_height = get_block_height(bl);
-    if (nettype() == MAINNET && (block_height % BLOCKS_EXPECTED_IN_DAYS(1) == 0))
-    {
-      cryptonote::BlockchainDB::fixup_context context  = {};
-      context.nettype = m_nettype;
-      context.recalc_diff.start_height = block_height - BLOCKS_EXPECTED_IN_DAYS(1);
-      m_db->fixup(context);
-    }
-  }
 
   // do this after updating the hard fork state since the weight limit may change due to fork
   if (!update_next_cumulative_weight_limit())


### PR DESCRIPTION
- Remove specifying height in rescan as full rescan is quick, custom height is not used anywhere in the code base and prone to implementation bugs (calculating difficulty is very fragile).
- Change the rescan loop to match how get_difficulty_for_next_block works (add timestamps then calculate next difficulty instead of the other way around) which caused off by 1 difficulties.
- Make sure the transition from Pico to RandomX starts on the correct block (again off by 1). 

This commit allows a v8 daemon to sync all of mainnet with no issues. It also makes rescan_difficulty on startup match the mainnet difficulties.

Currently syncing testnet, but I presume that difficulty there is broken as it's running with the broken rescan code.