### PR TITLE
Overhaul http RPC command-line options and allow public+private listening

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -46,7 +46,8 @@ local debian_pipeline(name, image,
                 apt_get_quiet + ' update',
                 apt_get_quiet + ' install -y eatmydata',
                 'eatmydata ' + apt_get_quiet + ' dist-upgrade -y',
-                'eatmydata ' + apt_get_quiet + ' install -y --no-install-recommends cmake git ca-certificates ninja-build ccache ' + deps,
+                'eatmydata ' + apt_get_quiet + ' install -y --no-install-recommends cmake git ca-certificates ninja-build ccache '
+                    + deps + (if test_lokid then ' gdb' else ''),
                 'mkdir build',
                 'cd build',
                 'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE='+build_type+' ' +
@@ -62,7 +63,7 @@ local debian_pipeline(name, image,
                     ['ninja -j' + jobs + ' -v']
             ) + (
                 if test_lokid then [
-                    '(sleep 3; echo "status\ndiff\nexit") | TERM=xterm ./bin/lokid --offline --data-dir=startuptest'
+                    '(sleep 3; echo "status\ndiff\nexit") | TERM=xterm ../utils/build_scripts/drone-gdb.sh ./bin/lokid --offline --data-dir=startuptest'
                 ] else []
             ) + (
                 if run_tests then [

--- a/src/common/command_line.h
+++ b/src/common/command_line.h
@@ -69,7 +69,7 @@ namespace command_line
   template<typename T>
   struct arg_descriptor<T, false>
   {
-    typedef T value_type;
+    using value_type = T;
 
     const char* name;
     const char* description;
@@ -78,20 +78,11 @@ namespace command_line
   };
 
   template<typename T>
-  struct arg_descriptor<std::vector<T>, false>
-  {
-    typedef std::vector<T> value_type;
-
-    const char* name;
-    const char* description;
-  };
-
-  template<typename T>
   struct arg_descriptor<T, true>
   {
     static_assert(!std::is_same_v<T, bool>, "Boolean switch can't be required");
 
-    typedef T value_type;
+    using value_type = T;
 
     const char* name;
     const char* description;
@@ -100,7 +91,7 @@ namespace command_line
   template<typename T>
   struct arg_descriptor<T, false, true>
   {
-    typedef T value_type;
+    using value_type = T;
 
     const char* name;
     const char* description;
@@ -116,7 +107,7 @@ namespace command_line
   template<typename T, int NUM_DEPS>
   struct arg_descriptor<T, false, true, NUM_DEPS>
   {
-    typedef T value_type;
+    using value_type = T;
 
     const char* name;
     const char* description;
@@ -144,14 +135,37 @@ namespace command_line
     return semantic;
   }
 
+  namespace {
+    template <typename T>
+    struct arg_stringify {
+      const T& v;
+      arg_stringify(const T& val) : v{val} {}
+    };
+    template <typename T>
+    std::ostream& operator<<(std::ostream& o, const arg_stringify<T>& a) {
+      return o << a.v;
+    }
+    template <typename T>
+    std::ostream& operator<<(std::ostream& o, const arg_stringify<std::vector<T>>& a) {
+      o << '{';
+      bool first = true;
+      for (auto& x : a.v) {
+        if (first) first = false;
+        else o << ",";
+        o << x;
+      }
+      return o << '}';
+    }
+  }
+
   template<typename T>
   boost::program_options::typed_value<T, char>* make_semantic(const arg_descriptor<T, false, true>& arg)
   {
     auto semantic = boost::program_options::value<T>();
     if (!arg.not_use_default) {
       std::ostringstream format;
-      format << arg.depf(false, true, arg.default_value) << ", "
-             << arg.depf(true, true, arg.default_value) << " if '"
+      format << arg_stringify{arg.depf(false, true, arg.default_value)} << ", "
+             << arg_stringify{arg.depf(true, true, arg.default_value)} << " if '"
              << arg.ref.name << "'";
       semantic->default_value(arg.depf(arg.ref.default_value, true, arg.default_value), format.str());
     }
@@ -166,12 +180,12 @@ namespace command_line
       std::array<bool, NUM_DEPS> depval;
       depval.fill(false);
       std::ostringstream format;
-      format << arg.depf(depval, true, arg.default_value);
+      format << arg_stringify{arg.depf(depval, true, arg.default_value)};
       for (size_t i = 0; i < depval.size(); ++i)
       {
         depval.fill(false);
         depval[i] = true;
-        format << ", " << arg.depf(depval, true, arg.default_value) << " if '" << arg.ref[i]->name << "'";
+        format << ", " << arg_stringify{arg.depf(depval, true, arg.default_value)} << " if '" << arg.ref[i]->name << "'";
       }
       for (size_t i = 0; i < depval.size(); ++i)
         depval[i] = arg.ref[i]->default_value;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -29,11 +29,14 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include <boost/asio/ip/address.hpp>
 #include <memory>
 #include <stdexcept>
 #include <lokimq/lokimq.h>
 #include <utility>
 
+#include "cryptonote_config.h"
+#include "cryptonote_core/cryptonote_core.h"
 #include "epee/misc_log_ex.h"
 #if defined(PER_BLOCK_CHECKPOINT)
 #include "blocks/blocks.h"
@@ -69,45 +72,40 @@ using namespace std::literals;
 
 namespace daemonize {
 
-static uint16_t parse_public_rpc_port(const boost::program_options::variables_map& vm)
+// Parse an IP:PORT string into a {IP,PORT} pair.  Throws if the string value is not valid.  Accepts
+// both IPv4 and IPv6 addresses, but the latter must be specified in square brackets, e.g. [::1]:2345,
+// and will be returned *without* square brackets.
+static std::pair<std::string, uint16_t> parse_ip_port(std::string_view ip_port, const std::string& argname)
 {
-  const auto& public_node_arg = cryptonote::rpc::http_server::arg_public_node;
-  const bool public_node = command_line::get_arg(vm, public_node_arg);
-  if (!public_node)
-    return 0;
+  std::pair<std::string, uint16_t> result;
+  auto& [ip, port] = result;
 
-  uint16_t rpc_port = 0;
-  const auto &arg_rpc_restricted_bind_port = cryptonote::rpc::http_server::arg_rpc_restricted_bind_port;
-  const auto &arg_rpc_bind_port            = cryptonote::rpc::http_server::arg_rpc_bind_port;
-  const auto &arg_restricted_rpc           = cryptonote::rpc::http_server::arg_restricted_rpc;
-
-  bool specified_restricted_port = !command_line::is_arg_defaulted(vm, arg_rpc_restricted_bind_port);
-  if (specified_restricted_port)
-    rpc_port = command_line::get_arg(vm, arg_rpc_restricted_bind_port);
-  else if (command_line::get_arg(vm, arg_restricted_rpc))
-    rpc_port = command_line::get_arg(vm, arg_rpc_bind_port);
+  if (auto colon = ip_port.rfind(":"); colon != std::string::npos && tools::parse_int(ip_port.substr(colon+1), port))
+    ip_port.remove_suffix(ip_port.size() - colon);
   else
-    throw std::runtime_error("Restricted RPC is required for --"s + public_node_arg.name + ", specify a restricted port via --" + arg_rpc_restricted_bind_port.name + " or restrict server via --" + arg_restricted_rpc.name);
+    throw std::runtime_error{"Invalid IP/port value specified to " + argname + ": " + std::string(ip_port)};
 
-  if (rpc_port == 0)
-    throw std::runtime_error("Please specify a non-zero port for restricted rpc via --"s + (specified_restricted_port ? arg_rpc_restricted_bind_port.name : arg_rpc_bind_port.name));
+  if (!ip_port.empty() && ip_port.front() == '[' && ip_port.back() == ']') {
+    ip_port.remove_prefix(1);
+    ip_port.remove_suffix(1);
+  }
 
-  const auto rpc_bind_address = command_line::get_arg(vm, cryptonote::rpc_args::descriptors().rpc_bind_ip);
-  const auto address = net::get_network_address(rpc_bind_address, rpc_port);
-  if (!address)
-    throw std::runtime_error("Failed to parse RPC bind address "s + rpc_bind_address + ":" + std::to_string(rpc_port));
-  if (address->get_zone() != epee::net_utils::zone::public_)
-    throw std::runtime_error(std::string(zone_to_string(address->get_zone()))
-      + " network zone is not supported, please check RPC server bind address");
+  std::string ip_str{ip_port};
+  boost::system::error_code ec;
+  auto addr =
+#if BOOST_VERSION >= 106600
+    boost::asio::ip::make_address
+#else
+    boost::asio::ip::address::from_string
+#endif
+    (ip_str, ec);
+  if (ec)
+    throw std::runtime_error{"Invalid IP address specified: " + ip_str};
 
-  if (address->is_loopback() || address->is_local())
-    MLOG_RED(el::Level::Warning, "--" << public_node_arg.name 
-      << " is enabled, but RPC server " << address->str() 
-      << " may be unreachable from outside, please check RPC server bind address");
+  ip = addr.to_string();
 
-  return rpc_port;
+  return result;
 }
-
 
 daemon::daemon(boost::program_options::variables_map vm_) :
     vm{std::move(vm_)},
@@ -130,19 +128,98 @@ daemon::daemon(boost::program_options::variables_map vm_) :
   protocol->set_p2p_endpoint(p2p.get());
   core->set_cryptonote_protocol(protocol.get());
 
+  auto rpc_config = cryptonote::rpc_args::process(vm);
+  bool new_rpc_options = !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_admin)
+    || !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_public);
+  // TODO: Remove these options, perhaps starting in loki 9.0
+  bool deprecated_rpc_options = !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_bind_port)
+    || !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_restricted_bind_port)
+    || !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_restricted_rpc)
+    || !is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_public_node)
+    || rpc_config.bind_ip.has_value()
+    || rpc_config.bind_ipv6_address.has_value()
+    || rpc_config.use_ipv6;
+
+  constexpr std::string_view deprecated_option_names = "--rpc-bind-ip/--rpc-bind-port/--rpc-restricted-bind-port/--restricted-rpc/--public-node/--rpc-use-ipv6"sv;
+
+  if (new_rpc_options && deprecated_rpc_options)
+    throw std::runtime_error{"Failed to initialize rpc settings: --rpc-public/--rpc-admin cannot be combined with deprecated " + std::string{deprecated_option_names} + " options"};
+
+  // bind ip, listen addr, required
+  std::vector<std::tuple<std::string, uint16_t, bool>> rpc_listen_admin, rpc_listen_public;
+  if (deprecated_rpc_options)
   {
-    const auto restricted = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_restricted_rpc);
-    const auto main_rpc_port = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_bind_port);
-    MGINFO("- core HTTP RPC server");
-    http_rpcs.emplace_back(std::piecewise_construct, std::tie("core"), std::tie(*rpc, vm, restricted, main_rpc_port));
+    MGINFO_RED(deprecated_option_names << " options are deprecated and will be removed from a future lokid version; use --rpc-public/--rpc-admin instead");
+
+    // These old options from Monero are really janky: --restricted-rpc turns the main port
+    // restricted, but then we also have --rpc-restricted-bind-port but both are stuck with
+    // --rpc-bind-ip, and then half of the options get parsed here but the IP option used to get
+    // parsed in the http_server code.
+    auto restricted = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_restricted_rpc);
+    auto main_rpc_port = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_bind_port);
+    auto restricted_rpc_port = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_restricted_bind_port);
+
+    if (main_rpc_port == 0) {
+      if (restricted && restricted_rpc_port != 0)
+        std::swap(main_rpc_port, restricted_rpc_port);
+      else if (command_line::get_arg(vm, cryptonote::arg_testnet_on))
+        main_rpc_port = config::testnet::RPC_DEFAULT_PORT;
+      else if (command_line::get_arg(vm, cryptonote::arg_devnet_on))
+        main_rpc_port = config::devnet::RPC_DEFAULT_PORT;
+      else
+        main_rpc_port = config::testnet::RPC_DEFAULT_PORT;
+    }
+    if (main_rpc_port && main_rpc_port == restricted_rpc_port)
+      restricted = true;
+
+    std::vector<uint16_t> public_ports;
+    if (restricted)
+      public_ports.push_back(main_rpc_port);
+    if (restricted_rpc_port && restricted_rpc_port != main_rpc_port)
+      public_ports.push_back(restricted_rpc_port);
+
+    for (uint16_t port : public_ports) {
+      rpc_listen_public.emplace_back(rpc_config.bind_ip.value_or("127.0.0.1"), main_rpc_port, rpc_config.require_ipv4);
+      if (rpc_config.bind_ipv6_address || rpc_config.use_ipv6)
+        rpc_listen_public.emplace_back(rpc_config.bind_ipv6_address.value_or("::1"), main_rpc_port, true);
+    }
+
+    if (!restricted && main_rpc_port) {
+      rpc_listen_admin.emplace_back(rpc_config.bind_ip.value_or("127.0.0.1"), main_rpc_port, rpc_config.require_ipv4);
+      if (rpc_config.bind_ipv6_address || rpc_config.use_ipv6)
+        rpc_listen_public.emplace_back(rpc_config.bind_ipv6_address.value_or("::1"), main_rpc_port, true);
+    }
+  }
+  else
+  { // no deprecated options
+
+    for (auto& bind : command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_admin)) {
+      if (bind == "none") continue;
+      auto [ip, port] = parse_ip_port(bind, "--rpc-admin");
+      bool ipv4 = ip.find(':') == std::string::npos;
+      // If using the default admin setting then don't require the bind to IPv6 localhost, or the
+      // IPv4 localhost bind if --rpc-ignore-ipv4 is given.
+      bool required = !command_line::is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_admin)
+        || (ipv4 && rpc_config.require_ipv4);
+      rpc_listen_admin.emplace_back(std::move(ip), port, required);
+    }
+    for (auto& bind : command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_public)) {
+      // Much simpler, since this is default empty: everything specified is required.
+      auto [ip, port] = parse_ip_port(bind, "--rpc-public");
+      rpc_listen_public.emplace_back(std::move(ip), port, true);
+    }
   }
 
-  if (!command_line::is_arg_defaulted(vm, cryptonote::rpc::http_server::arg_rpc_restricted_bind_port))
+  if (!rpc_listen_admin.empty())
   {
-    bool restricted = true;
-    auto restricted_rpc_port = command_line::get_arg(vm, cryptonote::rpc::http_server::arg_rpc_restricted_bind_port);
-    MGINFO("- restricted HTTP RPC server");
-    http_rpcs.emplace_back(std::piecewise_construct, std::tie("restricted"), std::tie(*rpc, vm, restricted, restricted_rpc_port));
+    MGINFO("- admin HTTP RPC server");
+    http_rpc_admin.emplace(*rpc, rpc_config, false /*not restricted*/, std::move(rpc_listen_admin));
+  }
+
+  if (!rpc_listen_public.empty())
+  {
+    MGINFO("- public HTTP RPC server");
+    http_rpc_public.emplace(*rpc, rpc_config, true /*restricted*/, std::move(rpc_listen_public));
   }
 
   MGINFO_BLUE("Done daemon object initialization");
@@ -152,9 +229,13 @@ daemon::~daemon()
 {
   MGINFO_BLUE("Deinitializing daemon objects...");
 
-  while (!http_rpcs.empty()) {
-    MGINFO("- " << http_rpcs.back().first << " HTTP RPC server");
-    http_rpcs.pop_back();
+  if (http_rpc_public) {
+    MGINFO("- public HTTP RPC server");
+    http_rpc_public.reset();
+  }
+  if (http_rpc_admin) {
+    MGINFO("- admin HTTP RPC server");
+    http_rpc_admin.reset();
   }
 
   MGINFO("- p2p");
@@ -192,7 +273,7 @@ void daemon::init_options(boost::program_options::options_description& option_sp
   cryptonote::core::init_options(option_spec);
   node_server::init_options(option_spec);
   cryptonote::rpc::core_rpc_server::init_options(option_spec, hidden);
-  cryptonote::rpc::http_server::init_options(option_spec);
+  cryptonote::rpc::http_server::init_options(option_spec, hidden);
   cryptonote::rpc::init_lmq_options(option_spec);
   quorumnet::init_core_callbacks();
 }
@@ -233,20 +314,17 @@ bool daemon::run(bool interactive)
     lmq_rpc = std::make_unique<cryptonote::rpc::lmq_rpc>(*core, *rpc, vm);
     core->start_lokimq();
 
-    for(auto& [desc, rpc]: http_rpcs)
-    {
-      MGINFO("Starting " << desc << " HTTP RPC server");
-      rpc.start();
+    if (http_rpc_admin) {
+      MGINFO("Starting admin HTTP RPC server");
+      http_rpc_admin->start();
+    }
+    if (http_rpc_public) {
+      MGINFO("Starting public HTTP RPC server");
+      http_rpc_public->start();
     }
 
     MGINFO("Starting RPC daemon handler");
     cryptonote::rpc::DaemonHandler rpc_daemon_handler(*core, *p2p);
-
-    if (uint16_t public_rpc_port = parse_public_rpc_port(vm))
-    {
-      MGINFO("Public RPC port " << public_rpc_port << " will be advertised to other peers over P2P");
-      p2p->set_rpc_port(public_rpc_port);
-    }
 
     std::unique_ptr<daemonize::command_server> rpc_commands;
     if (interactive)
@@ -271,10 +349,13 @@ bool daemon::run(bool interactive)
       rpc_commands->stop_handling();
     }
 
-    for (auto& [desc, rpc] : http_rpcs)
-    {
-      MGINFO("Stopping " << desc << " HTTP RPC server...");
-      rpc.shutdown();
+    if (http_rpc_public) {
+      MGINFO("Stopping public HTTP RPC server...");
+      http_rpc_public->shutdown();
+    }
+    if (http_rpc_admin) {
+      MGINFO("Stopping admin HTTP RPC server...");
+      http_rpc_admin->shutdown();
     }
 
     MGINFO("Node stopped.");

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -72,7 +72,7 @@ private:
   std::unique_ptr<protocol_handler> protocol;
   std::unique_ptr<node_server> p2p;
   std::unique_ptr<cryptonote::rpc::core_rpc_server> rpc;
-  std::list<std::pair<std::string, cryptonote::rpc::http_server>> http_rpcs;
+  std::optional<cryptonote::rpc::http_server> http_rpc_admin, http_rpc_public;
   std::unique_ptr<cryptonote::rpc::lmq_rpc> lmq_rpc;
 };
 

--- a/src/rpc/http_server.cpp
+++ b/src/rpc/http_server.cpp
@@ -5,7 +5,10 @@
 #include <lokimq/base64.h>
 #include <boost/endian/conversion.hpp>
 #include <lokimq/variant.h>
+#include "common/command_line.h"
 #include "common/string_util.h"
+#include "cryptonote_config.h"
+#include "cryptonote_core/cryptonote_core.h"
 #include "epee/net/jsonrpc_structs.h"
 #include "rpc/core_rpc_server_commands_defs.h"
 #include "rpc/rpc_args.h"
@@ -16,47 +19,64 @@
 
 namespace cryptonote::rpc {
 
-  const command_line::arg_descriptor<uint16_t, false, true, 2> http_server::arg_rpc_bind_port = {
-      "rpc-bind-port"
-    , "Port for RPC server"
-    , config::RPC_DEFAULT_PORT
-    , {{ &cryptonote::arg_testnet_on, &cryptonote::arg_devnet_on }}
-    , [](std::array<bool, 2> testnet_devnet, bool defaulted, uint16_t val) {
-        auto [testnet, devnet] = testnet_devnet;
-        return
-          (defaulted && testnet) ? config::testnet::RPC_DEFAULT_PORT :
-          (defaulted && devnet) ? config::devnet::RPC_DEFAULT_PORT :
-          val;
+  const command_line::arg_descriptor<std::vector<std::string>> http_server::arg_rpc_public{
+    "rpc-public",
+    "Specifies an IP:PORT to listen on for public (restricted) RPC requests; can be specified multiple times."
+  };
+
+  const command_line::arg_descriptor<std::vector<std::string>, false, true, 2> http_server::arg_rpc_admin{
+    "rpc-admin",
+    "Specifies an IP:PORT to listen on for admin (unrestricted) RPC requests; can be specified multiple times. Specify \"none\" to disable.",
+    {"127.0.0.1:" + std::to_string(config::RPC_DEFAULT_PORT), "[::1]:" + std::to_string(config::RPC_DEFAULT_PORT)},
+    {{ &cryptonote::arg_testnet_on, &cryptonote::arg_devnet_on }},
+    [](std::array<bool, 2> testnet_devnet, bool defaulted, std::vector<std::string> val) {
+      auto& [testnet, devnet] = testnet_devnet;
+      if (defaulted && (testnet || devnet)) {
+        auto port = std::to_string(testnet ? config::testnet::RPC_DEFAULT_PORT : config::devnet::RPC_DEFAULT_PORT);
+        val = {"127.0.0.1:" + port, "[::1]:" + port};
       }
-    };
+      return val;
+    }
+  };
+
+  const command_line::arg_descriptor<uint16_t> http_server::arg_rpc_bind_port = {
+      "rpc-bind-port",
+      "Port for RPC server; deprecated, use --rpc-public or --rpc-admin instead.",
+      0
+  };
 
   const command_line::arg_descriptor<uint16_t> http_server::arg_rpc_restricted_bind_port = {
       "rpc-restricted-bind-port"
-    , "Port for restricted RPC server"
+    , "Port for restricted RPC server; deprecated, use --rpc-public instead"
     , 0
     };
 
   const command_line::arg_descriptor<bool> http_server::arg_restricted_rpc = {
       "restricted-rpc"
-    , "Restrict RPC to view only commands and do not return privacy sensitive data in RPC calls"
+    , "Deprecated, use --rpc-public instead"
     , false
     };
 
+  // This option doesn't do anything anymore, but keep it here for now in case people added it to
+  // config files/startup flags.
   const command_line::arg_descriptor<bool> http_server::arg_public_node = {
       "public-node"
-    , "Allow other users to use the node as a remote (restricted RPC mode, view-only commands) and advertise it over P2P"
+    , "Deprecated; use --rpc-public option instead"
     , false
     };
 
   namespace { void long_poll_trigger(cryptonote::tx_memory_pool&); }
 
   //-----------------------------------------------------------------------------------
-  void http_server::init_options(boost::program_options::options_description& desc)
+  void http_server::init_options(boost::program_options::options_description& desc, boost::program_options::options_description& hidden)
   {
-    command_line::add_arg(desc, arg_rpc_bind_port);
-    command_line::add_arg(desc, arg_rpc_restricted_bind_port);
-    command_line::add_arg(desc, arg_restricted_rpc);
-    command_line::add_arg(desc, arg_public_node);
+    command_line::add_arg(desc, arg_rpc_public);
+    command_line::add_arg(desc, arg_rpc_admin);
+
+    command_line::add_arg(hidden, arg_rpc_bind_port);
+    command_line::add_arg(hidden, arg_rpc_restricted_bind_port);
+    command_line::add_arg(hidden, arg_restricted_rpc);
+    command_line::add_arg(hidden, arg_public_node);
 
     cryptonote::long_poll_trigger = long_poll_trigger;
   }
@@ -64,10 +84,10 @@ namespace cryptonote::rpc {
   //------------------------------------------------------------------------------------------------------------------------------
   http_server::http_server(
       core_rpc_server& server,
-      const boost::program_options::variables_map& vm,
-      const bool restricted,
-      uint16_t port
-      ) : m_server{server}, m_restricted{restricted}
+      rpc_args rpc_config,
+      bool restricted,
+      std::vector<std::tuple<std::string, uint16_t, bool>> bind)
+    : m_server{server}, m_restricted{restricted}
   {
     // uWS is designed to work from a single thread, which is good (we pull off the requests and
     // then stick them into the LMQ job queue to be scheduled along with other jobs).  But as a
@@ -93,7 +113,7 @@ namespace cryptonote::rpc {
     //   start()).
     //m_startup_promise
 
-    m_rpc_thread = std::thread{[this, rpc_config=cryptonote::rpc_args::process(vm), port] (
+    m_rpc_thread = std::thread{[this, rpc_config=std::move(rpc_config), bind=std::move(bind)] (
         std::promise<uWS::Loop*> loop_promise,
         std::future<bool> startup_future,
         std::promise<std::vector<us_listen_socket_t*>> startup_success) {
@@ -102,17 +122,12 @@ namespace cryptonote::rpc {
         create_rpc_endpoints(http);
       } catch (...) {
         loop_promise.set_exception(std::current_exception());
+        return;
       }
       loop_promise.set_value(uWS::Loop::get());
       if (!startup_future.get())
         // False means cancel, i.e. we got destroyed/shutdown without start() being called
         return;
-
-      std::vector<std::pair<std::string /*addr*/, bool /*required*/>> bind_addr;
-      if (!rpc_config.bind_ip.empty())
-        bind_addr.emplace_back(rpc_config.bind_ip, rpc_config.require_ipv4);
-      if (rpc_config.use_ipv6 && !rpc_config.bind_ipv6_address.empty())
-        bind_addr.emplace_back(rpc_config.bind_ipv6_address, true);
 
       m_login = rpc_config.login;
 
@@ -120,9 +135,9 @@ namespace cryptonote::rpc {
 
       std::vector<us_listen_socket_t*> listening;
       try {
-        bool bad = false;
-        int good = 0;
-        for (const auto& [addr, required] : bind_addr)
+        bool bad = false; // True if any required bind fails
+        int good = 0; // How many binds succeeded; we require at least 1
+        for (const auto& [addr, port, required] : bind)
           http.listen(addr, port, [&listening, req=required, &good, &bad](us_listen_socket_t* sock) {
             listening.push_back(sock);
             if (sock != nullptr) good++;
@@ -135,7 +150,7 @@ namespace cryptonote::rpc {
           if (listening.empty()) error << "no valid bind address(es) given";
           else {
             error << "tried to bind to:";
-            for (const auto& [addr, required] : bind_addr)
+            for (const auto& [addr, port, required] : bind)
               error << ' ' << addr << ':' << port;
           }
           throw std::runtime_error(error.str());

--- a/src/rpc/http_server.h
+++ b/src/rpc/http_server.h
@@ -35,6 +35,7 @@
 #include "common/password.h"
 #include "core_rpc_server.h"
 #include "http_server_base.h"
+#include "rpc/rpc_args.h"
 
 namespace cryptonote::rpc {
 
@@ -44,18 +45,22 @@ namespace cryptonote::rpc {
   class http_server : public http_server_base
   {
   public:
-    static const command_line::arg_descriptor<uint16_t, false, true, 2> arg_rpc_bind_port;
+    static const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_public;
+    static const command_line::arg_descriptor<std::vector<std::string>, false, true, 2> arg_rpc_admin;
+
+    // Deprecated:
+    static const command_line::arg_descriptor<uint16_t> arg_rpc_bind_port;
     static const command_line::arg_descriptor<uint16_t> arg_rpc_restricted_bind_port;
     static const command_line::arg_descriptor<bool> arg_restricted_rpc;
     static const command_line::arg_descriptor<bool> arg_public_node;
 
-    static void init_options(boost::program_options::options_description& desc);
+    static void init_options(boost::program_options::options_description& desc, boost::program_options::options_description& hidden);
 
     http_server(
         core_rpc_server& server,
-        const boost::program_options::variables_map& vm,
-        const bool restricted,
-        uint16_t port
+        rpc_args rpc_config,
+        bool restricted,
+        std::vector<std::tuple<std::string, uint16_t, bool>> bind // {IP,port,required}
         );
 
     ~http_server();

--- a/src/rpc/rpc_args.h
+++ b/src/rpc/rpc_args.h
@@ -57,7 +57,6 @@ namespace cryptonote
       const command_line::arg_descriptor<std::string> rpc_login;
       const command_line::arg_descriptor<bool> confirm_external_bind;
       const command_line::arg_descriptor<std::string> rpc_access_control_origins;
-      const command_line::arg_descriptor<bool> rpc_public_node;
       const command_line::arg_descriptor<std::string> zmq_rpc_bind_ip;   // Deprecated & ignored
       const command_line::arg_descriptor<std::string> zmq_rpc_bind_port; // Deprecated & ignored
     };
@@ -68,8 +67,9 @@ namespace cryptonote
     //! \return Arguments specified by user.  Throws on error.
     static rpc_args process(const boost::program_options::variables_map& vm);
 
-    std::string bind_ip;
-    std::string bind_ipv6_address;
+    // std::nullopt if not explicitly specified
+    std::optional<std::string> bind_ip;
+    std::optional<std::string> bind_ipv6_address;
     bool use_ipv6;
     bool require_ipv4;
     std::vector<std::string> access_control_origins;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -488,10 +488,10 @@ namespace tools
       return false;
     }
 
-    if (!rpc_config.bind_ip.empty())
-      m_bind.emplace_back(rpc_config.bind_ip, port, rpc_config.require_ipv4);
-    if (rpc_config.use_ipv6 && !rpc_config.bind_ipv6_address.empty())
-      m_bind.emplace_back(rpc_config.bind_ipv6_address, port, true);
+    if (rpc_config.bind_ip && !rpc_config.bind_ip->empty())
+      m_bind.emplace_back(*rpc_config.bind_ip, port, rpc_config.require_ipv4);
+    if (rpc_config.use_ipv6 && rpc_config.bind_ipv6_address && !rpc_config.bind_ipv6_address->empty())
+      m_bind.emplace_back(*rpc_config.bind_ipv6_address, port, true);
 
     const bool disable_auth = command_line::get_arg(m_vm, arg_disable_rpc_login);
 

--- a/utils/build_scripts/drone-gdb.sh
+++ b/utils/build_scripts/drone-gdb.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+rm -f crash.out.txt exit.out.txt
+gdb -q -x $(readlink -e $(dirname $0))/gdb-filter.py --args $@
+test -e crash.out.txt && cat crash.out.txt
+exit $(cat exit.out.txt)

--- a/utils/build_scripts/gdb-filter.py
+++ b/utils/build_scripts/gdb-filter.py
@@ -1,0 +1,36 @@
+def exit_handler (event):
+    """
+    write exit code of the program running in gdb to a file called exit.out.txt
+    """
+    code = 1
+    if hasattr(event, "exit_code"):
+        code = event.exit_code
+    with open("exit.out.txt", 'w') as f:
+        f.write("{}".format(code))
+
+def gdb_execmany(*cmds):
+    """
+    run multiple gdb commands
+    """
+    for cmd in cmds:
+        gdb.execute(cmd)
+
+def crash_handler (event):
+    """
+    handle a crash from the program running in gdb
+    """
+    if isinstance(event, gdb.SignalEvent):
+        log_file_name = "crash.out.txt"
+        # poop out log file for stack trace of all threads
+        gdb_execmany("set logging file {}".format(log_file_name), "set logging on", "set logging redirect on", "thread apply all bt full")
+        # quit gdb
+        gdb.execute("q")
+
+# set up event handlers to catch shit
+gdb.events.stop.connect(crash_handler)
+gdb.events.exited.connect(exit_handler)
+
+# run settings setup
+gdb_execmany("set confirm off", "set pagination off", "set print thread-events off")
+# run program and exit
+gdb_execmany("r", "q")


### PR DESCRIPTION
The HTTP RPC listening options inherited from Monero are a mess.  This PR overhauls them to support just two options:

- `--rpc-admin` - takes an IP:PORT value to listen on (and can be specified multiple times to listen on multiple IPs/ports)
- `--rpc-public` - same as above, but the listening RPC will be restricted.

which allows you to listen on whatever IP/port you want in a much simpler way.  You can list as many different IP:port values as you want to each of them and you'll get RPC listeners of the appropriate type on everything you ask for.  Previously it was impossible to listen with a restricted RPC server on a public IP and admin RPC server on localhost because of the mess of options and incompatibilities between them.

In short, these two options replace all of Monero's related options:

- `--rpc-bind-ip`
- `--rpc-bind-ipv6`
- `--restricted-rpc`
- `--rpc-use-ipv6`
- `--rpc-ignore-ipv4`
- `--rpc-bind-port`
- `--rpc-restricted-bind-port`
- `--confirm-external-bind`
- `--public-node` (* - see below)
- `--rpc-restricted-bind-ip` (proposed in an upstream Monero PR)

while being more flexible in every way.

For now the existing Monero options are still supported, but will produce log warnings on startup when used.  They will be removed in a future major version upgrade (probably loki 9.x).

`*` This PR makes the `--public-node` option a no-op (that is: the argument is still handled for backwards compatibility, but has no effect): we aren't currently using the p2p-public-rpc advertising mechanism in Loki.