### PR TITLE
Pulse: Use the latest round when querying quorums via rpc

### DIFF
--- a/src/cryptonote_core/pulse.cpp
+++ b/src/cryptonote_core/pulse.cpp
@@ -722,6 +722,15 @@ void pulse::handle_message(void *quorumnet_state, pulse::message const &msg)
     cryptonote::quorumnet_pulse_relay_message_to_quorum(quorumnet_state, msg, context.prepare_for_round.quorum, context.prepare_for_round.participant == sn_type::producer);
 }
 
+// TODO(doyle): Update pulse::perpare_for_round with this function after the hard fork and sanity check it on testnet.
+bool pulse::convert_time_to_round(pulse::time_point const &time, pulse::time_point const &r0_timestamp, uint8_t *round)
+{
+  auto const time_since_round_started = time <= r0_timestamp ? std::chrono::seconds(0) : (time - r0_timestamp);
+  size_t result_usize                 = time_since_round_started / service_nodes::PULSE_ROUND_TIME;
+  if (round) *round = static_cast<uint8_t>(result_usize);
+  return result_usize <= 255;
+}
+
 bool pulse::get_round_timings(cryptonote::Blockchain const &blockchain, uint64_t block_height, uint64_t prev_timestamp, pulse::timings &times)
 {
   times = {};

--- a/src/cryptonote_core/pulse.h
+++ b/src/cryptonote_core/pulse.h
@@ -99,6 +99,11 @@ struct timings
   pulse::time_point miner_fallback_timestamp;
 };
 
+// Calculate the current Pulse round active depending on the 'time' elapsed since round 0 started for a block.
+// r0_timestamp: The timestamp that round 0 starts at for the desired block (this timestamp can be calculated via 'pulse::get_round_timings').
+// round: (Optional) Set to the round that is currently active when the function returns true.
+// return: False when enough 'time' has elapsed such that Pulse round has overflowed 255 and Pulse blocks are no longer possible to generate.
+bool convert_time_to_round(pulse::time_point const &time, pulse::time_point const &r0_timestamp, uint8_t *round);
 bool get_round_timings(cryptonote::Blockchain const &blockchain, uint64_t height, uint64_t prev_timestamp, pulse::timings &times);
 
 } // namespace pulse


### PR DESCRIPTION
convert_time_to_round is copied code from pulse::prepare_for_round but since we're super close to the fork I'm not going to kick the bees nest and change consensus code. Change after hardfork and deploying on testnet.
