### PR TITLE
ios & android package updates

### DIFF
--- a/utils/build_scripts/drone-android-static-upload.sh
+++ b/utils/build_scripts/drone-android-static-upload.sh
@@ -21,7 +21,7 @@ chmod 600 ssh_key
 
 branch_or_tag=${DRONE_BRANCH:-${DRONE_TAG:-unknown}}
 
-upload_to="builds.lokinet.dev/${DRONE_REPO// /_}/${branch_or_tag// /_}"
+upload_to="oxen.rocks/${DRONE_REPO// /_}/${branch_or_tag// /_}"
 
 tmpdir=android-deps-${DRONE_COMMIT}
 mkdir -p $tmpdir/include $tmpdir/lib
@@ -47,7 +47,7 @@ for p in "${upload_dirs[@]}"; do
 -mkdir $dir_tmp"
 done
 
-sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@builds.lokinet.dev <<SFTP
+sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@oxen.rocks <<SFTP
 $mkdirs
 put $filename $upload_to
 SFTP

--- a/utils/build_scripts/drone-android-static-upload.sh
+++ b/utils/build_scripts/drone-android-static-upload.sh
@@ -24,12 +24,12 @@ branch_or_tag=${DRONE_BRANCH:-${DRONE_TAG:-unknown}}
 upload_to="builds.lokinet.dev/${DRONE_REPO// /_}/${branch_or_tag// /_}"
 
 tmpdir=android-deps-${DRONE_COMMIT}
-mkdir -p $tmpdir
-cp src/wallet/api/wallet2_api.h $tmpdir
+mkdir -p $tmpdir/include $tmpdir/lib
+cp src/wallet/api/wallet2_api.h $tmpdir/include
 
 for android_abi in "$@"; do
-    mkdir -p $tmpdir/${android_abi}
-    ln -s ../../build-${android_abi}/src/wallet/api/libwallet_merged.a $tmpdir/${android_abi}/libwallet_api.a
+    mkdir -p $tmpdir/lib/${android_abi}
+    ln -s ../../build-${android_abi}/src/wallet/api/libwallet_merged.a $tmpdir/lib/${android_abi}/libwallet_api.a
 done
 
 filename=android-deps-${DRONE_COMMIT}.tar.xz

--- a/utils/build_scripts/drone-ios-static-upload.sh
+++ b/utils/build_scripts/drone-ios-static-upload.sh
@@ -21,7 +21,7 @@ chmod 600 ssh_key
 
 branch_or_tag=${DRONE_BRANCH:-${DRONE_TAG:-unknown}}
 
-upload_to="builds.lokinet.dev/${DRONE_REPO// /_}/${branch_or_tag// /_}"
+upload_to="oxen.rocks/${DRONE_REPO// /_}/${branch_or_tag// /_}"
 
 tmpdir=ios-deps-${DRONE_COMMIT}
 mkdir -p $tmpdir/lib
@@ -47,7 +47,7 @@ for p in "${upload_dirs[@]}"; do
 -mkdir $dir_tmp"
 done
 
-sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@builds.lokinet.dev <<SFTP
+sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@oxen.rocks <<SFTP
 $mkdirs
 put $filename $upload_to
 SFTP

--- a/utils/build_scripts/drone-ios-static-upload.sh
+++ b/utils/build_scripts/drone-ios-static-upload.sh
@@ -30,23 +30,7 @@ mkdir -p $tmpdir/include
 # Merge the arm64 and simulator libs into a single multi-arch merged lib:
 lipo -create build/{arm64,sim64}/src/wallet/api/libwallet_merged.a -o $tmpdir/lib/libwallet_merged.a
 
-# Collect all the headers
-# Loki core:
-cd src
-find . \( -name '*.h' -or -name '*.hpp' \) -exec cp -v --parents {} ../$tmpdir/include \;
-cp -v daemonizer/posix_daemonizer.inl ../$tmpdir/include/daemonizer
-cd ..
-# epee:
-cp -rv contrib/epee/include/epee $tmpdir/include
-# external libs:
-mkdir $tmpdir/include/lokimq
-cp -v external/{easylogging++/*.h,db_drivers/liblmdb/lmdb.h,randomx/src/randomx.h} $tmpdir/include
-cp -v external/loki-mq/lokimq/*.h $tmpdir/include/lokimq
-cp -rv external/{boost,cpr/include/cpr,ghc-filesystem/include/ghc,libuv/include/*,rapidjson/include/rapidjson} $tmpdir/include
-cp -rv build/arm64/external/uWebSockets/* $tmpdir/include
-# static libs:
-cp -rv build/arm64/static-deps/include/* $tmpdir/include
-
+cp src/wallet/api/wallet2_api.h $tmpdir/include
 
 filename=ios-deps-${DRONE_COMMIT}.tar.xz
 XZ_OPTS="--threads=6" tar --dereference -cJvf $filename $tmpdir

--- a/utils/build_scripts/drone-static-upload.sh
+++ b/utils/build_scripts/drone-static-upload.sh
@@ -21,7 +21,7 @@ chmod 600 ssh_key
 
 branch_or_tag=${DRONE_BRANCH:-${DRONE_TAG:-unknown}}
 
-upload_to="builds.lokinet.dev/${DRONE_REPO// /_}/${branch_or_tag// /_}"
+upload_to="oxen.rocks/${DRONE_REPO// /_}/${branch_or_tag// /_}"
 
 filename=
 for f in loki-*.tar.xz loki-*.zip; do
@@ -49,7 +49,7 @@ for p in "${upload_dirs[@]}"; do
 -mkdir $dir_tmp"
 done
 
-sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@builds.lokinet.dev <<SFTP
+sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@oxen.rocks <<SFTP
 $mkdirs
 put $filename $upload_to
 SFTP

--- a/utils/build_scripts/drone-wallet-upload.sh
+++ b/utils/build_scripts/drone-wallet-upload.sh
@@ -25,7 +25,7 @@ fi
 # -mkdir a/, -mkdir a/b/, -mkdir a/b/c/, ... commands.  The leading `-` allows the command to fail
 # without error.
 branch_or_tag=${DRONE_BRANCH:-${DRONE_TAG:-unknown}}
-upload_to="builds.lokinet.dev/${DRONE_REPO// /_}/${branch_or_tag// /_}"
+upload_to="oxen.rocks/${DRONE_REPO// /_}/${branch_or_tag// /_}"
 upload_dirs=(${upload_to//\// })
 sftpcmds=
 dir_tmp=""
@@ -39,7 +39,7 @@ for filename in "${filenames[@]}"; do
 put $filename $upload_to"
 done
 
-sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@builds.lokinet.dev <<SFTP
+sftp -i ssh_key -b - -o StrictHostKeyChecking=off drone@oxen.rocks <<SFTP
 $sftpcmds
 SFTP
 


### PR DESCRIPTION
- Remove the massive amount of headers included in the ios package: the new ios wallet doesn't need them.
- Restructure the android archive to put files under lib/ include/ (which makes it a little easier to extract into the new android wallet).