### PR TITLE
Macos refresh fix

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -104,10 +104,12 @@ add_library(uSockets STATIC EXCLUDE_FROM_ALL ${usockets_src})
 target_compile_definitions(uSockets PRIVATE LIBUS_NO_SSL=1)
 target_include_directories(uSockets PRIVATE uWebSockets/uSockets/src)
 
-# On Windows uSockets uses libuv for its event loop:
-if (WIN32)
+# On Windows uSockets uses libuv for its event loop; on Mac kqueue is the default, but that seems to
+# not be reliable on older macos versions (like 10.12), so we use libuv on macos as well.
+if (WIN32 OR APPLE)
   add_subdirectory(libuv EXCLUDE_FROM_ALL)
   target_link_libraries(uSockets uv_a)
+  target_compile_definitions(uSockets PUBLIC LIBUS_USE_LIBUV)
 endif()
 
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -386,7 +386,7 @@ namespace tools
     // while we inject a wallet refresh into the uWS loop).
     while (!m_stop.load(std::memory_order_relaxed))
     {
-      bool refresh_now = !refreshing && (
+      bool refresh_now = !refreshing && m_wallet && (
           (m_auto_refresh_period > 0s && std::chrono::steady_clock::now() > m_last_auto_refresh_time + m_auto_refresh_period)
           || m_long_poll_new_changes);
 


### PR DESCRIPTION
Fixes refresh on older (10.12, and possibly 10.13?) macos versions.

Also tweaks when we start a refresh so that it will occur sooner after opening a new wallet.