### PR TITLE
Fix some stake unlock wallet_api code compilation problems

### DIFF
--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(wallet_api
   pending_transaction.cpp
   utils.cpp
   address_book.cpp
+  stake_unlock_result.cpp
   subaddress.cpp
   subaddress_account.cpp
   unsigned_transaction.cpp)

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -52,6 +52,10 @@ PendingTransactionImpl::PendingTransactionImpl(WalletImpl &wallet)
 {
 }
 
+PendingTransactionImpl::PendingTransactionImpl(WalletImpl& wallet, std::vector<tools::wallet2::pending_tx> pending_tx)
+    : m_wallet{wallet}, m_status{Status_Ok, ""}, m_pending_tx{std::move(pending_tx)}
+{}
+
 PendingTransactionImpl::~PendingTransactionImpl()
 {
 

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -42,6 +42,7 @@ class PendingTransactionImpl : public PendingTransaction
 {
 public:
     PendingTransactionImpl(WalletImpl &wallet);
+    PendingTransactionImpl(WalletImpl &wallet, std::vector<tools::wallet2::pending_tx> pending_tx);
     ~PendingTransactionImpl();
     std::pair<int, std::string> status() const override { return m_status; }
     bool good() const override { return m_status.first == Status_Ok; }

--- a/src/wallet/api/stake_unlock_result.cpp
+++ b/src/wallet/api/stake_unlock_result.cpp
@@ -1,11 +1,10 @@
 #include "stake_unlock_result.h"
+#include "pending_transaction.h"
 
 namespace Wallet {
 
-StakeUnlockResult::~StakeUnlockResult() {}
-
-StakeUnlockResultImpl::StakeUnlockResultImpl(tools::wallet2::request_stake_unlock_result res)
-    : result(std::move(res))
+StakeUnlockResultImpl::StakeUnlockResultImpl(WalletImpl& w, tools::wallet2::request_stake_unlock_result res)
+    : wallet{w}, result(std::move(res))
 {
 }
 
@@ -27,10 +26,9 @@ std::string StakeUnlockResultImpl::msg()
 }
 
 //----------------------------------------------------------------------------------------------------
-std::string StakeUnlockResultImpl::msg()
-PendingTransaction* StakeUnlockResultImpl:: ptx();
+PendingTransaction* StakeUnlockResultImpl::ptx()
 {
-    return &result.ptx;
+    return new PendingTransactionImpl{wallet, {{result.ptx}}};
 }
 
 } // namespace

--- a/src/wallet/api/stake_unlock_result.h
+++ b/src/wallet/api/stake_unlock_result.h
@@ -10,7 +10,7 @@ class WalletImpl;
 class StakeUnlockResultImpl : public StakeUnlockResult
 {
 public:
-    StakeUnlockResultImpl(tools::wallet2::request_stake_unlock_result res);
+    StakeUnlockResultImpl(WalletImpl& w, tools::wallet2::request_stake_unlock_result res);
     StakeUnlockResultImpl();
     ~StakeUnlockResultImpl();
 
@@ -19,6 +19,7 @@ public:
     PendingTransaction* ptx() override;
 
 private:
+    WalletImpl& wallet;
     tools::wallet2::request_stake_unlock_result result;
 };
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2474,17 +2474,16 @@ PendingTransaction* WalletImpl::stakePending(const std::string& sn_key_str, cons
 
 StakeUnlockResult* WalletImpl::canRequestStakeUnlock(const std::string &sn_key)
 {
-    tools::wallet2::request_stake_unlock_result res = {};
-
     crypto::public_key snode_key;
     if (!tools::hex_to_type(sn_key, snode_key))
     {
+      tools::wallet2::request_stake_unlock_result res{};
       res.success = false;
       res.msg = "Failed to Parse Service Node Key";
-      return new StakeUnlockResultImpl(res);
+      return new StakeUnlockResultImpl(*this, res);
     }
 
-    return new StakeUnlockResultImpl(m_wallet->can_request_stake_unlock(snode_key));
+    return new StakeUnlockResultImpl(*this, m_wallet->can_request_stake_unlock(snode_key));
 }
 
 StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
@@ -2496,7 +2495,7 @@ StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
     {
       res.success = false;
       res.msg = "Failed to Parse Service Node Key";
-      return new StakeUnlockResultImpl(res);
+      return new StakeUnlockResultImpl(*this, res);
     }
     tools::wallet2::request_stake_unlock_result unlock_result = m_wallet->can_request_stake_unlock(snode_key);
     if (unlock_result.success)
@@ -2509,17 +2508,17 @@ StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
       {
         res.success = false;
         res.msg = "Failed to commit tx.";
-        return new StakeUnlockResultImpl(res);
+        return new StakeUnlockResultImpl(*this, res);
       }
     }
     else
     {
       res.success = false;
       res.msg = tr("Cannot request stake unlock: " + unlock_result.msg);
-      return new StakeUnlockResultImpl(res);
+      return new StakeUnlockResultImpl(*this, res);
     }
 
-    return new StakeUnlockResultImpl(unlock_result);
+    return new StakeUnlockResultImpl(*this, unlock_result);
 }
 
 uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)


### PR DESCRIPTION
- stake_unlock_result.cpp wasn't actually getting built
- the `ptx()` return value wasn't compiling because there was no way to
convert the low-level pending_tx into a high-level PendingTransaction,
so I added code to make that work.