### PR TITLE
Fix rpc commands invoked via `lokid COMMAND`

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -72,10 +72,7 @@ using namespace std::literals;
 
 namespace daemonize {
 
-// Parse an IP:PORT string into a {IP,PORT} pair.  Throws if the string value is not valid.  Accepts
-// both IPv4 and IPv6 addresses, but the latter must be specified in square brackets, e.g. [::1]:2345,
-// and will be returned *without* square brackets.
-static std::pair<std::string, uint16_t> parse_ip_port(std::string_view ip_port, const std::string& argname)
+std::pair<std::string, uint16_t> parse_ip_port(std::string_view ip_port, const std::string& argname)
 {
   std::pair<std::string, uint16_t> result;
   auto& [ip, port] = result;
@@ -167,7 +164,7 @@ daemon::daemon(boost::program_options::variables_map vm_) :
       else if (command_line::get_arg(vm, cryptonote::arg_devnet_on))
         main_rpc_port = config::devnet::RPC_DEFAULT_PORT;
       else
-        main_rpc_port = config::testnet::RPC_DEFAULT_PORT;
+        main_rpc_port = config::RPC_DEFAULT_PORT;
     }
     if (main_rpc_port && main_rpc_port == restricted_rpc_port)
       restricted = true;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -48,6 +48,11 @@
 namespace daemonize
 {
 
+// Parse an IP:PORT string into a {IP,PORT} pair.  Throws if the string value is not valid.  Accepts
+// both IPv4 and IPv6 addresses, but the latter must be specified in square brackets, e.g. [::1]:2345,
+// and will be returned *without* square brackets.
+std::pair<std::string, uint16_t> parse_ip_port(std::string_view ip_port, const std::string& argname);
+
 class daemon {
 public:
   static void init_options(boost::program_options::options_description& option_spec, boost::program_options::options_description& hidden);


### PR DESCRIPTION
The wrong port was being used (because the new --rpc-admin value wasn't
being recognized), resulting in a connection failure.