### PR TITLE
Replaces check for in sync with is close to being synced

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8339,7 +8339,7 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
         return result;
       }
 
-      if (!is_synced())
+      if (!is_close_to_synced())
       {
         result.status = register_service_node_result_status::wallet_not_synced;
         result.msg    = tr("Wallet is not synced. Please synchronise your wallet to the blockchain");
@@ -14562,6 +14562,14 @@ bool wallet2::is_synced() const
   if (!m_node_rpc_proxy.get_height(height))
     return false;
   return get_blockchain_current_height() >= height;
+}
+//----------------------------------------------------------------------------------------------------
+bool wallet2::is_close_to_synced() const
+{
+  uint64_t height;
+  if (!m_node_rpc_proxy.get_height(height))
+    return false;
+  return get_blockchain_current_height() >= height-1;
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_segregation_fork_height() const

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8339,7 +8339,7 @@ wallet2::register_service_node_result wallet2::create_register_service_node_tx(c
         return result;
       }
 
-      if (!is_close_to_synced())
+      if (!is_synced(1))
       {
         result.status = register_service_node_result_status::wallet_not_synced;
         result.msg    = tr("Wallet is not synced. Please synchronise your wallet to the blockchain");
@@ -14556,20 +14556,12 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
   }
 }
 //----------------------------------------------------------------------------------------------------
-bool wallet2::is_synced() const
+bool wallet2::is_synced(uint64_t grace_blocks) const
 {
   uint64_t height;
   if (!m_node_rpc_proxy.get_height(height))
     return false;
-  return get_blockchain_current_height() >= height;
-}
-//----------------------------------------------------------------------------------------------------
-bool wallet2::is_close_to_synced() const
-{
-  uint64_t height;
-  if (!m_node_rpc_proxy.get_height(height))
-    return false;
-  return get_blockchain_current_height() >= height-1;
+  return get_blockchain_current_height() + grace_blocks >= height;
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_segregation_fork_height() const

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1214,6 +1214,7 @@ private:
     uint64_t get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day);    // 1<=month<=12, 1<=day<=31
 
     bool is_synced() const;
+    bool is_close_to_synced() const;
 
     uint64_t get_fee_percent(uint32_t priority, cryptonote::txtype type) const;
     cryptonote::byte_and_output_fees get_base_fees() const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1213,8 +1213,9 @@ private:
 
     uint64_t get_blockchain_height_by_date(uint16_t year, uint8_t month, uint8_t day);    // 1<=month<=12, 1<=day<=31
 
-    bool is_synced() const;
-    bool is_close_to_synced() const;
+    /// Returns true if the wallet is synced with the chain; if grace_blocks > 0 then the check is
+    /// that we are within that many blocks of the top of the chain.
+    bool is_synced(uint64_t grace_blocks = 0) const;
 
     uint64_t get_fee_percent(uint32_t priority, cryptonote::txtype type) const;
     cryptonote::byte_and_output_fees get_base_fees() const;


### PR DESCRIPTION
The wallet can occassionally become "out of sync" when a new block is
added so it becomes one block behind the chain height. This results in
errors in the wallet when staking which are unnecessary because the user immediately
calls the same function after it fails and it will succeed.