### PR TITLE
HF16: Set min storage server version to 2.0.7

### DIFF
--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -212,7 +212,7 @@ namespace service_nodes {
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
   constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION{{2, 0, 7}};
-  constexpr std::array<int, 3> MIN_LOKINET_VERSION{{0, 7, 0}};
+  constexpr std::array<int, 3> MIN_LOKINET_VERSION{{0, 8, 0}};
 
   // The minimum accepted version number, broadcasted by Service Nodes via uptime proofs for each hardfork
   struct proof_version

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -211,7 +211,7 @@ namespace service_nodes {
   // blocks out of sync and sending something that it thinks is legit.
   constexpr uint64_t VOTE_OR_TX_VERIFY_HEIGHT_BUFFER    = 5;
 
-  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION{{2, 0, 0}};
+  constexpr std::array<int, 3> MIN_STORAGE_SERVER_VERSION{{2, 0, 7}};
   constexpr std::array<int, 3> MIN_LOKINET_VERSION{{0, 7, 0}};
 
   // The minimum accepted version number, broadcasted by Service Nodes via uptime proofs for each hardfork


### PR DESCRIPTION
@jagerman Ready to merge if Testnet is already running on 2.0.7, otherwise we might get some unwanted deregistrations 