### PR TITLE
Fix wallet2 "failed to get random outs" error

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -183,7 +183,6 @@ namespace cryptonote { namespace rpc {
       return regs;
     }
 
-    constexpr size_t MAX_RESTRICTED_GLOBAL_FAKE_OUTS_COUNT = 5000;
     constexpr uint64_t OUTPUT_HISTOGRAM_RECENT_CUTOFF_RESTRICTION = 3 * 86400; // 3 days max, the wallet requests 1.8 days
     constexpr uint64_t round_up(uint64_t value, uint64_t quantum) { return (value + quantum - 1) / quantum * quantum; }
 
@@ -625,7 +624,7 @@ namespace cryptonote { namespace rpc {
     if (use_bootstrap_daemon_if_necessary<GET_OUTPUTS_BIN>(req, res))
       return res;
 
-    if (!context.admin && req.outputs.size() > MAX_RESTRICTED_GLOBAL_FAKE_OUTS_COUNT)
+    if (!context.admin && req.outputs.size() > GET_OUTPUTS_BIN::MAX_COUNT)
       res.status = "Too many outs requested";
     else if (m_core.get_outs(req, res))
       res.status = STATUS_OK;
@@ -643,7 +642,7 @@ namespace cryptonote { namespace rpc {
     if (use_bootstrap_daemon_if_necessary<GET_OUTPUTS>(req, res))
       return res;
 
-    if (!context.admin && req.outputs.size() > MAX_RESTRICTED_GLOBAL_FAKE_OUTS_COUNT) {
+    if (!context.admin && req.outputs.size() > GET_OUTPUTS::MAX_COUNT) {
       res.status = "Too many outs requested";
       return res;
     }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -448,6 +448,9 @@ namespace rpc {
   {
     static constexpr auto names() { return NAMES("get_outs.bin"); }
 
+    /// Maximum outputs that may be requested in a single request (unless admin)
+    static constexpr size_t MAX_COUNT = 5000;
+
     struct request
     {
       std::vector<get_outputs_out> outputs; // Array of structure `get_outputs_out`.
@@ -481,6 +484,9 @@ namespace rpc {
   struct GET_OUTPUTS : PUBLIC, LEGACY
   {
     static constexpr auto names() { return NAMES("get_outs"); }
+
+    /// Maximum outputs that may be requested in a single request (unless admin)
+    static constexpr size_t MAX_COUNT = 5000;
 
     struct request
     {


### PR DESCRIPTION
wallet2 fails to build a tx using a public node if it needs to request
more than 5000 because public nodes return an error if more than 5000
txes are requested.

This fixes the wallet to make multiple requests of 5000 each when needed
so that it won't hit the remote's error condition.  (This is a bit
better than just upping the limit because other RPC requests get a
chance to run).