### PR TITLE
Fix Monero P2P remote DOS

### DIFF
--- a/contrib/epee/include/epee/storages/portable_storage_from_bin.h
+++ b/contrib/epee/include/epee/storages/portable_storage_from_bin.h
@@ -129,8 +129,8 @@ namespace epee
       CHECK_AND_ASSERT_THROW_MES(size <= m_count, "Size sanity check failed");
       storage_entry se{std::in_place_type<array_entry>, std::in_place_type<array_t<T>>};
       auto& arr = var::get<array_t<T>>(var::get<array_entry>(se));
-      if constexpr (!std::is_same_v<T, bool>) // bool uses a std::deque instead of vector because
-        arr.reserve(size);                    // std::vector<bool> is broken by design
+      if constexpr (!std::is_same_v<T, bool>) // bool uses a std::deque, which isn't reserveable
+        arr.reserve(std::min<size_t>(size, 4096));
 
       while(size--)
         read(arr.emplace_back());


### PR DESCRIPTION
Monero serialization reserves memory before validating the size of the incoming data, thus allowing a remote node to send malicious data that causes the local node to run itself out of memory.

This fixes it by limiting the amount of memory we'll reserve in advance to a sane amount.