### PR TITLE
Strip android libs, disable trezor & protobuf

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,6 +1,6 @@
 local default_deps_base='libsystemd-dev libboost-thread-dev libgtest-dev ' +
     'libboost-serialization-dev libboost-program-options-dev libunbound-dev nettle-dev libevent-dev libminiupnpc-dev ' +
-    'libunwind8-dev libsodium-dev libssl-dev libreadline-dev libhidapi-dev libusb-1.0-0-dev libprotobuf-dev protobuf-compiler python3 ' +
+    'libunwind8-dev libsodium-dev libssl-dev libreadline-dev libhidapi-dev libusb-1.0-0-dev python3 ' +
     'pkg-config libsqlite3-dev qttools5-dev libcurl4-openssl-dev';
 local default_deps='g++ ' + default_deps_base; // g++ sometimes needs replacement
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -242,9 +242,8 @@ local gui_wallet_step_darwin = {
                     + android_build_steps('armeabi-v7a', cmake_extra='-DARCH=armv7-a -DARCH_ID=arm32')
                     + android_build_steps('arm64-v8a', cmake_extra='-DARCH=armv8-a -DARCH_ID=arm64')
                     + android_build_steps('x86_64', cmake_extra='-DARCH="x86-64 -msse4.2 -mpopcnt" -DARCH_ID=x86-64')
-                    + android_build_steps('x86', cmake_extra='-DARCH="i686 -mssse3 -mfpmath=sse" -DARCH_ID=i386')
                     + [
-                    './utils/build_scripts/drone-android-static-upload.sh armeabi-v7a arm64-v8a x86_64 x86'
+                    './utils/build_scripts/drone-android-static-upload.sh armeabi-v7a arm64-v8a x86_64'
                 ]
             }
         ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,8 @@ if (BUILD_TESTS)
   add_definitions(-DUNIT_TEST)
 endif()
 
+OPTION(USE_DEVICE_TREZOR "Build Trezor support (currently non-functional)" OFF)
+
 find_package(Git)
 if(NOT MANUAL_SUBMODULES)
   if(GIT_FOUND)
@@ -496,8 +498,9 @@ add_subdirectory(external)
 
 target_compile_definitions(easylogging PRIVATE AUTO_INITIALIZE_EASYLOGGINGPP)
 
-# Trezor support check
-include(CheckTrezor)
+if(USE_DEVICE_TREZOR)
+  include(CheckTrezor)
+endif()
 
 if(MSVC)
   add_definitions("/bigobj /MP /W3 /GS- /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4345 /D_WIN32_WINNT=0x0600 /DWIN32_LEAN_AND_MEAN /DGTEST_HAS_TR1_TUPLE=0 /FIinline_c.h /D__SSE4_1__")

--- a/cmake/CheckTrezor.cmake
+++ b/cmake/CheckTrezor.cmake
@@ -1,4 +1,3 @@
-OPTION(USE_DEVICE_TREZOR "Trezor support compilation" ON)
 OPTION(USE_DEVICE_TREZOR_LIBUSB "Trezor LibUSB compilation" ON)
 OPTION(USE_DEVICE_TREZOR_UDP_RELEASE "Trezor UdpTransport in release mode" OFF)
 OPTION(USE_DEVICE_TREZOR_DEBUG "Trezor Debugging enabled" OFF)

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -540,25 +540,27 @@ endif()
 
 
 
-set(protobuf_extra "")
-if(ANDROID)
-  set(protobuf_extra "LDFLAGS=-llog")
+if(USE_DEVICE_TREZOR)
+  set(protobuf_extra "")
+  if(ANDROID)
+    set(protobuf_extra "LDFLAGS=-llog")
+  endif()
+  build_external(protobuf
+    CONFIGURE_COMMAND
+      ./configure ${cross_host} --disable-shared --prefix=${DEPS_DESTDIR} --with-pic
+        "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}"
+        ${cross_extra} ${protobuf_extra}
+        "CPP=${deps_cc} -E" "CXXCPP=${deps_cxx} -E"
+        "CC_FOR_BUILD=${deps_cc}" "CXX_FOR_BUILD=${deps_cxx}"  # Thanks Google for making people hunt for undocumented magic variables
+    BUILD_BYPRODUCTS
+      ${DEPS_DESTDIR}/lib/libprotobuf-lite.a
+      ${DEPS_DESTDIR}/lib/libprotobuf.a
+      ${DEPS_DESTDIR}/lib/libprotoc.a
+      ${DEPS_DESTDIR}/include/google/protobuf
+  )
+  add_static_target(protobuf_lite protobuf_external libprotobuf-lite.a)
+  add_static_target(protobuf_bloated protobuf_external libprotobuf.a)
 endif()
-build_external(protobuf
-  CONFIGURE_COMMAND
-    ./configure ${cross_host} --disable-shared --prefix=${DEPS_DESTDIR} --with-pic
-      "CC=${deps_cc}" "CXX=${deps_cxx}" "CFLAGS=${deps_CFLAGS}" "CXXFLAGS=${deps_CXXFLAGS}"
-      ${cross_extra} ${protobuf_extra}
-      "CPP=${deps_cc} -E" "CXXCPP=${deps_cxx} -E"
-      "CC_FOR_BUILD=${deps_cc}" "CXX_FOR_BUILD=${deps_cxx}"  # Thanks Google for making people hunt for undocumented magic variables
-  BUILD_BYPRODUCTS
-    ${DEPS_DESTDIR}/lib/libprotobuf-lite.a
-    ${DEPS_DESTDIR}/lib/libprotobuf.a
-    ${DEPS_DESTDIR}/lib/libprotoc.a
-    ${DEPS_DESTDIR}/include/google/protobuf
-)
-add_static_target(protobuf_lite protobuf_external libprotobuf-lite.a)
-add_static_target(protobuf_bloated protobuf_external libprotobuf.a)
 
 
 

--- a/src/wallet/api/CMakeLists.txt
+++ b/src/wallet/api/CMakeLists.txt
@@ -95,6 +95,11 @@ function(combine_archives output_archive)
 endfunction(combine_archives)
 
 if (STATIC AND BUILD_STATIC_DEPS)
+    set(merged_protobuf)
+    if(TARGET protobuf_lite)
+      set(merged_protobuf protobuf_lite)
+    endif()
+
     combine_archives(wallet_merged
             wallet_api
             wallet
@@ -124,7 +129,7 @@ if (STATIC AND BUILD_STATIC_DEPS)
             expat
             libunbound
             sqlite3
-            protobuf_lite
+            ${merged_protobuf}
             sodium
             libzmq
             CURL::libcurl

--- a/src/wallet/api/address_book.cpp
+++ b/src/wallet/api/address_book.cpp
@@ -38,12 +38,15 @@
 #include <vector>
 
 namespace Wallet {
-  
+
+EXPORT
 AddressBook::~AddressBook() {}
-  
+
+EXPORT
 AddressBookImpl::AddressBookImpl(WalletImpl *wallet)
     : m_wallet(wallet), m_errorCode(Status_Ok) {}
 
+EXPORT
 bool AddressBookImpl::addRow(const std::string &dst_addr, const std::string &description)
 {
   clearStatus();
@@ -63,6 +66,7 @@ bool AddressBookImpl::addRow(const std::string &dst_addr, const std::string &des
   return r;
 }
 
+EXPORT
 void AddressBookImpl::refresh() 
 {
   LOG_PRINT_L2("Refreshing addressbook");
@@ -85,6 +89,7 @@ void AddressBookImpl::refresh()
   
 }
 
+EXPORT
 bool AddressBookImpl::deleteRow(std::size_t rowId)
 {
   LOG_PRINT_L2("Deleting address book row " << rowId);
@@ -94,6 +99,7 @@ bool AddressBookImpl::deleteRow(std::size_t rowId)
   return r;
 } 
 
+EXPORT
 void AddressBookImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -101,17 +107,20 @@ void AddressBookImpl::clearRows() {
    m_rows.clear();
 }
 
+EXPORT
 void AddressBookImpl::clearStatus(){
   m_errorString = "";
   m_errorCode = 0;
 }
 
+EXPORT
 std::vector<AddressBookRow*> AddressBookImpl::getAll() const
 {
   return m_rows;
 }
 
 
+EXPORT
 AddressBookImpl::~AddressBookImpl()
 {
   clearRows();

--- a/src/wallet/api/common_defines.h
+++ b/src/wallet/api/common_defines.h
@@ -1,7 +1,9 @@
-#ifndef WALLET_API_COMMON_DEFINES_H__
-#define WALLET_API_COMMON_DEFINES_H__
+#pragma once
 
 #define tr(x) (x)
 
+#ifdef __GNUC__
+#define EXPORT __attribute__((visibility("default"))) __attribute__((used))
+#else
+#define EXPORT
 #endif
-

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -44,27 +44,33 @@
 
 namespace Wallet {
 
+EXPORT
 PendingTransaction::~PendingTransaction() {}
 
 
+EXPORT
 PendingTransactionImpl::PendingTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet), m_status{Status_Ok, ""}
 {
 }
 
+EXPORT
 PendingTransactionImpl::PendingTransactionImpl(WalletImpl& wallet, std::vector<tools::wallet2::pending_tx> pending_tx)
     : m_wallet{wallet}, m_status{Status_Ok, ""}, m_pending_tx{std::move(pending_tx)}
 {}
 
+EXPORT
 PendingTransactionImpl::~PendingTransactionImpl()
 {
 
 }
 
+EXPORT
 void PendingTransactionImpl::setError(std::string error_msg) {
   m_status = {Status_Error, tr(error_msg)};
 }
 
+EXPORT
 std::vector<std::string> PendingTransactionImpl::txid() const
 {
     std::vector<std::string> txid;
@@ -73,6 +79,7 @@ std::vector<std::string> PendingTransactionImpl::txid() const
     return txid;
 }
 
+EXPORT
 bool PendingTransactionImpl::commit(std::string_view filename_, bool overwrite, bool blink)
 {
 
@@ -148,6 +155,7 @@ bool PendingTransactionImpl::commit(std::string_view filename_, bool overwrite, 
     return good();
 }
 
+EXPORT
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;
@@ -159,6 +167,7 @@ uint64_t PendingTransactionImpl::amount() const
     return result;
 }
 
+EXPORT
 uint64_t PendingTransactionImpl::dust() const
 {
     uint64_t result = 0;
@@ -168,6 +177,7 @@ uint64_t PendingTransactionImpl::dust() const
     return result;
 }
 
+EXPORT
 uint64_t PendingTransactionImpl::fee() const
 {
     uint64_t result = 0;
@@ -177,11 +187,13 @@ uint64_t PendingTransactionImpl::fee() const
     return result;
 }
 
+EXPORT
 uint64_t PendingTransactionImpl::txCount() const
 {
     return m_pending_tx.size();
 }
 
+EXPORT
 std::vector<uint32_t> PendingTransactionImpl::subaddrAccount() const
 {
     std::vector<uint32_t> result;
@@ -190,6 +202,7 @@ std::vector<uint32_t> PendingTransactionImpl::subaddrAccount() const
     return result;
 }
 
+EXPORT
 std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
 {
     std::vector<std::set<uint32_t>> result;
@@ -198,6 +211,7 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
     return result;
 }
 
+EXPORT
 std::string PendingTransactionImpl::multisigSignData() {
     try {
         if (!m_wallet.multisig().isMultisig) {
@@ -217,6 +231,7 @@ std::string PendingTransactionImpl::multisigSignData() {
     return std::string();
 }
 
+EXPORT
 void PendingTransactionImpl::signMultisigTx() {
     try {
         std::vector<crypto::hash> ignore;
@@ -236,6 +251,7 @@ void PendingTransactionImpl::signMultisigTx() {
     }
 }
 
+EXPORT
 std::vector<std::string> PendingTransactionImpl::signersKeys() const {
     std::vector<std::string> keys;
     keys.reserve(m_signers.size());

--- a/src/wallet/api/stake_unlock_result.cpp
+++ b/src/wallet/api/stake_unlock_result.cpp
@@ -1,31 +1,37 @@
 #include "stake_unlock_result.h"
+#include "common_defines.h"
 #include "pending_transaction.h"
 
 namespace Wallet {
 
+EXPORT
 StakeUnlockResultImpl::StakeUnlockResultImpl(WalletImpl& w, tools::wallet2::request_stake_unlock_result res)
     : wallet{w}, result(std::move(res))
 {
 }
 
+EXPORT
 StakeUnlockResultImpl::~StakeUnlockResultImpl()
 {
     LOG_PRINT_L3("Stake Unlock Result Deleted");
 }
 
 //----------------------------------------------------------------------------------------------------
+EXPORT
 bool StakeUnlockResultImpl::success()
 {
     return result.success;
 }
 
 //----------------------------------------------------------------------------------------------------
+EXPORT
 std::string StakeUnlockResultImpl::msg()
 {
     return result.msg;
 }
 
 //----------------------------------------------------------------------------------------------------
+EXPORT
 PendingTransaction* StakeUnlockResultImpl::ptx()
 {
     return new PendingTransactionImpl{wallet, {{result.ptx}}};

--- a/src/wallet/api/subaddress.cpp
+++ b/src/wallet/api/subaddress.cpp
@@ -36,17 +36,21 @@
 
 namespace Wallet {
   
+EXPORT
 Subaddress::~Subaddress() {}
   
+EXPORT
 SubaddressImpl::SubaddressImpl(WalletImpl *wallet)
     : m_wallet(wallet) {}
 
+EXPORT
 void SubaddressImpl::addRow(uint32_t accountIndex, const std::string &label)
 {
   m_wallet->m_wallet->add_subaddress(accountIndex, label);
   refresh(accountIndex);
 }
 
+EXPORT
 void SubaddressImpl::setLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label)
 {
   try
@@ -60,6 +64,7 @@ void SubaddressImpl::setLabel(uint32_t accountIndex, uint32_t addressIndex, cons
   }
 }
 
+EXPORT
 void SubaddressImpl::refresh(uint32_t accountIndex) 
 {
   LOG_PRINT_L2("Refreshing subaddress");
@@ -71,6 +76,7 @@ void SubaddressImpl::refresh(uint32_t accountIndex)
   }
 }
 
+EXPORT
 void SubaddressImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -78,11 +84,13 @@ void SubaddressImpl::clearRows() {
    m_rows.clear();
 }
 
+EXPORT
 std::vector<SubaddressRow*> SubaddressImpl::getAll() const
 {
   return m_rows;
 }
 
+EXPORT
 SubaddressImpl::~SubaddressImpl()
 {
   clearRows();

--- a/src/wallet/api/subaddress_account.cpp
+++ b/src/wallet/api/subaddress_account.cpp
@@ -36,23 +36,28 @@
 
 namespace Wallet {
   
+EXPORT
 SubaddressAccount::~SubaddressAccount() {}
   
+EXPORT
 SubaddressAccountImpl::SubaddressAccountImpl(WalletImpl *wallet)
     : m_wallet(wallet) {}
 
+EXPORT
 void SubaddressAccountImpl::addRow(const std::string &label)
 {
   m_wallet->m_wallet->add_subaddress_account(label);
   refresh();
 }
 
+EXPORT
 void SubaddressAccountImpl::setLabel(uint32_t accountIndex, const std::string &label)
 {
   m_wallet->m_wallet->set_subaddress_label({accountIndex, 0}, label);
   refresh();
 }
 
+EXPORT
 void SubaddressAccountImpl::refresh() 
 {
   LOG_PRINT_L2("Refreshing subaddress account");
@@ -70,6 +75,7 @@ void SubaddressAccountImpl::refresh()
   }
 }
 
+EXPORT
 void SubaddressAccountImpl::clearRows() {
    for (auto r : m_rows) {
      delete r;
@@ -77,11 +83,13 @@ void SubaddressAccountImpl::clearRows() {
    m_rows.clear();
 }
 
+EXPORT
 std::vector<SubaddressAccountRow*> SubaddressAccountImpl::getAll() const
 {
   return m_rows;
 }
 
+EXPORT
 SubaddressAccountImpl::~SubaddressAccountImpl()
 {
   clearRows();

--- a/src/wallet/api/transaction_history.cpp
+++ b/src/wallet/api/transaction_history.cpp
@@ -32,6 +32,7 @@
 #include "transaction_history.h"
 #include "transaction_info.h"
 #include "wallet.h"
+#include "common_defines.h"
 
 #include "crypto/hash.h"
 #include "wallet/wallet2.h"
@@ -42,21 +43,25 @@
 
 namespace Wallet {
 
+EXPORT
 TransactionHistory::~TransactionHistory() {}
 
 
+EXPORT
 TransactionHistoryImpl::TransactionHistoryImpl(WalletImpl *wallet)
     : m_wallet(wallet)
 {
 
 }
 
+EXPORT
 TransactionHistoryImpl::~TransactionHistoryImpl()
 {
     for (auto t : m_history)
         delete t;
 }
 
+EXPORT
 int TransactionHistoryImpl::count() const
 {
     std::shared_lock lock{m_historyMutex};
@@ -64,6 +69,7 @@ int TransactionHistoryImpl::count() const
     return result;
 }
 
+EXPORT
 TransactionInfo *TransactionHistoryImpl::transaction(int index) const
 {
     std::shared_lock lock{m_historyMutex};
@@ -74,6 +80,7 @@ TransactionInfo *TransactionHistoryImpl::transaction(int index) const
     return index_ < m_history.size() ? m_history[index_] : nullptr;
 }
 
+EXPORT
 TransactionInfo *TransactionHistoryImpl::transaction(std::string_view id) const
 {
     std::shared_lock lock{m_historyMutex};
@@ -84,6 +91,7 @@ TransactionInfo *TransactionHistoryImpl::transaction(std::string_view id) const
     return itr != m_history.end() ? *itr : nullptr;
 }
 
+EXPORT
 std::vector<TransactionInfo *> TransactionHistoryImpl::getAll() const
 {
     std::shared_lock lock{m_historyMutex};
@@ -98,6 +106,7 @@ static reward_type from_pay_type(wallet::pay_type ptype) {
     }
 }
 
+EXPORT
 void TransactionHistoryImpl::refresh()
 {
     // multithreaded access:

--- a/src/wallet/api/transaction_info.cpp
+++ b/src/wallet/api/transaction_info.cpp
@@ -29,16 +29,20 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include "transaction_info.h"
+#include "common_defines.h"
 
 
 namespace Wallet {
 
+EXPORT
 TransactionInfo::~TransactionInfo() {}
 
+EXPORT
 TransactionInfo::Transfer::Transfer(uint64_t _amount, std::string _address)
     : amount(_amount), address(std::move(_address)) {}
 
 
+EXPORT
 TransactionInfoImpl::TransactionInfoImpl()
     : m_direction(Direction_Out)
       , m_pending(false)
@@ -55,92 +59,110 @@ TransactionInfoImpl::TransactionInfoImpl()
 
 }
 
+EXPORT
 TransactionInfoImpl::~TransactionInfoImpl()
 {
 
 }
 
+EXPORT
 int TransactionInfoImpl::direction() const
 {
     return m_direction;
 }
 
+EXPORT
 bool TransactionInfoImpl::isServiceNodeReward() const
 {
     return m_reward_type == reward_type::service_node;
 }
 
+EXPORT
 bool TransactionInfoImpl::isMinerReward() const
 {
     return m_reward_type == reward_type::miner;
 }
 
+EXPORT
 bool TransactionInfoImpl::isPending() const
 {
     return m_pending;
 }
 
+EXPORT
 bool TransactionInfoImpl::isFailed() const
 {
     return m_failed;
 }
 
+EXPORT
 uint64_t TransactionInfoImpl::amount() const
 {
     return m_amount;
 }
 
+EXPORT
 uint64_t TransactionInfoImpl::fee() const
 {
     return m_fee;
 }
 
+EXPORT
 uint64_t TransactionInfoImpl::blockHeight() const
 {
     return m_blockheight;
 }
 
+EXPORT
 std::set<uint32_t> TransactionInfoImpl::subaddrIndex() const
 {
     return m_subaddrIndex;
 }
 
+EXPORT
 uint32_t TransactionInfoImpl::subaddrAccount() const
 {
     return m_subaddrAccount;
 }
 
+EXPORT
 std::string TransactionInfoImpl::label() const
 {
     return m_label;
 }
 
 
+EXPORT
 std::string TransactionInfoImpl::hash() const
 {
     return m_hash;
 }
 
+EXPORT
 std::time_t TransactionInfoImpl::timestamp() const
 {
     return m_timestamp;
 }
 
+EXPORT
 std::string TransactionInfoImpl::paymentId() const
 {
     return m_paymentid;
 }
 
+EXPORT
 const std::vector<TransactionInfo::Transfer> &TransactionInfoImpl::transfers() const
 {
     return m_transfers;
 }
 
+EXPORT
 uint64_t TransactionInfoImpl::confirmations() const
 {
     return m_confirmations;
 }
 
+EXPORT
 uint64_t TransactionInfoImpl::unlockTime() const
 {
     return m_unlock_time;

--- a/src/wallet/api/unsigned_transaction.cpp
+++ b/src/wallet/api/unsigned_transaction.cpp
@@ -42,19 +42,23 @@
 
 namespace Wallet {
 
+EXPORT
 UnsignedTransaction::~UnsignedTransaction() {}
 
 
+EXPORT
 UnsignedTransactionImpl::UnsignedTransactionImpl(WalletImpl &wallet)
     : m_wallet(wallet), m_status{Status_Ok, ""}
 {
 }
 
+EXPORT
 UnsignedTransactionImpl::~UnsignedTransactionImpl()
 {
     LOG_PRINT_L3("Unsigned tx deleted");
 }
 
+EXPORT
 bool UnsignedTransactionImpl::sign(std::string_view signedFileName_)
 {
   auto signedFileName = fs::u8path(signedFileName_);
@@ -82,6 +86,7 @@ bool UnsignedTransactionImpl::sign(std::string_view signedFileName_)
 }
 
 //----------------------------------------------------------------------------------------------------
+EXPORT
 bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_num_txes, const std::function<const wallet::tx_construction_data&(size_t)> &get_tx, const std::string &extra_message)
 {
   // gather info to ask the user
@@ -197,6 +202,7 @@ bool UnsignedTransactionImpl::checkLoadedTx(const std::function<size_t()> get_nu
   return true;
 }
 
+EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::amount() const
 {
     std::vector<uint64_t> result;
@@ -208,6 +214,7 @@ std::vector<uint64_t> UnsignedTransactionImpl::amount() const
     return result;
 }
 
+EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::fee() const
 {
     std::vector<uint64_t> result;
@@ -220,6 +227,7 @@ std::vector<uint64_t> UnsignedTransactionImpl::fee() const
     return result;
 } 
 
+EXPORT
 std::vector<uint64_t> UnsignedTransactionImpl::mixin() const
 {
     std::vector<uint64_t> result;    
@@ -236,11 +244,13 @@ std::vector<uint64_t> UnsignedTransactionImpl::mixin() const
     return result;
 }    
 
+EXPORT
 uint64_t UnsignedTransactionImpl::txCount() const
 {
     return m_unsigned_tx_set.txes.size();
 }
 
+EXPORT
 std::vector<std::string> UnsignedTransactionImpl::paymentId() const 
 {
     std::vector<std::string> result;
@@ -270,6 +280,7 @@ std::vector<std::string> UnsignedTransactionImpl::paymentId() const
     return result;
 }
 
+EXPORT
 std::vector<std::string> UnsignedTransactionImpl::recipientAddress() const 
 {
     // TODO: return integrated address if short payment ID exists
@@ -284,6 +295,7 @@ std::vector<std::string> UnsignedTransactionImpl::recipientAddress() const
     return result;
 }
 
+EXPORT
 uint64_t UnsignedTransactionImpl::minMixinCount() const
 {    
     uint64_t min_mixin = ~0;  

--- a/src/wallet/api/utils.cpp
+++ b/src/wallet/api/utils.cpp
@@ -28,12 +28,14 @@
 //
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
+#include "common_defines.h"
 #include "epee/misc_log_ex.h"
 #include "common/util.h"
 
 namespace Wallet {
 namespace Utils {
 
+EXPORT
 bool isAddressLocal(const std::string &address)
 { 
     try {
@@ -44,6 +46,7 @@ bool isAddressLocal(const std::string &address)
     }
 }
 
+EXPORT
 void onStartup()
 {
     tools::on_startup();

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -114,6 +114,7 @@ namespace {
 struct Wallet2CallbackImpl : public tools::i_wallet2_callback
 {
 
+    EXPORT
     Wallet2CallbackImpl(WalletImpl * wallet)
      : m_listener(nullptr)
      , m_wallet(wallet)
@@ -121,21 +122,25 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
 
     }
 
+    EXPORT
     ~Wallet2CallbackImpl()
     {
 
     }
 
+    EXPORT
     void setListener(WalletListener * listener)
     {
         m_listener = listener;
     }
 
+    EXPORT
     WalletListener * getListener() const
     {
         return m_listener;
     }
 
+    EXPORT
     void on_new_block(uint64_t height, const cryptonote::block& block) override
     {
         // Don't flood the GUI with signals. On fast refresh - send signal every 1000th block
@@ -149,6 +154,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
+    EXPORT
     void on_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index, uint64_t unlock_time, bool blink) override
     {
         std::string tx_hash = tools::type_to_hex(txid);
@@ -164,6 +170,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
+    EXPORT
     void on_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx, uint64_t amount, const cryptonote::subaddress_index& subaddr_index) override
     {
 
@@ -180,6 +187,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
+    EXPORT
     void on_money_spent(uint64_t height,
                         const crypto::hash &txid,
                         const cryptonote::transaction &in_tx,
@@ -200,12 +208,14 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
         }
     }
 
+    EXPORT
     void on_skip_transaction(uint64_t height, const crypto::hash &txid, const cryptonote::transaction& tx) override
     {
         // TODO;
     }
 
     // Light wallet callbacks
+    EXPORT
     void on_lw_new_block(uint64_t height) override
     {
       if (m_listener) {
@@ -213,6 +223,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     void on_lw_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -221,6 +232,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     void on_lw_unconfirmed_money_received(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -229,6 +241,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     void on_lw_money_spent(uint64_t height, const crypto::hash &txid, uint64_t amount) override
     {
       if (m_listener) {
@@ -237,6 +250,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     void on_device_button_request(uint64_t code) override
     {
       if (m_listener) {
@@ -244,6 +258,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     void on_device_button_pressed() override
     {
       if (m_listener) {
@@ -251,6 +266,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       }
     }
 
+    EXPORT
     std::optional<epee::wipeable_string> on_device_pin_request() override
     {
       if (m_listener) {
@@ -262,6 +278,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       return std::nullopt;
     }
 
+    EXPORT
     std::optional<epee::wipeable_string> on_device_passphrase_request(bool& on_device) override
     {
       if (m_listener) {
@@ -275,6 +292,7 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
       return std::nullopt;
     }
 
+    EXPORT
     void on_device_progress(const hw::device_progress & event) override
     {
       if (m_listener) {
@@ -286,16 +304,20 @@ struct Wallet2CallbackImpl : public tools::i_wallet2_callback
     WalletImpl     * m_wallet;
 };
 
+EXPORT
 Wallet::~Wallet() {}
 
+EXPORT
 WalletListener::~WalletListener() {}
 
 
+EXPORT
 std::string Wallet::displayAmount(uint64_t amount)
 {
     return cryptonote::print_money(amount);
 }
 
+EXPORT
 uint64_t Wallet::amountFromString(const std::string &amount)
 {
     uint64_t result = 0;
@@ -303,6 +325,7 @@ uint64_t Wallet::amountFromString(const std::string &amount)
     return result;
 }
 
+EXPORT
 uint64_t Wallet::amountFromDouble(double amount)
 {
     std::stringstream ss;
@@ -310,6 +333,7 @@ uint64_t Wallet::amountFromDouble(double amount)
     return amountFromString(ss.str());
 }
 
+EXPORT
 std::string Wallet::genPaymentId()
 {
     crypto::hash8 payment_id = crypto::rand<crypto::hash8>();
@@ -317,23 +341,27 @@ std::string Wallet::genPaymentId()
 
 }
 
+EXPORT
 bool Wallet::paymentIdValid(const std::string &payment_id)
 {
     return payment_id.size() == 16 && lokimq::is_hex(payment_id);
 }
 
+EXPORT
 bool Wallet::serviceNodePubkeyValid(const std::string &str)
 {
     crypto::public_key sn_key;
     return str.size() == 64 && lokimq::is_hex(str);
 }
 
+EXPORT
 bool Wallet::addressValid(const std::string &str, NetworkType nettype)
 {
   cryptonote::address_parse_info info;
   return get_account_address_from_str(info, static_cast<cryptonote::network_type>(nettype), str);
 }
 
+EXPORT
 bool Wallet::keyValid(const std::string &secret_key_string, const std::string &address_string, bool isViewKey, NetworkType nettype, std::string &error)
 {
   cryptonote::address_parse_info info;
@@ -370,6 +398,7 @@ bool Wallet::keyValid(const std::string &secret_key_string, const std::string &a
   return true;
 }
 
+EXPORT
 std::string Wallet::paymentIdFromAddress(const std::string &str, NetworkType nettype)
 {
   cryptonote::address_parse_info info;
@@ -380,33 +409,40 @@ std::string Wallet::paymentIdFromAddress(const std::string &str, NetworkType net
   return tools::type_to_hex(info.payment_id);
 }
 
+EXPORT
 uint64_t Wallet::maximumAllowedAmount()
 {
     return std::numeric_limits<uint64_t>::max();
 }
 
+EXPORT
 void Wallet::init(const char *argv0, const char *default_log_base_name, const std::string& log_path, bool console) {
     epee::string_tools::set_module_name_and_folder(argv0);
     mlog_configure(log_path.empty() ? mlog_get_default_log_path(default_log_base_name) : log_path, console);
 }
 
+EXPORT
 void Wallet::debug(const std::string &category, const std::string &str) {
     MCDEBUG(category.empty() ? OXEN_DEFAULT_LOG_CATEGORY : category.c_str(), str);
 }
 
+EXPORT
 void Wallet::info(const std::string &category, const std::string &str) {
     MCINFO(category.empty() ? OXEN_DEFAULT_LOG_CATEGORY : category.c_str(), str);
 }
 
+EXPORT
 void Wallet::warning(const std::string &category, const std::string &str) {
     MCWARNING(category.empty() ? OXEN_DEFAULT_LOG_CATEGORY : category.c_str(), str);
 }
 
+EXPORT
 void Wallet::error(const std::string &category, const std::string &str) {
     MCERROR(category.empty() ? OXEN_DEFAULT_LOG_CATEGORY : category.c_str(), str);
 }
 
 ///////////////////////// WalletImpl implementation ////////////////////////
+EXPORT
 WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     :m_wallet(nullptr)
     , m_status(Wallet::Status_Ok, "")
@@ -448,6 +484,7 @@ WalletImpl::WalletImpl(NetworkType nettype, uint64_t kdf_rounds)
     });
 }
 
+EXPORT
 WalletImpl::~WalletImpl()
 {
 
@@ -471,6 +508,7 @@ WalletImpl::~WalletImpl()
     LOG_PRINT_L1(__FUNCTION__ << " finished");
 }
 
+EXPORT
 bool WalletImpl::create(std::string_view path_, const std::string &password, const std::string &language)
 {
 
@@ -509,6 +547,7 @@ bool WalletImpl::create(std::string_view path_, const std::string &password, con
     return true;
 }
 
+EXPORT
 bool WalletImpl::createWatchOnly(std::string_view path_, const std::string &password, const std::string &language) const
 {
     auto path = fs::u8path(path_);
@@ -576,6 +615,7 @@ bool WalletImpl::createWatchOnly(std::string_view path_, const std::string &pass
     return true;
 }
 
+EXPORT
 bool WalletImpl::recoverFromKeysWithPassword(std::string_view path_,
                                  const std::string &password,
                                  const std::string &language,
@@ -673,6 +713,7 @@ bool WalletImpl::recoverFromKeysWithPassword(std::string_view path_,
     return true;
 }
 
+EXPORT
 bool WalletImpl::recoverFromDevice(std::string_view path_, const std::string &password, const std::string &device_name)
 {
     auto path = fs::u8path(path_);
@@ -691,11 +732,13 @@ bool WalletImpl::recoverFromDevice(std::string_view path_, const std::string &pa
     return true;
 }
 
+EXPORT
 Wallet::Device WalletImpl::getDeviceType() const
 {
     return static_cast<Wallet::Device>(m_wallet->get_device_type());
 }
 
+EXPORT
 bool WalletImpl::open(std::string_view path_, const std::string &password)
 {
     auto path = fs::u8path(path_);
@@ -723,6 +766,7 @@ bool WalletImpl::open(std::string_view path_, const std::string &password)
     return good();
 }
 
+EXPORT
 bool WalletImpl::recover(std::string_view path_, const std::string &password, const std::string &seed, const std::string &seed_offset/* = {}*/)
 {
     auto path = fs::u8path(path_);
@@ -759,6 +803,7 @@ bool WalletImpl::recover(std::string_view path_, const std::string &password, co
     return good();
 }
 
+EXPORT
 bool WalletImpl::close(bool store)
 {
 
@@ -787,6 +832,7 @@ bool WalletImpl::close(bool store)
     return result;
 }
 
+EXPORT
 std::string WalletImpl::seed() const
 {
     epee::wipeable_string seed;
@@ -795,25 +841,30 @@ std::string WalletImpl::seed() const
     return std::string(seed.data(), seed.size()); // TODO
 }
 
+EXPORT
 std::string WalletImpl::getSeedLanguage() const
 {
     return m_wallet->get_seed_language();
 }
 
+EXPORT
 void WalletImpl::setSeedLanguage(const std::string &arg)
 {
     m_wallet->set_seed_language(arg);
 }
 
+EXPORT
 std::pair<int, std::string> WalletImpl::status() const {
     std::lock_guard l{m_statusMutex};
     return m_status;
 }
+EXPORT
 bool WalletImpl::good() const {
     std::lock_guard l{m_statusMutex};
     return m_status.first == Status_Ok;
 }
 
+EXPORT
 bool WalletImpl::setPassword(const std::string &password)
 {
     clearStatus();
@@ -826,6 +877,7 @@ bool WalletImpl::setPassword(const std::string &password)
     return good();
 }
 
+EXPORT
 bool WalletImpl::setDevicePin(const std::string &pin)
 {
     clearStatus();
@@ -837,6 +889,7 @@ bool WalletImpl::setDevicePin(const std::string &pin)
     return good();
 }
 
+EXPORT
 bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
 {
     clearStatus();
@@ -848,11 +901,13 @@ bool WalletImpl::setDevicePassphrase(const std::string &passphrase)
     return good();
 }
 
+EXPORT
 std::string WalletImpl::address(uint32_t accountIndex, uint32_t addressIndex) const
 {
     return m_wallet->get_subaddress_as_str({accountIndex, addressIndex});
 }
 
+EXPORT
 std::string WalletImpl::integratedAddress(const std::string &payment_id) const
 {
     crypto::hash8 pid;
@@ -861,26 +916,31 @@ std::string WalletImpl::integratedAddress(const std::string &payment_id) const
     return m_wallet->get_integrated_address_as_str(pid);
 }
 
+EXPORT
 std::string WalletImpl::secretViewKey() const
 {
     return tools::type_to_hex(m_wallet->get_account().get_keys().m_view_secret_key);
 }
 
+EXPORT
 std::string WalletImpl::publicViewKey() const
 {
     return tools::type_to_hex(m_wallet->get_account().get_keys().m_account_address.m_view_public_key);
 }
 
+EXPORT
 std::string WalletImpl::secretSpendKey() const
 {
     return tools::type_to_hex(m_wallet->get_account().get_keys().m_spend_secret_key);
 }
 
+EXPORT
 std::string WalletImpl::publicSpendKey() const
 {
     return tools::type_to_hex(m_wallet->get_account().get_keys().m_account_address.m_spend_public_key);
 }
 
+EXPORT
 std::string WalletImpl::publicMultisigSignerKey() const
 {
     try {
@@ -891,11 +951,13 @@ std::string WalletImpl::publicMultisigSignerKey() const
     }
 }
 
+EXPORT
 std::string WalletImpl::path() const
 {
     return m_wallet->path().u8string();
 }
 
+EXPORT
 bool WalletImpl::store(std::string_view path_)
 {
     auto path = fs::u8path(path_);
@@ -915,16 +977,19 @@ bool WalletImpl::store(std::string_view path_)
     return true;
 }
 
+EXPORT
 std::string WalletImpl::filename() const
 {
     return m_wallet->get_wallet_file().u8string();
 }
 
+EXPORT
 std::string WalletImpl::keysFilename() const
 {
     return m_wallet->get_keys_file().u8string();
 }
 
+EXPORT
 bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transaction_size_limit, const std::string &daemon_username, const std::string &daemon_password, bool use_ssl, bool lightWallet)
 {
     clearStatus();
@@ -934,11 +999,13 @@ bool WalletImpl::init(const std::string &daemon_address, uint64_t upper_transact
     return doInit(daemon_address, upper_transaction_size_limit, use_ssl);
 }
 
+EXPORT
 bool WalletImpl::lightWalletLogin(bool &isNewWallet) const
 {
   return m_wallet->light_wallet_login(isNewWallet);
 }
 
+EXPORT
 bool WalletImpl::lightWalletImportWalletRequest(std::string &payment_id, uint64_t &fee, bool &new_request, bool &request_fulfilled, std::string &payment_address, std::string &status)
 {
   try
@@ -964,36 +1031,43 @@ bool WalletImpl::lightWalletImportWalletRequest(std::string &payment_id, uint64_
   return true;
 }
 
+EXPORT
 void WalletImpl::setRefreshFromBlockHeight(uint64_t refresh_from_block_height)
 {
     m_wallet->set_refresh_from_block_height(refresh_from_block_height);
 }
 
+EXPORT
 void WalletImpl::setRecoveringFromSeed(bool recoveringFromSeed)
 {
     m_recoveringFromSeed = recoveringFromSeed;
 }
 
+EXPORT
 void WalletImpl::setRecoveringFromDevice(bool recoveringFromDevice)
 {
     m_recoveringFromDevice = recoveringFromDevice;
 }
 
+EXPORT
 void WalletImpl::setSubaddressLookahead(uint32_t major, uint32_t minor)
 {
     m_wallet->set_subaddress_lookahead(major, minor);
 }
 
+EXPORT
 uint64_t WalletImpl::balance(uint32_t accountIndex) const
 {
     return m_wallet->balance(accountIndex, false);
 }
 
+EXPORT
 uint64_t WalletImpl::unlockedBalance(uint32_t accountIndex) const
 {
     return m_wallet->unlocked_balance(accountIndex, false);
 }
 
+EXPORT
 std::vector<std::pair<std::string, uint64_t>>* WalletImpl::listCurrentStakes() const
 {
     std::vector<std::pair<std::string, uint64_t>>* stakes = new std::vector<std::pair<std::string, uint64_t>>;
@@ -1010,6 +1084,7 @@ std::vector<std::pair<std::string, uint64_t>>* WalletImpl::listCurrentStakes() c
     return stakes;
 }
 
+EXPORT
 uint64_t WalletImpl::blockChainHeight() const
 {
     if(m_wallet->light_wallet()) {
@@ -1017,16 +1092,19 @@ uint64_t WalletImpl::blockChainHeight() const
     }
     return m_wallet->get_blockchain_current_height();
 }
+EXPORT
 uint64_t WalletImpl::approximateBlockChainHeight() const
 {
     return m_wallet->get_approximate_blockchain_height();
 }
 
+EXPORT
 uint64_t WalletImpl::estimateBlockChainHeight() const
 {
     return m_wallet->estimate_blockchain_height();
 }
 
+EXPORT
 uint64_t WalletImpl::daemonBlockChainHeight() const
 {
     if(m_wallet->light_wallet()) {
@@ -1046,6 +1124,7 @@ uint64_t WalletImpl::daemonBlockChainHeight() const
     return result;
 }
 
+EXPORT
 uint64_t WalletImpl::daemonBlockChainTargetHeight() const
 {
     if(m_wallet->light_wallet()) {
@@ -1068,6 +1147,7 @@ uint64_t WalletImpl::daemonBlockChainTargetHeight() const
     return result;
 }
 
+EXPORT
 bool WalletImpl::daemonSynced() const
 {   
     if(connected() == Wallet::ConnectionStatus_Disconnected)
@@ -1076,11 +1156,13 @@ bool WalletImpl::daemonSynced() const
     return (blockChainHeight >= daemonBlockChainTargetHeight() && blockChainHeight > 1);
 }
 
+EXPORT
 bool WalletImpl::synchronized() const
 {
     return m_synchronized;
 }
 
+EXPORT
 bool WalletImpl::refresh()
 {
     clearStatus();
@@ -1090,6 +1172,7 @@ bool WalletImpl::refresh()
     return good();
 }
 
+EXPORT
 void WalletImpl::refreshAsync()
 {
     LOG_PRINT_L3(__FUNCTION__ << ": Refreshing asynchronously..");
@@ -1097,6 +1180,7 @@ void WalletImpl::refreshAsync()
     m_refreshCV.notify_one();
 }
 
+EXPORT
 bool WalletImpl::rescanBlockchain()
 {
     clearStatus();
@@ -1105,12 +1189,14 @@ bool WalletImpl::rescanBlockchain()
     return good();
 }
 
+EXPORT
 void WalletImpl::rescanBlockchainAsync()
 {
     m_refreshShouldRescan = true;
     refreshAsync();
 }
 
+EXPORT
 void WalletImpl::setAutoRefreshInterval(int millis)
 {
     if (millis > MAX_REFRESH_INTERVAL_MILLIS) {
@@ -1122,6 +1208,7 @@ void WalletImpl::setAutoRefreshInterval(int millis)
     }
 }
 
+EXPORT
 int WalletImpl::autoRefreshInterval() const
 {
     return m_refreshIntervalMillis;
@@ -1149,6 +1236,7 @@ UnsignedTransaction* WalletImpl::loadUnsignedTx(std::string_view unsigned_filena
   return transaction;
 }
 
+EXPORT
 bool WalletImpl::submitTransaction(std::string_view filename_) {
   auto fileName = fs::u8path(filename_);
   clearStatus();
@@ -1168,6 +1256,7 @@ bool WalletImpl::submitTransaction(std::string_view filename_) {
   return true;
 }
 
+EXPORT
 bool WalletImpl::exportKeyImages(std::string_view filename_) 
 {
   auto filename = fs::u8path(filename_);
@@ -1194,6 +1283,7 @@ bool WalletImpl::exportKeyImages(std::string_view filename_)
   return true;
 }
 
+EXPORT
 bool WalletImpl::importKeyImages(std::string_view filename_)
 {
   auto filename = fs::u8path(filename_);
@@ -1218,22 +1308,27 @@ bool WalletImpl::importKeyImages(std::string_view filename_)
   return true;
 }
 
+EXPORT
 void WalletImpl::addSubaddressAccount(const std::string& label)
 {
     m_wallet->add_subaddress_account(label);
 }
+EXPORT
 size_t WalletImpl::numSubaddressAccounts() const
 {
     return m_wallet->get_num_subaddress_accounts();
 }
+EXPORT
 size_t WalletImpl::numSubaddresses(uint32_t accountIndex) const
 {
     return m_wallet->get_num_subaddresses(accountIndex);
 }
+EXPORT
 void WalletImpl::addSubaddress(uint32_t accountIndex, const std::string& label)
 {
     m_wallet->add_subaddress(accountIndex, label);
 }
+EXPORT
 std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex) const
 {
     try
@@ -1247,6 +1342,7 @@ std::string WalletImpl::getSubaddressLabel(uint32_t accountIndex, uint32_t addre
         return "";
     }
 }
+EXPORT
 void WalletImpl::setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex, const std::string &label)
 {
     try
@@ -1260,6 +1356,7 @@ void WalletImpl::setSubaddressLabel(uint32_t accountIndex, uint32_t addressIndex
     }
 }
 
+EXPORT
 MultisigState WalletImpl::multisig() const {
     MultisigState state;
     state.isMultisig = m_wallet->multisig(&state.isReady, &state.threshold, &state.total);
@@ -1267,6 +1364,7 @@ MultisigState WalletImpl::multisig() const {
     return state;
 }
 
+EXPORT
 std::string WalletImpl::getMultisigInfo() const {
     try {
         clearStatus();
@@ -1279,6 +1377,7 @@ std::string WalletImpl::getMultisigInfo() const {
     return {};
 }
 
+EXPORT
 std::string WalletImpl::makeMultisig(const std::vector<std::string>& info, uint32_t threshold) {
     try {
         clearStatus();
@@ -1295,6 +1394,7 @@ std::string WalletImpl::makeMultisig(const std::vector<std::string>& info, uint3
     return {};
 }
 
+EXPORT
 std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &info) {
     try {
         clearStatus();
@@ -1309,6 +1409,7 @@ std::string WalletImpl::exchangeMultisigKeys(const std::vector<std::string> &inf
     return {};
 }
 
+EXPORT
 bool WalletImpl::finalizeMultisig(const std::vector<std::string>& extraMultisigInfo) {
     try {
         clearStatus();
@@ -1327,6 +1428,7 @@ bool WalletImpl::finalizeMultisig(const std::vector<std::string>& extraMultisigI
     return false;
 }
 
+EXPORT
 bool WalletImpl::exportMultisigImages(std::string& images) {
     try {
         clearStatus();
@@ -1343,6 +1445,7 @@ bool WalletImpl::exportMultisigImages(std::string& images) {
     return false;
 }
 
+EXPORT
 size_t WalletImpl::importMultisigImages(const std::vector<std::string>& images) {
     try {
         clearStatus();
@@ -1371,6 +1474,7 @@ size_t WalletImpl::importMultisigImages(const std::vector<std::string>& images) 
     return 0;
 }
 
+EXPORT
 bool WalletImpl::hasMultisigPartialKeyImages() const {
     try {
         clearStatus();
@@ -1385,6 +1489,7 @@ bool WalletImpl::hasMultisigPartialKeyImages() const {
     return false;
 }
 
+EXPORT
 PendingTransaction* WalletImpl::restoreMultisigTransaction(const std::string& signData) {
     try {
         clearStatus();
@@ -1420,6 +1525,7 @@ PendingTransaction* WalletImpl::restoreMultisigTransaction(const std::string& si
 //    - unconfirmed_transfer_details;
 //    - confirmed_transfer_details)
 
+EXPORT
 PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std::string> &dst_addr, std::optional<std::vector<uint64_t>> amount, uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
 {
@@ -1577,6 +1683,7 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<std:
     return transaction;
 }
 
+EXPORT
 PendingTransaction *WalletImpl::createTransaction(const std::string &dst_addr, std::optional<uint64_t> amount,
                                                   uint32_t priority, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 
@@ -1584,6 +1691,7 @@ PendingTransaction *WalletImpl::createTransaction(const std::string &dst_addr, s
     return createTransactionMultDest(std::vector<std::string> {dst_addr},  amount ? (std::vector<uint64_t> {*amount}) : (std::optional<std::vector<uint64_t>>()), priority, subaddr_account, subaddr_indices);
 }
 
+EXPORT
 PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
 
 {
@@ -1666,11 +1774,13 @@ PendingTransaction *WalletImpl::createSweepUnmixableTransaction()
     return transaction;
 }
 
+EXPORT
 void WalletImpl::disposeTransaction(PendingTransaction *t)
 {
     delete t;
 }
 
+EXPORT
 uint64_t WalletImpl::estimateTransactionFee(uint32_t priority, uint32_t recipients) const
 {
     constexpr uint32_t typical_size = 2000;
@@ -1679,38 +1789,45 @@ uint64_t WalletImpl::estimateTransactionFee(uint32_t priority, uint32_t recipien
     return (base_fee.first * typical_size + base_fee.second * (recipients + 1)) * pct / 100;
 }
 
+EXPORT
 TransactionHistory *WalletImpl::history()
 {
     return m_history.get();
 }
 
+EXPORT
 AddressBook *WalletImpl::addressBook()
 {
     return m_addressBook.get();
 }
 
+EXPORT
 Subaddress *WalletImpl::subaddress()
 {
     return m_subaddress.get();
 }
 
+EXPORT
 SubaddressAccount *WalletImpl::subaddressAccount()
 {
     return m_subaddressAccount.get();
 }
 
+EXPORT
 void WalletImpl::setListener(WalletListener *l)
 {
     // TODO thread synchronization;
     m_wallet2Callback->setListener(l);
 }
 
+EXPORT
 bool WalletImpl::setCacheAttribute(const std::string &key, const std::string &val)
 {
     m_wallet->set_attribute(key, val);
     return true;
 }
 
+EXPORT
 std::string WalletImpl::getCacheAttribute(const std::string &key) const
 {
     std::string value;
@@ -1718,6 +1835,7 @@ std::string WalletImpl::getCacheAttribute(const std::string &key) const
     return value;
 }
 
+EXPORT
 bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
 {
     cryptonote::blobdata txid_data;
@@ -1729,6 +1847,7 @@ bool WalletImpl::setUserNote(const std::string &txid, const std::string &note)
     return true;
 }
 
+EXPORT
 std::string WalletImpl::getUserNote(const std::string &txid) const
 {
     cryptonote::blobdata txid_data;
@@ -1739,6 +1858,7 @@ std::string WalletImpl::getUserNote(const std::string &txid) const
     return m_wallet->get_tx_note(htxid);
 }
 
+EXPORT
 std::string WalletImpl::getTxKey(const std::string &txid_str) const
 {
     crypto::hash txid;
@@ -1775,6 +1895,7 @@ std::string WalletImpl::getTxKey(const std::string &txid_str) const
     }
 }
 
+EXPORT
 bool WalletImpl::checkTxKey(const std::string &txid_str, std::string_view tx_key_str, const std::string &address_str, uint64_t &received, bool &in_pool, uint64_t &confirmations)
 {
     crypto::hash txid;
@@ -1820,6 +1941,7 @@ bool WalletImpl::checkTxKey(const std::string &txid_str, std::string_view tx_key
     }
 }
 
+EXPORT
 std::string WalletImpl::getTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message) const
 {
     crypto::hash txid;
@@ -1848,6 +1970,7 @@ std::string WalletImpl::getTxProof(const std::string &txid_str, const std::strin
     }
 }
 
+EXPORT
 bool WalletImpl::checkTxProof(const std::string &txid_str, const std::string &address_str, const std::string &message, const std::string &signature, bool &good, uint64_t &received, bool &in_pool, uint64_t &confirmations)
 {
     crypto::hash txid;
@@ -1877,6 +2000,7 @@ bool WalletImpl::checkTxProof(const std::string &txid_str, const std::string &ad
     }
 }
 
+EXPORT
 std::string WalletImpl::getSpendProof(const std::string &txid_str, const std::string &message) const {
     crypto::hash txid;
     if(!tools::hex_to_type(txid_str, txid))
@@ -1897,6 +2021,7 @@ std::string WalletImpl::getSpendProof(const std::string &txid_str, const std::st
     }
 }
 
+EXPORT
 bool WalletImpl::checkSpendProof(const std::string &txid_str, const std::string &message, const std::string &signature, bool &good) const {
     good = false;
     crypto::hash txid;
@@ -1919,6 +2044,7 @@ bool WalletImpl::checkSpendProof(const std::string &txid_str, const std::string 
     }
 }
 
+EXPORT
 std::string WalletImpl::getReserveProof(bool all, uint32_t account_index, uint64_t amount, const std::string &message) const {
     try
     {
@@ -1937,6 +2063,7 @@ std::string WalletImpl::getReserveProof(bool all, uint32_t account_index, uint64
     }
 }
 
+EXPORT
 bool WalletImpl::checkReserveProof(const std::string &address, const std::string &message, const std::string &signature, bool &good, uint64_t &total, uint64_t &spent) const {
     cryptonote::address_parse_info info;
     if (!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), address))
@@ -1964,11 +2091,13 @@ bool WalletImpl::checkReserveProof(const std::string &address, const std::string
     }
 }
 
+EXPORT
 std::string WalletImpl::signMessage(const std::string &message)
 {
   return m_wallet->sign(message);
 }
 
+EXPORT
 bool WalletImpl::verifySignedMessage(const std::string &message, const std::string &address, const std::string &signature) const
 {
   cryptonote::address_parse_info info;
@@ -1979,6 +2108,7 @@ bool WalletImpl::verifySignedMessage(const std::string &message, const std::stri
   return m_wallet->verify(message, info.address, signature);
 }
 
+EXPORT
 std::string WalletImpl::signMultisigParticipant(const std::string &message) const
 {
     clearStatus();
@@ -1998,6 +2128,7 @@ std::string WalletImpl::signMultisigParticipant(const std::string &message) cons
     return {};
 }
 
+EXPORT
 bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const std::string &publicKey, const std::string &signature) const
 {
     clearStatus();
@@ -2016,6 +2147,7 @@ bool WalletImpl::verifyMessageWithPublicKey(const std::string &message, const st
     return false;
 }
 
+EXPORT
 bool WalletImpl::connectToDaemon()
 {
     bool result = m_wallet->check_connection(NULL, NULL, DEFAULT_CONNECTION_TIMEOUT_MILLIS);
@@ -2028,6 +2160,7 @@ bool WalletImpl::connectToDaemon()
     return result;
 }
 
+EXPORT
 Wallet::ConnectionStatus WalletImpl::connected() const
 {
     rpc::version_t version;
@@ -2040,37 +2173,44 @@ Wallet::ConnectionStatus WalletImpl::connected() const
     return Wallet::ConnectionStatus_Connected;
 }
 
+EXPORT
 void WalletImpl::setTrustedDaemon(bool arg)
 {
     m_wallet->set_trusted_daemon(arg);
 }
 
+EXPORT
 bool WalletImpl::trustedDaemon() const
 {
     return m_wallet->is_trusted_daemon();
 }
 
+EXPORT
 bool WalletImpl::watchOnly() const
 {
     return m_wallet->watch_only();
 }
 
+EXPORT
 void WalletImpl::clearStatus() const
 {
     std::lock_guard l{m_statusMutex};
     m_status = {Status_Ok, ""};
 }
 
+EXPORT
 bool WalletImpl::setStatusError(std::string message) const
 {
     return setStatus(Status_Error, std::move(message));
 }
 
+EXPORT
 bool WalletImpl::setStatusCritical(std::string message) const
 {
     return setStatus(Status_Critical, std::move(message));
 }
 
+EXPORT
 bool WalletImpl::setStatus(int status, std::string message) const
 {
     std::lock_guard l{m_statusMutex};
@@ -2079,6 +2219,7 @@ bool WalletImpl::setStatus(int status, std::string message) const
     return status == Status_Ok;
 }
 
+EXPORT
 void WalletImpl::refreshThreadFunc()
 {
     LOG_PRINT_L3(__FUNCTION__ << ": starting refresh thread");
@@ -2111,6 +2252,7 @@ void WalletImpl::refreshThreadFunc()
     LOG_PRINT_L3(__FUNCTION__ << ": refresh thread stopped");
 }
 
+EXPORT
 void WalletImpl::doRefresh()
 {
     bool rescan = m_refreshShouldRescan.exchange(false);
@@ -2150,6 +2292,7 @@ void WalletImpl::doRefresh()
 }
 
 
+EXPORT
 void WalletImpl::startRefresh()
 {
     if (!m_refreshEnabled) {
@@ -2161,6 +2304,7 @@ void WalletImpl::startRefresh()
 
 
 
+EXPORT
 void WalletImpl::stopRefresh()
 {
     if (!m_refreshThreadDone) {
@@ -2171,6 +2315,7 @@ void WalletImpl::stopRefresh()
     }
 }
 
+EXPORT
 void WalletImpl::pauseRefresh()
 {
     LOG_PRINT_L2(__FUNCTION__ << ": refresh paused...");
@@ -2181,6 +2326,7 @@ void WalletImpl::pauseRefresh()
 }
 
 
+EXPORT
 bool WalletImpl::isNewWallet() const
 {
     // in case wallet created without daemon connection, closed and opened again,
@@ -2191,6 +2337,7 @@ bool WalletImpl::isNewWallet() const
     return !(blockChainHeight() > 1 || m_recoveringFromSeed || m_recoveringFromDevice || m_rebuildWalletCache) && !watchOnly();
 }
 
+EXPORT
 void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
 {
   // If the device being used is HW device with cold signing protocol, cold sign then.
@@ -2206,6 +2353,7 @@ void WalletImpl::pendingTxPostProcess(PendingTransactionImpl * pending)
   pending->m_pending_tx = exported_txs.ptx;
 }
 
+EXPORT
 bool WalletImpl::doInit(const std::string &daemon_address, uint64_t upper_transaction_size_limit, bool ssl)
 {
     if (!m_wallet->init(daemon_address, m_daemon_login, /*proxy=*/ "", upper_transaction_size_limit))
@@ -2232,16 +2380,19 @@ bool WalletImpl::doInit(const std::string &daemon_address, uint64_t upper_transa
     return true;
 }
 
+EXPORT
 bool WalletImpl::parse_uri(const std::string &uri, std::string &address, std::string &payment_id, uint64_t &amount, std::string &tx_description, std::string &recipient_name, std::vector<std::string> &unknown_parameters, std::string &error)
 {
     return m_wallet->parse_uri(uri, address, payment_id, amount, tx_description, recipient_name, unknown_parameters, error);
 }
 
+EXPORT
 std::string WalletImpl::getDefaultDataDir() const
 {
  return tools::get_default_data_dir();
 }
 
+EXPORT
 bool WalletImpl::rescanSpent()
 {
   clearStatus();
@@ -2260,16 +2411,19 @@ bool WalletImpl::rescanSpent()
 }
 
 
+EXPORT
 void WalletImpl::hardForkInfo(uint8_t &version, uint64_t &earliest_height) const
 {
     m_wallet->get_hard_fork_info(version, earliest_height);
 }
 
+EXPORT
 bool WalletImpl::useForkRules(uint8_t version, int64_t early_blocks) const 
 {
     return m_wallet->use_fork_rules(version,early_blocks);
 }
 
+EXPORT
 bool WalletImpl::blackballOutputs(const std::vector<std::string> &outputs, bool add)
 {
     std::vector<std::pair<uint64_t, uint64_t>> raw_outputs;
@@ -2308,6 +2462,7 @@ bool WalletImpl::blackballOutputs(const std::vector<std::string> &outputs, bool 
     return true;
 }
 
+EXPORT
 bool WalletImpl::blackballOutput(const std::string &amount, const std::string &offset)
 {
     uint64_t raw_amount, raw_offset;
@@ -2330,6 +2485,7 @@ bool WalletImpl::blackballOutput(const std::string &amount, const std::string &o
     return true;
 }
 
+EXPORT
 bool WalletImpl::unblackballOutput(const std::string &amount, const std::string &offset)
 {
     uint64_t raw_amount, raw_offset;
@@ -2352,6 +2508,7 @@ bool WalletImpl::unblackballOutput(const std::string &amount, const std::string 
     return true;
 }
 
+EXPORT
 bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ring) const
 {
     crypto::key_image raw_key_image;
@@ -2369,6 +2526,7 @@ bool WalletImpl::getRing(const std::string &key_image, std::vector<uint64_t> &ri
     return true;
 }
 
+EXPORT
 bool WalletImpl::getRings(const std::string &txid, std::vector<std::pair<std::string, std::vector<uint64_t>>> &rings) const
 {
     crypto::hash raw_txid;
@@ -2391,6 +2549,7 @@ bool WalletImpl::getRings(const std::string &txid, std::vector<std::pair<std::st
     return true;
 }
 
+EXPORT
 bool WalletImpl::setRing(const std::string &key_image, const std::vector<uint64_t> &ring, bool relative)
 {
     crypto::key_image raw_key_image;
@@ -2408,36 +2567,43 @@ bool WalletImpl::setRing(const std::string &key_image, const std::vector<uint64_
     return true;
 }
 
+EXPORT
 void WalletImpl::segregatePreForkOutputs(bool segregate)
 {
     m_wallet->segregate_pre_fork_outputs(segregate);
 }
 
+EXPORT
 void WalletImpl::segregationHeight(uint64_t height)
 {
     m_wallet->segregation_height(height);
 }
 
+EXPORT
 void WalletImpl::keyReuseMitigation2(bool mitigation)
 {
     m_wallet->key_reuse_mitigation2(mitigation);
 }
 
+EXPORT
 bool WalletImpl::lockKeysFile()
 {
     return m_wallet->lock_keys_file();
 }
 
+EXPORT
 bool WalletImpl::unlockKeysFile()
 {
     return m_wallet->unlock_keys_file();
 }
 
+EXPORT
 bool WalletImpl::isKeysFileLocked()
 {
     return m_wallet->is_keys_file_locked();
 }
 
+EXPORT
 PendingTransaction* WalletImpl::stakePending(const std::string& sn_key_str, const uint64_t& amount)
 {
   /// Note(maxim): need to be careful to call `WalletImpl::disposeTransaction` when it is no longer needed
@@ -2466,6 +2632,7 @@ PendingTransaction* WalletImpl::stakePending(const std::string& sn_key_str, cons
   return transaction;
 }
 
+EXPORT
 StakeUnlockResult* WalletImpl::canRequestStakeUnlock(const std::string &sn_key)
 {
     crypto::public_key snode_key;
@@ -2480,6 +2647,7 @@ StakeUnlockResult* WalletImpl::canRequestStakeUnlock(const std::string &sn_key)
     return new StakeUnlockResultImpl(*this, m_wallet->can_request_stake_unlock(snode_key));
 }
 
+EXPORT
 StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
 {
     tools::wallet2::request_stake_unlock_result res = {};
@@ -2515,11 +2683,13 @@ StakeUnlockResult* WalletImpl::requestStakeUnlock(const std::string &sn_key)
     return new StakeUnlockResultImpl(*this, unlock_result);
 }
 
+EXPORT
 uint64_t WalletImpl::coldKeyImageSync(uint64_t &spent, uint64_t &unspent)
 {
     return m_wallet->cold_key_image_sync(spent, unspent);
 }
 
+EXPORT
 void WalletImpl::deviceShowAddress(uint32_t accountIndex, uint32_t addressIndex, const std::string &paymentId)
 {
     std::optional<crypto::hash8> payment_id_param = std::nullopt;

--- a/src/wallet/api/wallet2_api.h
+++ b/src/wallet/api/wallet2_api.h
@@ -1185,23 +1185,8 @@ struct WalletManagerBase
     //! returns current blockchain target height
     virtual uint64_t blockchainTargetHeight() = 0;
 
-    //! returns current network difficulty
-    virtual uint64_t networkDifficulty() = 0;
-
-    //! returns current mining hash rate (0 if not mining)
-    virtual double miningHashRate() = 0;
-
     //! returns current block target
     virtual uint64_t blockTarget() = 0;
-
-    //! returns true iff mining
-    virtual bool isMining() = 0;
-
-    //! starts mining with the set number of threads
-    virtual bool startMining(const std::string& address, uint32_t threads = 1) = 0;
-
-    //! stops mining
-    virtual bool stopMining() = 0;
 
     //! resolves an OpenAlias address to a monero address
     virtual std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const = 0;

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -264,45 +264,11 @@ uint64_t WalletManagerImpl::blockchainTargetHeight()
     return std::max(res->target_height, res->height);
 }
 
-uint64_t WalletManagerImpl::networkDifficulty()
-{
-    auto res = get_info(m_http_client);
-    return res ? res->difficulty : 0;
-}
-
-double WalletManagerImpl::miningHashRate()
-{
-    auto mres = json_rpc<cryptonote::rpc::MINING_STATUS>(m_http_client);
-    return mres && mres->active ? mres->speed : 0.0;
-}
-
 EXPORT
 uint64_t WalletManagerImpl::blockTarget()
 {
     auto res = get_info(m_http_client);
     return res ? res->target : 0;
-}
-
-bool WalletManagerImpl::isMining()
-{
-    auto mres = json_rpc<cryptonote::rpc::MINING_STATUS>(m_http_client);
-    return mres && mres->active;
-}
-
-bool WalletManagerImpl::startMining(const std::string &address, uint32_t threads)
-{
-    cryptonote::rpc::START_MINING::request mreq{};
-    mreq.miner_address = address;
-    mreq.threads_count = threads;
-
-    auto mres = json_rpc<cryptonote::rpc::START_MINING>(m_http_client, mreq);
-    return mres && mres->status == cryptonote::rpc::STATUS_OK;
-}
-
-bool WalletManagerImpl::stopMining()
-{
-    auto mres = json_rpc<cryptonote::rpc::STOP_MINING>(m_http_client);
-    return mres && mres->status == cryptonote::rpc::STATUS_OK;
 }
 
 EXPORT

--- a/src/wallet/api/wallet_manager.cpp
+++ b/src/wallet/api/wallet_manager.cpp
@@ -45,6 +45,7 @@
 
 namespace Wallet {
 
+EXPORT
 Wallet* WalletManagerImpl::createWallet(std::string_view path, const std::string &password,
                                     const std::string &language, NetworkType nettype, uint64_t kdf_rounds)
 {
@@ -53,6 +54,7 @@ Wallet* WalletManagerImpl::createWallet(std::string_view path, const std::string
     return wallet;
 }
 
+EXPORT
 Wallet* WalletManagerImpl::openWallet(std::string_view path, const std::string &password, NetworkType nettype, uint64_t kdf_rounds, WalletListener * listener)
 {
     WalletImpl* wallet = new WalletImpl(nettype, kdf_rounds);
@@ -67,6 +69,7 @@ Wallet* WalletManagerImpl::openWallet(std::string_view path, const std::string &
     return wallet;
 }
 
+EXPORT
 Wallet* WalletManagerImpl::recoveryWallet(std::string_view path,
                                                 const std::string &password,
                                                 const std::string &mnemonic,
@@ -83,6 +86,7 @@ Wallet* WalletManagerImpl::recoveryWallet(std::string_view path,
     return wallet;
 }
 
+EXPORT
 Wallet* WalletManagerImpl::createWalletFromKeys(std::string_view path,
                                                 const std::string &password,
                                                 const std::string &language,
@@ -101,6 +105,7 @@ Wallet* WalletManagerImpl::createWalletFromKeys(std::string_view path,
     return wallet;
 }
 
+EXPORT
 Wallet* WalletManagerImpl::createWalletFromDevice(std::string_view path,
                                                   const std::string &password,
                                                   NetworkType nettype,
@@ -130,6 +135,7 @@ Wallet* WalletManagerImpl::createWalletFromDevice(std::string_view path,
     return wallet;
 }
 
+EXPORT
 bool WalletManagerImpl::closeWallet(Wallet* wallet, bool store)
 {
     WalletImpl* wallet_ = dynamic_cast<WalletImpl*>(wallet);
@@ -144,6 +150,7 @@ bool WalletManagerImpl::closeWallet(Wallet* wallet, bool store)
     return result;
 }
 
+EXPORT
 bool WalletManagerImpl::walletExists(std::string_view path)
 {
     bool keys_file_exists;
@@ -155,11 +162,13 @@ bool WalletManagerImpl::walletExists(std::string_view path)
     return false;
 }
 
+EXPORT
 bool WalletManagerImpl::verifyWalletPassword(std::string_view keys_file_name, const std::string &password, bool no_spend_key, uint64_t kdf_rounds) const
 {
 	    return tools::wallet2::verify_password(fs::u8path(keys_file_name), password, no_spend_key, hw::get_device("default"), kdf_rounds);
 }
 
+EXPORT
 bool WalletManagerImpl::queryWalletDevice(Wallet::Device& device_type, std::string_view keys_file_name, const std::string &password, uint64_t kdf_rounds) const
 {
     hw::device::device_type type;
@@ -168,6 +177,7 @@ bool WalletManagerImpl::queryWalletDevice(Wallet::Device& device_type, std::stri
     return r;
 }
 
+EXPORT
 std::vector<std::string> WalletManagerImpl::findWallets(std::string_view path_)
 {
     auto path = fs::u8path(path_);
@@ -196,11 +206,13 @@ std::vector<std::string> WalletManagerImpl::findWallets(std::string_view path_)
     return result;
 }
 
+EXPORT
 std::string WalletManagerImpl::errorString() const
 {
     return m_errorString;
 }
 
+EXPORT
 void WalletManagerImpl::setDaemonAddress(std::string address)
 {
     if (!tools::starts_with(address, "https://") && !tools::starts_with(address, "http://"))
@@ -208,6 +220,7 @@ void WalletManagerImpl::setDaemonAddress(std::string address)
     m_http_client.set_base_url(std::move(address));
 }
 
+EXPORT
 bool WalletManagerImpl::connected(uint32_t *version)
 {
     using namespace cryptonote::rpc;
@@ -235,12 +248,14 @@ static std::optional<cryptonote::rpc::GET_INFO::response> get_info(cryptonote::r
 }
 
 
+EXPORT
 uint64_t WalletManagerImpl::blockchainHeight()
 {
     auto res = get_info(m_http_client);
     return res ? res->height : 0;
 }
 
+EXPORT
 uint64_t WalletManagerImpl::blockchainTargetHeight()
 {
     auto res = get_info(m_http_client);
@@ -261,6 +276,7 @@ double WalletManagerImpl::miningHashRate()
     return mres && mres->active ? mres->speed : 0.0;
 }
 
+EXPORT
 uint64_t WalletManagerImpl::blockTarget()
 {
     auto res = get_info(m_http_client);
@@ -289,6 +305,7 @@ bool WalletManagerImpl::stopMining()
     return mres && mres->status == cryptonote::rpc::STATUS_OK;
 }
 
+EXPORT
 std::string WalletManagerImpl::resolveOpenAlias(const std::string &address, bool &dnssec_valid) const
 {
     std::vector<std::string> addresses = tools::dns_utils::addresses_from_url(address, dnssec_valid);
@@ -298,6 +315,7 @@ std::string WalletManagerImpl::resolveOpenAlias(const std::string &address, bool
 }
 
 ///////////////////// WalletManagerFactory implementation //////////////////////
+EXPORT
 WalletManagerBase *WalletManagerFactory::getWalletManager()
 {
 
@@ -310,11 +328,13 @@ WalletManagerBase *WalletManagerFactory::getWalletManager()
     return g_walletManager;
 }
 
+EXPORT
 void WalletManagerFactory::setLogLevel(int level)
 {
     mlog_set_log_level(level);
 }
 
+EXPORT
 void WalletManagerFactory::setLogCategories(const std::string &categories)
 {
     mlog_set_log(categories.c_str());

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -29,7 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 
-#include "wallet/api/wallet2_api.h"
+#include "wallet2_api.h"
 #include "rpc/http_client.h"
 #include <string>
 

--- a/src/wallet/api/wallet_manager.h
+++ b/src/wallet/api/wallet_manager.h
@@ -75,12 +75,7 @@ public:
     bool connected(uint32_t *version = NULL) override;
     uint64_t blockchainHeight() override;
     uint64_t blockchainTargetHeight() override;
-    uint64_t networkDifficulty() override;
-    double miningHashRate() override;
     uint64_t blockTarget() override;
-    bool isMining() override;
-    bool startMining(const std::string &address, uint32_t threads = 1) override;
-    bool stopMining() override;
     std::string resolveOpenAlias(const std::string &address, bool &dnssec_valid) const override;
 
 private:

--- a/utils/build_scripts/drone-android-static-upload.sh
+++ b/utils/build_scripts/drone-android-static-upload.sh
@@ -29,6 +29,12 @@ cp src/wallet/api/wallet2_api.h $tmpdir/include
 
 for android_abi in "$@"; do
     mkdir -p $tmpdir/lib/${android_abi}
+    strip_arch=$android_abi-linux-android
+    if [ "$android_abi" = "armeabi-v7a" ]; then strip_arch=arm-linux-androideabi
+    elif [ "$android_abi" = "arm64-v8a" ]; then strip_arch=aarch64-linux-android
+    elif [ "$android_abi" = "x86" ]; then strip_arch=i686-linux-android
+    fi
+    /usr/lib/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/$strip_arch/bin/strip --strip-debug build-${android_abi}/src/wallet/api/libwallet_merged.a
     ln -s ../../../build-${android_abi}/src/wallet/api/libwallet_merged.a $tmpdir/lib/${android_abi}/libwallet_api.a
 done
 

--- a/utils/build_scripts/drone-ios-static-upload.sh
+++ b/utils/build_scripts/drone-ios-static-upload.sh
@@ -28,7 +28,7 @@ mkdir -p $tmpdir/lib
 mkdir -p $tmpdir/include
 
 # Merge the arm64 and simulator libs into a single multi-arch merged lib:
-lipo -create build/{arm64,sim64}/src/wallet/api/libwallet_merged.a -o $tmpdir/lib/libwallet_merged.a
+lipo -create build/{arm64,sim64}/src/wallet/api/libwallet_merged.a -o $tmpdir/lib/libwallet_api.a
 
 cp src/wallet/api/wallet2_api.h $tmpdir/include
 


### PR DESCRIPTION
- The android libs were massive because they were unstripped; this strips debug symbols which reduces the sizes significantly.  (A full strip takes out symbols that the wallet still needs to link again).

- Makes the ios static library filename match android (libwallet_api.a)

- This PR also removes Trezor, which doesn't even work, and thus also eliminates the protobuf dependency (which only Trezor depends on).

- Finally this removes obsolete mining-related functions from wallet_api.