### PR TITLE
Only compile cn_monero_hash on Android

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -135,6 +135,7 @@ local android_build_steps(android_abi, android_platform=21, jobs=6, cmake_extra=
         '-DCMAKE_BUILD_TYPE=Release ' +
         '-DCMAKE_TOOLCHAIN_FILE=/usr/lib/android-sdk/ndk-bundle/build/cmake/android.toolchain.cmake ' +
         '-DANDROID_PLATFORM=' + android_platform + ' -DANDROID_ABI=' + android_abi + ' ' +
+        '-DMONERO_SLOW_HASH=ON ' +
         '-DBUILD_STATIC_DEPS=ON -DSTATIC=ON -G Ninja ' + cmake_extra,
     'ninja -j' + jobs + ' -v wallet_merged',
     'cd ..',

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -51,8 +51,13 @@ add_library(cncrypto
   cn_heavy_hash_soft.cpp
   cn_turtle_hash.c
   rx-slow-hash.c
-  cn_monero_slow_hash.c
   tree-hash.c)
+
+option(MONERO_SLOW_HASH "Enable support for Monero CNv0/CNv1 hashing (currently only used in the Android wallet). Defaults to disabled because this causes many false alarms in virus/malware detection software." OFF)
+if(MONERO_SLOW_HASH)
+  target_sources(cncrypto PRIVATE cn_monero_slow_hash.c)
+  target_compile_definitions(cncrypto PUBLIC ENABLE_MONERO_SLOW_HASH)
+endif()
 
 target_link_libraries(cncrypto
   PUBLIC

--- a/src/crypto/hash-ops.h
+++ b/src/crypto/hash-ops.h
@@ -63,7 +63,9 @@ enum
 #define CN_TURTLE_PAGE_SIZE 262144
 void cn_fast_hash(const void *data, size_t length, char *hash);
 void cn_turtle_hash(const void *data, size_t length, char *hash, int light, int variant, int prehashed, uint32_t scratchpad, uint32_t iterations);
+#ifdef ENABLE_MONERO_SLOW_HASH
 void cn_monero_hash(const void *data, size_t length, char *hash, int variant, int prehashed);
+#endif
 
 void hash_extra_blake(const void *data, size_t length, char *hash);
 void hash_extra_groestl(const void *data, size_t length, char *hash);

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -72,10 +72,12 @@ namespace crypto {
 
   enum struct cn_slow_hash_type
   {
+#ifdef ENABLE_MONERO_SLOW_HASH
     // NOTE: Monero's slow hash for Android only, we still use the old hashing algorithm for hashing the KeyStore containing private keys
     cryptonight_v0,
     cryptonight_v0_prehashed,
     cryptonight_v1_prehashed,
+#endif
 
     heavy_v1,
     heavy_v2,
@@ -96,6 +98,7 @@ namespace crypto {
       }
       break;
 
+#ifdef ENABLE_MONERO_SLOW_HASH
       case cn_slow_hash_type::cryptonight_v0:
       case cn_slow_hash_type::cryptonight_v1_prehashed:
       {
@@ -113,6 +116,7 @@ namespace crypto {
         cn_monero_hash(data, length, hash.data, variant, prehashed);
       }
       break;
+#endif
 
       case cn_slow_hash_type::turtle_lite_v2:
       default:


### PR DESCRIPTION
This causes a ton of fake positive malware detections if it is build
into the binary, so just disable it on everything except Android.