### PR TITLE
Add tx fee estimate to wallet api

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1654,28 +1654,13 @@ void WalletImpl::disposeTransaction(PendingTransaction *t)
     delete t;
 }
 
-#if 0
-uint64_t WalletImpl::estimateTransactionFee(const std::vector<std::tuple<std::string, uint64_t>> &destinations, uint32_t priority) const
+uint64_t WalletImpl::estimateTransactionFee(uint32_t priority, uint32_t recipients) const
 {
-#if 0
-    const size_t pubkey_size = 33;
-    const size_t encrypted_paymentid_size = 11;
-    const size_t extra_size = pubkey_size + encrypted_paymentid_size;
-
-    return m_wallet->estimate_fee(
-        1 /*inputs*/,
-        CRYPTONOTE_DEFAULT_TX_MIXIN /*mixin*/,
-        destinations.size() + 1 /*outputs*/,
-        extra_size,
-        m_wallet->use_fork_rules(HF_VERSION_CLSAG, 0),
-        m_wallet->get_base_fees(),
-        m_wallet->get_fee_percent(priority),
-        m_wallet->get_fee_quantization_mask());
-#else
-    return 0; // TODO: IMPLEMENT
-#endif
+    constexpr uint32_t typical_size = 2000;
+    const auto base_fee = m_wallet->get_base_fees();
+    uint64_t pct = m_wallet->get_fee_percent(priority == 1 ? 1 : 5, txtype::standard);
+    return (base_fee.first * typical_size + base_fee.second * (recipients + 1)) * pct / 100;
 }
-#endif
 
 TransactionHistory *WalletImpl::history()
 {

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -156,8 +156,7 @@ public:
     bool importKeyImages(std::string_view filename) override;
 
     void disposeTransaction(PendingTransaction * t) override;
-    // TODO(loki): Implement
-    // uint64_t estimateTransactionFee(const std::vector<std::pair<std::string, uint64_t>> &destinations, PendingTransaction::Priority priority) const override;
+    uint64_t estimateTransactionFee(uint32_t priority, uint32_t recipients = 1) const override;
     TransactionHistory * history() override;
     AddressBook * addressBook() override;
     Subaddress * subaddress() override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -851,14 +851,11 @@ struct Wallet
 
     /*!
      * \brief Estimates transaction fee.
-     * \param destinations Vector consisting of <address, amount> pairs.
-     * \return Estimated fee.
+     * \param priority - the tx priority. 1 = low priority, 5 = blink.
+     * \param recipients - number of recipients *not* counting the return address for change. Defaults to 1.
+     * \return Estimated fee in atomic units.
      */
-    // TODO(loki): Implement
-#if 0
-    virtual uint64_t estimateTransactionFee(const std::vector<std::pair<std::string, uint64_t>> &destinations,
-                                            uint32_t priority) const = 0;
-#endif
+    virtual uint64_t estimateTransactionFee(uint32_t priority, uint32_t recipients = 1) const = 0;
 
    /*!
     * \brief exportKeyImages - exports key images to file


### PR DESCRIPTION
The estimate is crude, based on a 2kB tx size.