### PR TITLE
Fix LNS cache storage via RPC wallet

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8836,28 +8836,19 @@ std::vector<wallet2::pending_tx> wallet2::lns_create_buy_mapping_tx(lns::mapping
   return result;
 }
 
-std::vector<wallet2::pending_tx> wallet2::lns_create_buy_mapping_tx(std::string const &type,
-                                                                    std::string const *owner,
-                                                                    std::string const *backup_owner,
-                                                                    std::string const &name,
-                                                                    std::string const &value,
-                                                                    std::string *reason,
-                                                                    uint32_t priority,
-                                                                    uint32_t account_index,
-                                                                    std::set<uint32_t> subaddr_indices)
+std::optional<lns::mapping_type> wallet2::lns_validate_type(std::string_view type, lns::lns_tx_type lns_action, std::string *reason)
 {
   std::optional<uint8_t> hf_version = get_hard_fork_version();
   if (!hf_version)
   {
     if (reason) *reason = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
-    return {};
+    return std::nullopt;
   }
   lns::mapping_type mapping_type;
-  if (!lns::validate_mapping_type(type, *hf_version, lns::lns_tx_type::buy, &mapping_type, reason))
-    return {};
+  if (!lns::validate_mapping_type(type, *hf_version, lns_action, &mapping_type, reason))
+    return std::nullopt;
 
-  std::vector<wallet2::pending_tx> result = lns_create_buy_mapping_tx(mapping_type, owner, backup_owner, name, value, reason, priority, account_index, subaddr_indices);
-  return result;
+  return mapping_type;
 }
 
 std::vector<wallet2::pending_tx> wallet2::lns_create_renewal_tx(
@@ -8900,29 +8891,6 @@ std::vector<wallet2::pending_tx> wallet2::lns_create_renewal_tx(
                                       subaddr_indices,
                                       tx_params);
   return result;
-}
-
-std::vector<wallet2::pending_tx> wallet2::lns_create_renewal_tx(
-    std::string const &type,
-    std::string const &name,
-    std::string *reason,
-    uint32_t priority,
-    uint32_t account_index,
-    std::set<uint32_t> subaddr_indices,
-    std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response
-    )
-{
-  lns::mapping_type mapping_type = lns::mapping_type::session;
-  std::optional<uint8_t> hf_version = get_hard_fork_version();
-  if (!hf_version)
-  {
-    if (reason) *reason = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
-    return {};
-  }
-  if (!lns::validate_mapping_type(type, *hf_version, lns::lns_tx_type::renew, &mapping_type, reason))
-    return {};
-
-  return lns_create_renewal_tx(mapping_type, name, reason, priority, account_index, subaddr_indices, response);
 }
 
 
@@ -8982,32 +8950,6 @@ std::vector<wallet2::pending_tx> wallet2::lns_create_update_mapping_tx(lns::mapp
                                       account_index,
                                       subaddr_indices,
                                       tx_params);
-  return result;
-}
-
-std::vector<wallet2::pending_tx> wallet2::lns_create_update_mapping_tx(std::string const &type,
-                                                                       std::string const &name,
-                                                                       std::string const *value,
-                                                                       std::string const *owner,
-                                                                       std::string const *backup_owner,
-                                                                       std::string const *signature,
-                                                                       std::string *reason,
-                                                                       uint32_t priority,
-                                                                       uint32_t account_index,
-                                                                       std::set<uint32_t> subaddr_indices,
-                                                                       std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response)
-{
-  lns::mapping_type mapping_type = lns::mapping_type::session;
-  std::optional<uint8_t> hf_version = get_hard_fork_version();
-  if (!hf_version)
-  {
-    if (reason) *reason = ERR_MSG_NETWORK_VERSION_QUERY_FAILED;
-    return {};
-  }
-  if (!lns::validate_mapping_type(type, *hf_version, lns::lns_tx_type::update, &mapping_type, reason))
-    return {};
-
-  std::vector<wallet2::pending_tx> result = lns_create_update_mapping_tx(mapping_type, name, value, owner, backup_owner, signature, reason, priority, account_index, subaddr_indices, response);
   return result;
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1357,17 +1357,20 @@ private:
       pending_tx  ptx;
     };
     request_stake_unlock_result can_request_stake_unlock(const crypto::public_key &sn_key);
+
+    // Attempts to convert the LNS type string to a mapping type (checking the current hard fork).
+    // If type isn't valid then returns std::nullopt and sets the failure reason in `reason` (if not
+    // nullptr).
+    std::optional<lns::mapping_type> lns_validate_type(std::string_view type, lns::lns_tx_type lns_action, std::string *reason);
+
     std::vector<pending_tx> lns_create_buy_mapping_tx(lns::mapping_type type, std::string const *owner, std::string const *backup_owner, std::string name, std::string const &value, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
-    std::vector<pending_tx> lns_create_buy_mapping_tx(std::string const &type, std::string const *owner, std::string const *backup_owner, std::string const &name, std::string const &value, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {});
 
     // signature: (Optional) If set, use the signature given, otherwise by default derive the signature from the wallet spend key as an ed25519 key.
     //            The signature is derived from the hash of the previous txid blob and previous value blob of the mapping. By default this is signed using the wallet's spend key as an ed25519 keypair.
     std::vector<pending_tx> lns_create_update_mapping_tx(lns::mapping_type type, std::string name, std::string const *value, std::string const *owner, std::string const *backup_owner, std::string const *signature, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {}, std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response = {});
-    std::vector<pending_tx> lns_create_update_mapping_tx(std::string const &type, std::string const &name, std::string const *value, std::string const *owner, std::string const *backup_owner, std::string const *signature, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {}, std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response = {});
 
     // LNS renewal (for lokinet registrations, not for session/wallet)
     std::vector<pending_tx> lns_create_renewal_tx(lns::mapping_type type, std::string name, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {}, std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response = {});
-    std::vector<pending_tx> lns_create_renewal_tx(std::string const &type, std::string const &name, std::string *reason, uint32_t priority = 0, uint32_t account_index = 0, std::set<uint32_t> subaddr_indices = {}, std::vector<cryptonote::rpc::LNS_NAMES_TO_OWNERS::response_entry> *response = {});
 
     // Generate just the signature required for putting into lns_update_mapping command in the wallet
     bool lns_make_update_mapping_signature(lns::mapping_type type, std::string name, std::string const *value, std::string const *owner, std::string const *backup_owner, lns::generic_signature &signature, uint32_t account_index = 0, std::string *reason = nullptr);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -39,7 +39,7 @@
 #include <chrono>
 #include <exception>
 
-#include "wallet/wallet_rpc_server_error_codes.h"
+#include "wallet_rpc_server_error_codes.h"
 #include "wallet_rpc_server.h"
 #include "wallet/wallet_args.h"
 #include "common/command_line.h"
@@ -3057,7 +3057,11 @@ namespace {
     LNS_BUY_MAPPING::response res{};
 
     std::string reason;
-    std::vector<wallet2::pending_tx> ptx_vector = m_wallet->lns_create_buy_mapping_tx(req.type,
+    auto type = m_wallet->lns_validate_type(req.type, lns::lns_tx_type::buy, &reason);
+    if (!type)
+      throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Invalid LNS buy type: " + reason};
+
+    std::vector<wallet2::pending_tx> ptx_vector = m_wallet->lns_create_buy_mapping_tx(*type,
                                                                                       req.owner.size() ? &req.owner : nullptr,
                                                                                       req.backup_owner.size() ? &req.backup_owner : nullptr,
                                                                                       req.name,
@@ -3072,7 +3076,7 @@ namespace {
     //Save the LNS record to the wallet cache
     std::string name_hash_str = lns::name_to_base64_hash(req.name);
     tools::wallet2::lns_detail detail = {
-      lns::mapping_type::session,
+      *type,
       req.name,
       name_hash_str,
       req.value,
@@ -3104,11 +3108,15 @@ namespace {
     LNS_RENEW_MAPPING::response res{};
 
     std::string reason;
+    auto type = m_wallet->lns_validate_type(req.type, lns::lns_tx_type::renew, &reason);
+    if (!type)
+      throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Invalid LNS renewal type: " + reason};
+
     std::vector<wallet2::pending_tx> ptx_vector = m_wallet->lns_create_renewal_tx(
-        req.type, req.name, &reason, req.priority, req.account_index, req.subaddr_indices);
+        *type, req.name, &reason, req.priority, req.account_index, req.subaddr_indices);
 
     if (ptx_vector.empty())
-      throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Failed to create LNS transaction: " + reason};
+      throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Failed to create LNS renewal transaction: " + reason};
 
     fill_response(         ptx_vector,
                            req.get_tx_key,
@@ -3134,8 +3142,12 @@ namespace {
     LNS_UPDATE_MAPPING::response res{};
 
     std::string reason;
+    auto type = m_wallet->lns_validate_type(req.type, lns::lns_tx_type::update, &reason);
+    if (!type)
+      throw wallet_rpc_error{error_code::TX_NOT_POSSIBLE, "Invalid LNS update type: " + reason};
+
     std::vector<wallet2::pending_tx> ptx_vector =
-        m_wallet->lns_create_update_mapping_tx(req.type,
+        m_wallet->lns_create_update_mapping_tx(*type,
                                                req.name,
                                                req.value.empty()        ? nullptr : &req.value,
                                                req.owner.empty()        ? nullptr : &req.owner,
@@ -3153,7 +3165,7 @@ namespace {
     std::string name_hash_str = lns::name_to_base64_hash(req.name);
     m_wallet->delete_lns_cache_record(name_hash_str);
     tools::wallet2::lns_detail detail = {
-      lns::mapping_type::session,
+      *type,
       req.name,
       name_hash_str,
       req.value,


### PR DESCRIPTION
- Add a wallet function to convert the type string into a type value
- Remove the lns buy/update/renew overloads that take a string; callers
  now use the above instead to convert (and check) the type.
- Fix rpc wallet cache entries to set the proper type in the lns cache
  instead of always inserting session type.