### PR TITLE
LNS: Don't overwrite err message on validation fail

### DIFF
--- a/src/cryptonote_core/loki_name_system.cpp
+++ b/src/cryptonote_core/loki_name_system.cpp
@@ -776,9 +776,6 @@ static bool check_condition(bool condition, std::string* reason, T&&... args) {
 
 bool validate_lns_name(mapping_type type, std::string name, std::string *reason)
 {
-  std::stringstream err_stream;
-  LOKI_DEFER { if (reason) *reason = err_stream.str(); };
-
   bool const is_lokinet = is_lokinet_type(type);
   size_t max_name_len   = 0;
 
@@ -790,7 +787,12 @@ bool validate_lns_name(mapping_type type, std::string name, std::string *reason)
   else if (type == mapping_type::wallet)  max_name_len = lns::WALLET_NAME_MAX;
   else
   {
-    if (reason) err_stream << "LNS type=" << type << ", specifies unhandled mapping type in name validation";
+    if (reason)
+    {
+      std::stringstream err_stream;
+      err_stream << "LNS type=" << mapping_type_str(type) << ", specifies unhandled mapping type in name validation";
+      *reason = err_stream.str();
+    }
     return false;
   }
 

--- a/src/cryptonote_core/loki_name_system.h
+++ b/src/cryptonote_core/loki_name_system.h
@@ -105,17 +105,17 @@ struct mapping_value
 };
 inline std::ostream &operator<<(std::ostream &os, mapping_value const &v) { return os << lokimq::to_hex(v.to_view()); }
 
-inline char const *mapping_type_str(mapping_type type)
+inline std::string_view mapping_type_str(mapping_type type)
 {
   switch(type)
   {
-    case mapping_type::lokinet:         return "lokinet"; // general type stored in the database; 1 year when in a purchase tx
-    case mapping_type::lokinet_2years:  return "lokinet_2years";  // Only used in a buy tx, not in the DB
-    case mapping_type::lokinet_5years:  return "lokinet_5years";  // "
-    case mapping_type::lokinet_10years: return "lokinet_10years"; // "
-    case mapping_type::session:         return "session";
-    case mapping_type::wallet:          return "wallet";
-    default: assert(false);             return "xx_unhandled_type";
+    case mapping_type::lokinet:         return "lokinet"sv; // general type stored in the database; 1 year when in a purchase tx
+    case mapping_type::lokinet_2years:  return "lokinet_2years"sv;  // Only used in a buy tx, not in the DB
+    case mapping_type::lokinet_5years:  return "lokinet_5years"sv;  // "
+    case mapping_type::lokinet_10years: return "lokinet_10years"sv; // "
+    case mapping_type::session:         return "session"sv;
+    case mapping_type::wallet:          return "wallet"sv;
+    default: assert(false);             return "xx_unhandled_type"sv;
   }
 }
 inline std::ostream &operator<<(std::ostream &os, mapping_type type) { return os << mapping_type_str(type); }


### PR DESCRIPTION
- Scope guard overwrote the contents of `reason` which was already being set in the helper function `check_condition` in the subsequent validation checks so the wallet would report an empty error.
- String_view-ify mapping_type_str
- Use std::optional directly on type in wallet