### PR TITLE
Fix config file parsing to recognize hidden options

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -140,7 +140,10 @@ int main(int argc, char const * argv[])
     {
       try
       {
-        po::store(po::parse_config_file<char>(config_path.string<std::string>().c_str(), core_settings), vm);
+        po::store(po::parse_config_file<char>(
+                    config_path.string<std::string>().c_str(),
+                    po::options_description{}.add(core_settings).add(hidden_options)),
+                vm);
       }
       catch (const std::exception &e)
       {


### PR DESCRIPTION
The old deprecated zmq-rpc-bind-port and other hidden deprecated options
weren't being properly recognized when in a config file because only the
visible settings were passed in.  This fixes it to also pass in hidden
settings.