### PR TITLE
Fix cli wallet on Windows not saving properly

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5951,6 +5951,12 @@ void wallet2::store_to(const fs::path &path, const epee::wipeable_string &passwo
 
     // here we have "*.new" file, we need to rename it to be without ".new"
     std::error_code e;
+#ifdef WIN32
+    // std::filesystem on Windows seems buggy: the standard requires that it overwrites
+    // (atomically), but it doesn't and instead fails when the file already exists, so manually
+    // remove it first.  If it fails then just ignore it and let the rename try anyway.
+    fs::remove(m_wallet_file, e);
+#endif
     fs::rename(new_file, m_wallet_file, e);
     THROW_WALLET_EXCEPTION_IF(e, error::file_save_error, m_wallet_file, e);
   }


### PR DESCRIPTION
std::filesystem::rename() on windows appears buggy: it is meant to work
like POSIX rename (which atomically replaces the file if it exists), but
either mingw or Windows itself is buggy and just fails instead.  Delete
manually first, on Windows.

On Windows, you'd see (either on manual save or when saving at exit):
```
[wallet LD3Y7f]: save
Error: failed to save file "w": File exists
```