### PR TITLE
Clean up stake pending api call

### DIFF
--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -57,6 +57,10 @@ PendingTransactionImpl::~PendingTransactionImpl()
 
 }
 
+void PendingTransactionImpl::setError(std::string error_msg) {
+  m_status = {Status_Error, tr(error_msg)};
+}
+
 std::vector<std::string> PendingTransactionImpl::txid() const
 {
     std::vector<std::string> txid;

--- a/src/wallet/api/pending_transaction.h
+++ b/src/wallet/api/pending_transaction.h
@@ -44,6 +44,7 @@ public:
     PendingTransactionImpl(WalletImpl &wallet);
     ~PendingTransactionImpl();
     std::pair<int, std::string> status() const override { return m_status; }
+    void setError(std::string error_msg) override;
     bool good() const override { return m_status.first == Status_Ok; }
     bool commit(std::string_view filename = "", bool overwrite = false, bool blink = false) override;
     uint64_t amount() const override;

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -129,7 +129,7 @@ public:
     std::string getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const override;
     void setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label) override;
 
-    PendingTransaction* stakePending(const std::string& service_node_key, const std::string& amount, std::string& error_msg) override;
+    PendingTransaction* stakePending(const std::string& service_node_key, const uint64_t& amount) override;
 
     StakeUnlockResult* canRequestStakeUnlock(const std::string &sn_key) override;
 

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -69,6 +69,8 @@ struct PendingTransaction
     /// returns true if the status is currently set to Status_Ok, false otherwise.
     /// For more details, call status() instead.
     virtual bool good() const = 0;
+    /// sets error status to true with reason
+    virtual void setError(std::string error_msg) = 0;
     /// returns error status code (Status_Ok, Status_Error, or Status_Critical) and error string.
     virtual std::pair<int, std::string> status() const = 0;
     // commit transaction or save to file if filename (utf-8) is provided.
@@ -1015,7 +1017,7 @@ struct Wallet
     virtual Device getDeviceType() const = 0;
 
     /// Prepare a staking transaction; return nullptr on failure
-    virtual PendingTransaction* stakePending(const std::string& service_node_key, const std::string& amount, std::string& error_msg) = 0;
+    virtual PendingTransaction* stakePending(const std::string& service_node_key, const uint64_t& amount) = 0;
 
     virtual StakeUnlockResult* canRequestStakeUnlock(const std::string &sn_key) = 0;
 


### PR DESCRIPTION
Changed the amount parameter to uint64_t rather than parsing a string
parameter, absorbed the error message into the pending transaction
struct.

General ease of use changes for the usage of wallet2_api.h 