### PR TITLE
List current stakes

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6271,12 +6271,7 @@ bool simple_wallet::query_locked_stakes(bool print_result)
   std::string msg_buf;
   {
     using namespace cryptonote;
-    auto [success, response] = m_wallet->get_all_service_nodes();
-    if (!success)
-    {
-      fail_msg_writer() << "Connection to daemon failed when requesting full service node list";
-      return has_locked_stakes;
-    }
+    auto response = m_wallet->list_current_stakes();
 
     cryptonote::account_public_address const primary_address = m_wallet->get_address();
     for (rpc::GET_SERVICE_NODES::response::entry const &node_info : response)
@@ -6284,16 +6279,6 @@ bool simple_wallet::query_locked_stakes(bool print_result)
       bool only_once = true;
       for (const auto& contributor : node_info.contributors)
       {
-        address_parse_info address_info = {};
-        if (!cryptonote::get_account_address_from_str(address_info, m_wallet->nettype(), contributor.address))
-        {
-          fail_msg_writer() << tr("Failed to parse string representation of address: ") << contributor.address;
-          continue;
-        }
-
-        if (primary_address != address_info.address)
-          continue;
-
         for (size_t i = 0; i < contributor.locked_contributions.size(); ++i)
         {
           const auto& contribution = contributor.locked_contributions[i];

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -994,6 +994,13 @@ uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
     return m_wallet->unlocked_balance(accountIndex, false);
 }
 
+std::vector<std::pair<std::string, uint32_t>>* WalletImpl::listCurrentStakes() const
+{
+    std::vector<std::pair<std::string, uint32_t>>* stakes = new std::vector<std::pair<std::string, uint32_t>>;
+    
+    return stakes;
+}
+
 uint64_t WalletImpl::blockChainHeight() const
 {
     if(m_wallet->light_wallet()) {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -997,6 +997,19 @@ uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
 std::vector<std::pair<std::string, uint32_t>>* WalletImpl::listCurrentStakes() const
 {
     std::vector<std::pair<std::string, uint32_t>>* stakes = new std::vector<std::pair<std::string, uint32_t>>;
+
+    auto response = m_wallet->list_current_stakes();
+
+    for (rpc::GET_SERVICE_NODES::response::entry const &node_info : response)
+    {
+      for (const auto& contributor : node_info.contributors)
+      {
+        for (size_t i = 0; i < contributor.locked_contributions.size(); ++i)
+        {
+          stakes->push_back(std::make_pair(node_info.service_node_pubkey, contributor.amount));
+        }
+      }
+    }
     
     return stakes;
 }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1002,15 +1002,11 @@ std::vector<std::pair<std::string, uint32_t>>* WalletImpl::listCurrentStakes() c
 
     for (rpc::GET_SERVICE_NODES::response::entry const &node_info : response)
     {
-      for (const auto& contributor : node_info.contributors)
-      {
-        for (size_t i = 0; i < contributor.locked_contributions.size(); ++i)
+        for (const auto& contributor : node_info.contributors)
         {
-          stakes->push_back(std::make_pair(node_info.service_node_pubkey, contributor.amount));
+            stakes->push_back(std::make_pair(node_info.service_node_pubkey, contributor.amount));
         }
-      }
     }
-    
     return stakes;
 }
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -98,6 +98,7 @@ public:
     bool trustedDaemon() const override;
     uint64_t balance(uint32_t accountIndex = 0) const override;
     uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
+    std::vector<std::pair<std::string, uint32_t>>* listCurrentStakes() const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -600,7 +600,7 @@ struct Wallet
 
    /**
     * @brief listCurrentStakes - returns a list of the wallets locked stakes, provides both service node address and the staked amount
-    * @return 
+    * @return
     */
     virtual std::vector<std::pair<std::string, uint32_t>>* listCurrentStakes() const = 0;
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -599,6 +599,12 @@ struct Wallet
     }
 
    /**
+    * @brief listCurrentStakes - returns a list of the wallets locked stakes, provides both service node address and the staked amount
+    * @return 
+    */
+    virtual std::vector<std::pair<std::string, uint32_t>>* listCurrentStakes() const = 0;
+
+   /**
     * @brief watchOnly - checks if wallet is watch only
     * @return - true if watch only
     */

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12942,7 +12942,7 @@ uint64_t wallet2::get_approximate_blockchain_height() const
 std::vector<rpc::GET_SERVICE_NODES::response::entry> wallet2::list_current_stakes()
 {
 
-  std::vector<rpc::GET_SERVICE_NODES::response::entry> service_node_states; 
+  std::vector<rpc::GET_SERVICE_NODES::response::entry> service_node_states;
 
   auto [success, all_nodes] = this->get_all_service_nodes();
   if (!success)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12951,8 +12951,6 @@ cryptonote::rpc::GET_SERVICE_NODES::response wallet2::list_current_stakes()
     return response;
   }
 
-  response = 
-
   cryptonote::account_public_address const primary_address = this->get_address();
   for (rpc::GET_SERVICE_NODES::response::entry const &node_info : all_nodes)
   {
@@ -12971,8 +12969,8 @@ cryptonote::rpc::GET_SERVICE_NODES::response wallet2::list_current_stakes()
     }
   }
 
-  all_nodes.service_node_states = service_node_states;
-  return all_nodes;
+  response.service_node_states = service_node_states;
+  return response;
 }
 
 void wallet2::set_lns_cache_record(wallet2::lns_detail detail)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12939,24 +12939,27 @@ uint64_t wallet2::get_approximate_blockchain_height() const
   return approx_blockchain_height;
 }
 
-static cryptonote::rpc::GET_SERVICE_NODES::response list_current_stakes()
+cryptonote::rpc::GET_SERVICE_NODES::response wallet2::list_current_stakes()
 {
+
+  cryptonote::rpc::GET_SERVICE_NODES::response response;
   std::vector<rpc::GET_SERVICE_NODES::response::entry> service_node_states; 
 
-  auto [success, all_nodes] = wallet2::get_all_service_nodes();
+  auto [success, all_nodes] = this->get_all_service_nodes();
   if (!success)
   {
-    all_nodes.service_node_states = service_node_states;
-    return all_nodes;
+    return response;
   }
 
-  cryptonote::account_public_address const primary_address = wallet2::get_address();
+  response = 
+
+  cryptonote::account_public_address const primary_address = this->get_address();
   for (rpc::GET_SERVICE_NODES::response::entry const &node_info : all_nodes)
   {
     for (const auto& contributor : node_info.contributors)
     {
       address_parse_info address_info = {};
-      if (!cryptonote::get_account_address_from_str(address_info, wallet2::nettype(), contributor.address))
+      if (!cryptonote::get_account_address_from_str(address_info, this->nettype(), contributor.address))
       {
         continue;
       }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -12939,16 +12939,15 @@ uint64_t wallet2::get_approximate_blockchain_height() const
   return approx_blockchain_height;
 }
 
-cryptonote::rpc::GET_SERVICE_NODES::response wallet2::list_current_stakes()
+std::vector<rpc::GET_SERVICE_NODES::response::entry> wallet2::list_current_stakes()
 {
 
-  cryptonote::rpc::GET_SERVICE_NODES::response response;
   std::vector<rpc::GET_SERVICE_NODES::response::entry> service_node_states; 
 
   auto [success, all_nodes] = this->get_all_service_nodes();
   if (!success)
   {
-    return response;
+    return service_node_states;
   }
 
   cryptonote::account_public_address const primary_address = this->get_address();
@@ -12969,8 +12968,7 @@ cryptonote::rpc::GET_SERVICE_NODES::response wallet2::list_current_stakes()
     }
   }
 
-  response.service_node_states = service_node_states;
-  return response;
+  return service_node_states;
 }
 
 void wallet2::set_lns_cache_record(wallet2::lns_detail detail)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -809,6 +809,7 @@ private:
     auto get_all_service_nodes()                                    const { return m_node_rpc_proxy.get_all_service_nodes(); }
     auto get_service_nodes(std::vector<std::string> const &pubkeys) const { return m_node_rpc_proxy.get_service_nodes(pubkeys); }
     auto get_service_node_blacklisted_key_images()                  const { return m_node_rpc_proxy.get_service_node_blacklisted_key_images(); }
+    static cryptonote::rpc::GET_SERVICE_NODES::response list_current_stakes();
     auto lns_owners_to_names(cryptonote::rpc::LNS_OWNERS_TO_NAMES::request const &request) const { return m_node_rpc_proxy.lns_owners_to_names(request); }
     auto lns_names_to_owners(cryptonote::rpc::LNS_NAMES_TO_OWNERS::request const &request) const { return m_node_rpc_proxy.lns_names_to_owners(request); }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -809,7 +809,7 @@ private:
     auto get_all_service_nodes()                                    const { return m_node_rpc_proxy.get_all_service_nodes(); }
     auto get_service_nodes(std::vector<std::string> const &pubkeys) const { return m_node_rpc_proxy.get_service_nodes(pubkeys); }
     auto get_service_node_blacklisted_key_images()                  const { return m_node_rpc_proxy.get_service_node_blacklisted_key_images(); }
-    cryptonote::rpc::GET_SERVICE_NODES::response list_current_stakes();
+    std::vector<cryptonote::rpc::GET_SERVICE_NODES::response::entry> list_current_stakes();
     auto lns_owners_to_names(cryptonote::rpc::LNS_OWNERS_TO_NAMES::request const &request) const { return m_node_rpc_proxy.lns_owners_to_names(request); }
     auto lns_names_to_owners(cryptonote::rpc::LNS_NAMES_TO_OWNERS::request const &request) const { return m_node_rpc_proxy.lns_names_to_owners(request); }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -809,7 +809,7 @@ private:
     auto get_all_service_nodes()                                    const { return m_node_rpc_proxy.get_all_service_nodes(); }
     auto get_service_nodes(std::vector<std::string> const &pubkeys) const { return m_node_rpc_proxy.get_service_nodes(pubkeys); }
     auto get_service_node_blacklisted_key_images()                  const { return m_node_rpc_proxy.get_service_node_blacklisted_key_images(); }
-    static cryptonote::rpc::GET_SERVICE_NODES::response list_current_stakes();
+    cryptonote::rpc::GET_SERVICE_NODES::response list_current_stakes();
     auto lns_owners_to_names(cryptonote::rpc::LNS_OWNERS_TO_NAMES::request const &request) const { return m_node_rpc_proxy.lns_owners_to_names(request); }
     auto lns_names_to_owners(cryptonote::rpc::LNS_NAMES_TO_OWNERS::request const &request) const { return m_node_rpc_proxy.lns_names_to_owners(request); }
 


### PR DESCRIPTION
Creates a new function in the wallet to list the stakes that the wallet has locked up. 

- Modifies `print_locked_stakes` to utilise this new function

Also adds a new function to the wallet_api which returns a vector of the service nodes and staked amounts, this utilises the newly created function in wallet to do so.
