### PR TITLE
Macos 10.14 compatibility

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -155,8 +155,8 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
                         'ninja strip_binaries', 'ninja create_zip', '../utils/build_scripts/drone-static-upload.sh']),
 
     // Macos builds:
+    mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DARCH=core2 -DARCH_ID=amd64',
+                build_tests=false, extra_cmds=static_check_and_upload),
     mac_builder('macOS (Release)', run_tests=true),
     mac_builder('macOS (Debug)', build_type='Debug', cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
-    mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DARCH=core2',
-                build_tests=false, extra_cmds=static_check_and_upload),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -150,7 +150,7 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
                     build_tests=false, lto=true, extra_cmds=static_check_and_upload),
     // Static mingw build (on focal) which gets uploaded to builds.lokinet.dev:
     debian_pipeline("Static (win64)", "ubuntu:focal", deps='g++ g++-mingw-w64-x86-64 '+static_build_deps,
-                    cmake_extra='-DCMAKE_TOOLCHAIN_FILE=../cmake/64-bit-toolchain.cmake -DBUILD_STATIC_DEPS=ON',
+                    cmake_extra='-DCMAKE_TOOLCHAIN_FILE=../cmake/64-bit-toolchain.cmake -DBUILD_STATIC_DEPS=ON -DARCH=x86-64',
                     build_tests=false, lto=false, test_lokid=false, extra_cmds=[
                         'ninja strip_binaries', 'ninja create_zip', '../utils/build_scripts/drone-static-upload.sh']),
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -157,6 +157,6 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
     // Macos builds:
     mac_builder('macOS (Release)', run_tests=true),
     mac_builder('macOS (Debug)', build_type='Debug', cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
-    mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14',
+    mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DARCH=core2',
                 build_tests=false, extra_cmds=static_check_and_upload),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -156,7 +156,7 @@ local static_build_deps='autoconf automake make qttools5-dev file libtool gperf 
 
     // Macos builds:
     mac_builder('macOS (Static)', cmake_extra='-DBUILD_STATIC_DEPS=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DARCH=core2 -DARCH_ID=amd64',
-                build_tests=false, extra_cmds=static_check_and_upload),
+                build_tests=false, extra_cmds=static_check_and_upload, lto=true),
     mac_builder('macOS (Release)', run_tests=true),
     mac_builder('macOS (Debug)', build_type='Debug', cmake_extra='-DBUILD_DEBUG_UTILS=ON'),
 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ endif()
 cmake_minimum_required(VERSION 3.10)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
+# Has to be set before `project()`, and ignored on non-macos:
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "macOS deployment target (Apple clang only)")
+
 project(loki
     VERSION 8.1.1
     LANGUAGES CXX C)

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -305,6 +305,11 @@ if(APPLE AND BOOST_VERSION VERSION_LESS 1.74.0)
   set(boost_patch_commands PATCH_COMMAND patch -p1 -d tools/build -i ${PROJECT_SOURCE_DIR}/utils/build_scripts/boostorg-build-pr560-macos-build-fix.patch)
 endif()
 
+set(boost_buildflags "cxxflags=-fPIC")
+if(APPLE)
+  set(boost_buildflags "cxxflags=\"-fPIC -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}\"" "cflags=-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 build_external(boost
   #  PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/user-config.bjam tools/build/src/user-config.jam
   ${boost_patch_commands}
@@ -315,7 +320,7 @@ build_external(boost
   BUILD_COMMAND true
   INSTALL_COMMAND
     ./b2 -d0 variant=release link=static runtime-link=static optimization=speed ${boost_extra}
-      threading=multi threadapi=${boost_threadapi} cxxflags=-fPIC cxxstd=14 visibility=global
+      threading=multi threadapi=${boost_threadapi} ${boost_buildflags} cxxstd=14 visibility=global
       --disable-icu --user-config=${CMAKE_CURRENT_BINARY_DIR}/user-config.bjam
       install
   BUILD_BYPRODUCTS

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -165,6 +165,13 @@ if(CMAKE_CROSSCOMPILING)
   endif()
 endif()
 
+set(deps_CFLAGS "-O2 ${flto}")
+set(deps_CXXFLAGS "-O2 ${flto}")
+
+if(APPLE)
+  set(deps_CFLAGS "${deps_CFLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  set(deps_CXXFLAGS "${deps_CXXFLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
 
 # Builds a target; takes the target name (e.g. "readline") and builds it in an external project with
 # target name suffixed with `_external`.  Its upper-case value is used to get the download details
@@ -173,7 +180,7 @@ endif()
 set(build_def_DEPENDS "")
 set(build_def_PATCH_COMMAND "")
 set(build_def_CONFIGURE_COMMAND ./configure ${cross_host} --disable-shared --prefix=${DEPS_DESTDIR} --with-pic
-    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-O2 ${flto}" "CXXFLAGS=-O2 ${flto}" ${cross_rc})
+    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}" ${cross_rc})
 set(build_def_BUILD_COMMAND make)
 set(build_def_INSTALL_COMMAND make install)
 set(build_def_BUILD_BYPRODUCTS ${DEPS_DESTDIR}/lib/lib___TARGET___.a ${DEPS_DESTDIR}/include/___TARGET___.h)
@@ -208,7 +215,7 @@ endfunction()
 
 
 build_external(zlib
-  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "CC=${deps_cc}" "CFLAGS=-O2 ${flto}" ./configure --prefix=${DEPS_DESTDIR} --static
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS}" ./configure --prefix=${DEPS_DESTDIR} --static
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libz.a
     ${DEPS_DESTDIR}/include/zlib.h
@@ -229,7 +236,7 @@ build_external(openssl
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CC=${deps_cc} ${openssl_system_env} ./config
     --prefix=${DEPS_DESTDIR} no-shared no-capieng no-dso no-dtls1 no-ec_nistp_64_gcc_128 no-gost
     no-heartbeats no-md2 no-rc5 no-rdrand no-rfc3779 no-sctp no-ssl-trace no-ssl2 no-ssl3
-    no-static-engine no-tests no-weak-ssl-ciphers no-zlib-dynamic "CFLAGS=-O2 ${flto}"
+    no-static-engine no-tests no-weak-ssl-ciphers no-zlib-dynamic "CFLAGS=${deps_CFLAGS}"
   INSTALL_COMMAND make install_sw
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libssl.a ${DEPS_DESTDIR}/lib/libcrypto.a
@@ -245,7 +252,7 @@ set(OPENSSL_VERSION 1.1.1)
 build_external(expat
   CONFIGURE_COMMAND ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --enable-static
   --disable-shared --with-pic --without-examples --without-tests --without-docbook --without-xmlwf
-  "CC=${deps_cc}" "CFLAGS=-O2 ${flto}"
+  "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS}"
 )
 add_static_target(expat expat_external libexpat.a)
 
@@ -256,7 +263,7 @@ build_external(unbound
   --enable-static --with-libunbound-only --with-pic
   --$<IF:$<BOOL:${USE_LTO}>,enable,disable>-flto --with-ssl=${DEPS_DESTDIR}
   --with-libexpat=${DEPS_DESTDIR}
-  "CC=${deps_cc}" "CFLAGS=-O2 ${flto}"
+  "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS}"
 )
 add_static_target(libunbound unbound_external libunbound.a)
 if(WIN32)
@@ -350,7 +357,7 @@ if (NOT WIN32)
       --disable-rpath --disable-colorfgbg --disable-ext-mouse --disable-symlinks --enable-warnings
       --enable-assertions --with-default-terminfo-dir=/etc/_terminfo_
       --with-terminfo-dirs=/etc/_terminfo_ --disable-pc-files --enable-database --enable-sp-funcs
-      --disable-term-driver --enable-interop --enable-widec "CC=${CMAKE_C_COMPILER}" "CFLAGS=-O2 -fPIC ${flto}"
+      --disable-term-driver --enable-interop --enable-widec "CC=${CMAKE_C_COMPILER}" "CFLAGS=${deps_CFLAGS} -fPIC"
     INSTALL_COMMAND make install.libs
     BUILD_BYPRODUCTS
       ${DEPS_DESTDIR}/lib/libncursesw.a
@@ -367,7 +374,7 @@ if (NOT WIN32)
   build_external(readline
     DEPENDS ncurses_external
     CONFIGURE_COMMAND ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --disable-shared --with-curses
-      "CC=${deps_cc}" "CFLAGS=-fPIC ${flto}"
+      "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS} -fPIC"
     BUILD_BYPRODUCTS
       ${DEPS_DESTDIR}/lib/libreadline.a
       ${DEPS_DESTDIR}/include/readline
@@ -388,7 +395,7 @@ if(APPLE OR WIN32)
 else()
   build_external(eudev
     CONFIGURE_COMMAND autoreconf -ivf && ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --disable-shared --disable-introspection
-      --disable-programs --disable-manpages --disable-hwdb --with-pic "CC=${deps_cc}" "CFLAGS=-O2 ${flto}"
+      --disable-programs --disable-manpages --disable-hwdb --with-pic "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS}"
     BUILD_BYPRODUCTS
       ${DEPS_DESTDIR}/lib/libudev.a
       ${DEPS_DESTDIR}/include/libudev.h
@@ -401,7 +408,7 @@ endif()
 
 build_external(libusb
   CONFIGURE_COMMAND autoreconf -ivf && ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --disable-shared --disable-udev --with-pic
-    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-O2 ${flto}" "CXXFLAGS=-O2 ${flto}"
+    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}"
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libusb-1.0.a
     ${DEPS_DESTDIR}/include/libusb-1.0
@@ -422,7 +429,7 @@ endif()
 build_external(hidapi
   DEPENDS ${maybe_eudev} libusb_external
   CONFIGURE_COMMAND autoreconf -ivf && ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --disable-shared --enable-static --with-pic
-    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-O2 ${flto}" "CXXFLAGS=-O2 ${flto}"
+    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}"
     "libudev_CFLAGS=-I${DEPS_DESTDIR}/include" "libudev_LIBS=-L${DEPS_DESTDIR}/lib -ludev"
     "libusb_CFLAGS=-I${DEPS_DESTDIR}/include/libusb-1.0" "libusb_LIBS=-L${DEPS_DESTDIR}/lib -lusb-1.0"
   BUILD_BYPRODUCTS
@@ -445,7 +452,7 @@ set_target_properties(hidapi_libusb PROPERTIES
 build_external(protobuf
   CONFIGURE_COMMAND
     ./configure ${cross_host} --disable-shared --prefix=${DEPS_DESTDIR} --with-pic
-      "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-O2 ${flto}" "CXXFLAGS=-O2 ${flto}"
+      "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}"
       "CPP=${deps_cc} -E" "CXXCPP=${deps_cxx} -E"
       "CC_FOR_BUILD=${deps_cc}" "CXX_FOR_BUILD=${deps_cxx}"  # Thanks Google for making people hunt for undocumented magic variables
   BUILD_BYPRODUCTS
@@ -472,7 +479,7 @@ build_external(zmq
   CONFIGURE_COMMAND ./configure ${cross_host} --prefix=${DEPS_DESTDIR} --enable-static --disable-shared
     --disable-curve-keygen --enable-curve --disable-drafts --disable-libunwind --with-libsodium
     --without-pgm --without-norm --without-vmci --without-docs --with-pic --disable-Werror
-    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-O2 -fstack-protector ${flto}" "CXXFLAGS=-O2 -fstack-protector ${flto}"
+    "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=-fstack-protector ${deps_CFLAGS}" "CXXFLAGS=-fstack-protector ${deps_CXXFLAGS}"
     "sodium_CFLAGS=-I${DEPS_DESTDIR}/include" "sodium_LIBS=-L${DEPS_DESTDIR}/lib -lsodium"
 )
 add_static_target(libzmq zmq_external libzmq.a)
@@ -510,7 +517,7 @@ build_external(curl
   --disable-progress-meter --without-brotli --with-zlib=${DEPS_DESTDIR} ${curl_ssl_opts}
   --without-libmetalink --without-librtmp --disable-versioned-symbols --enable-hidden-symbols
   --without-zsh-functions-dir --without-fish-functions-dir
-  "CC=${deps_cc}" "CFLAGS=-O2 ${flto}" ${curl_LIBS}
+  "CC=${deps_cc}" "CFLAGS=${deps_CFLAGS}" ${curl_LIBS}
   BUILD_BYPRODUCTS
     ${DEPS_DESTDIR}/lib/libcurl.a
     ${DEPS_DESTDIR}/include/curl/curl.h

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -307,7 +307,7 @@ endif()
 
 set(boost_buildflags "cxxflags=-fPIC")
 if(APPLE)
-  set(boost_buildflags "cxxflags=\"-fPIC -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}\"" "cflags=-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  set(boost_buildflags "cxxflags=-fPIC -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}" "cflags=-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 
 build_external(boost

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -63,6 +63,21 @@ target_link_libraries(cncrypto
   PRIVATE
     extra)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES Clang OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  # If we're compiling for x86/amd64 then we need to force on -maes -msse2 for the hard intel code:
+  # it has a run-time check to not actually call it if not supported by the running CPU.
+  # Unfortunately CMake sucks for actually reliably giving us the target architecture, so we'll just
+  # try to compile with these flags if the compiler accepts them.
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-msse2 COMPILER_SUPPORTS_SSE2)
+  if(COMPILER_SUPPORTS_SSE2)
+    check_cxx_compiler_flag(-maes COMPILER_SUPPORTS_AES)
+    if(COMPILER_SUPPORTS_AES)
+      set_source_files_properties(cn_heavy_hash_hard_intel.cpp PROPERTIES COMPILE_FLAGS "-maes -msse2")
+    endif()
+  endif()
+endif()
+
 # Because of the way Qt works on android with JNI, the code does not live in the main android thread
 # So this code runs with a 1 MB default stack size. 
 # This will force the use of the heap for the allocation of the scratchpad

--- a/src/crypto/cn_heavy_hash_hard_intel.cpp
+++ b/src/crypto/cn_heavy_hash_hard_intel.cpp
@@ -32,10 +32,6 @@
 #if defined(__x86_64__) || defined(__i386__) || defined(_M_X86) || defined(_M_X64)
 
 #ifdef __GNUC__
-#  ifndef __clang__
-     // Force on aes support; we do a cpuid check at runtime before it actually gets invoked.
-#    pragma GCC target ("aes,sse2")
-#  endif
 #  include <x86intrin.h>
 #endif
 


### PR DESCRIPTION
Set up the macos deployment target for 10.14 compatibility.

I have some hacks in mind for 10.12 wallet-compatible binaries, but they will probably involve building a patched version to avoid std::variant and other things that macos <10.14 hates.

(Also pulls in the windows generic build commit from `stable`).