### PR TITLE
wallet2: export/import_key_images with blink fix

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -13419,6 +13419,15 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
           error::wallet_internal_error, "Key image out of validity domain: input " + std::to_string(n + offset) + "/"
           + std::to_string(signed_key_images.size()) + ", key image " + key_image_str);
 
+      // TODO(loki): This can fail in a worse-case scenario. We re-sort blinks
+      // when they arrive out of order (i.e. blink is confirmed in mempool and
+      // gets inserted into m_transfers in a different order from the order they
+      // are committed to the blockchain).
+
+      // If a watch only wallet sees a blink and the main wallet doesn't, then
+      // for that block, export_key_images will fail temporarily until the
+      // block is commited and the wallets sorts its transfers into a finalized
+      // canonical ordering.
       THROW_WALLET_EXCEPTION_IF(!crypto::check_ring_signature((const crypto::hash&)key_image, key_image, pkeys, &signature),
           error::signature_check_failed, std::to_string(n + offset) + "/"
           + std::to_string(signed_key_images.size()) + ", key image " + key_image_str


### PR DESCRIPTION
Due to prior behaviour of immediately accepting blinks, they get
commited to the wallet's transfers container early. A second view wallet,
that restores the first wallet seed will _not_ see the blinks if it is
generated after the fact as this information is not stored in the
blockchain.

The second view wallet will restore transactions from the blockchain in
the order they were committed to the blockchain (oblivious to any blink
transactions as this is not stored by the blockchain, only those who
see it in the mempool at the time it is relayed would optimistically
save it to their transfers container).

This leads to importing key images breaking as the two wallets expect
_slightly_ different key images at different indexes in their respective
transfer container.

The fix here is to sort all transfers again once we confirm the blink,
placing the transfer into the correct slot in the container. This sort
only occurs within the latest block (as blinks are only relevant at
the tip of the chain) so resorting occurs typically with 1 blocks worth
of transactions for the wallet and so will always be quick and not
expensive.

You can reproduce this bug by checking out the tag v8.1.1

1. Wallet A sends to Wallet B transfer_1 without blink `transfer unimportant WalletB <amount>`
2. Wallet A sends to Wallet B transfer_2 _before_ transfer_1 gets mined into a block `transfer blink WalletB <amount>`
3. Wallet B must receive the Blink and be refreshed _before_ the next block gets mined to commit it to Wallet B's cache.
4. Wait for the next block to get mined and refresh to accept the block

- Wallet B now has instantly confirmed transfer_2 the Blink into the transfer
  container at index 0.

- Wallet B confirms the slow transfer transfer_1 and saves it into transfer
  container at index 1.

Since the network received transfer_1 first in the mempool, it will get
included in the block first with the Blink second. Now Wallet B's
transfers are out of sync with what is the canonical ordering on the
network.

5. export_key_images and import it into a view only wallet based on Wallet B.
6. import_key_images will fail due to the blockchain/wallet cache mismatch.

This fixes https://github.com/loki-project/loki-core/issues/1120 
