### PR TITLE
Check before trying to create directory

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -619,8 +619,7 @@ namespace cryptonote
       folder /= "fake";
 
     // make sure the data directory exists, and try to lock it
-
-    if (std::error_code ec; !fs::create_directories(folder, ec) && ec)
+    if (std::error_code ec; !fs::is_directory(folder, ec) && !fs::create_directories(folder, ec) && ec)
     {
       MERROR("Failed to create directory " + folder.u8string() + (ec ? ": " + ec.message() : ""s));
       return false;


### PR DESCRIPTION
How this was written was fine if the data directory is an actual
directory, but it could fail if it was a symlink to a directory.

This commit adds an extra check for fs::is_directory() which works
through the symlink and thus avoids trying to create (and failing) in
such a case.