### PR TITLE
wallet api: Change stake amounts to uint64_t's

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -994,9 +994,9 @@ uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
     return m_wallet->unlocked_balance(accountIndex, false);
 }
 
-std::vector<std::pair<std::string, uint32_t>>* WalletImpl::listCurrentStakes() const
+std::vector<std::pair<std::string, uint64_t>>* WalletImpl::listCurrentStakes() const
 {
-    std::vector<std::pair<std::string, uint32_t>>* stakes = new std::vector<std::pair<std::string, uint32_t>>;
+    std::vector<std::pair<std::string, uint64_t>>* stakes = new std::vector<std::pair<std::string, uint64_t>>;
 
     auto response = m_wallet->list_current_stakes();
 

--- a/src/wallet/api/wallet.h
+++ b/src/wallet/api/wallet.h
@@ -98,7 +98,7 @@ public:
     bool trustedDaemon() const override;
     uint64_t balance(uint32_t accountIndex = 0) const override;
     uint64_t unlockedBalance(uint32_t accountIndex = 0) const override;
-    std::vector<std::pair<std::string, uint32_t>>* listCurrentStakes() const override;
+    std::vector<std::pair<std::string, uint64_t>>* listCurrentStakes() const override;
     uint64_t blockChainHeight() const override;
     uint64_t approximateBlockChainHeight() const override;
     uint64_t estimateBlockChainHeight() const override;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -602,7 +602,7 @@ struct Wallet
     * @brief listCurrentStakes - returns a list of the wallets locked stakes, provides both service node address and the staked amount
     * @return
     */
-    virtual std::vector<std::pair<std::string, uint32_t>>* listCurrentStakes() const = 0;
+    virtual std::vector<std::pair<std::string, uint64_t>>* listCurrentStakes() const = 0;
 
    /**
     * @brief watchOnly - checks if wallet is watch only


### PR DESCRIPTION
uint32_t's aren't big enough to hold typical stake amounts